### PR TITLE
feat: Add JavaScript escape hatch APIs to MonacoController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-04-20
+
+### Added
+- Added `runJavaScript()` and `runJavaScriptReturningResult()` public methods on `MonacoController`. These delegate to the underlying `PlatformWebViewController` and provide a general-purpose escape hatch for configuring language services, injecting plugins, or calling Monaco APIs not yet wrapped by the typed API.
+
 ## [1.4.0] - 2026-01-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.0] - 2026-04-20
+## [1.5.0] - 2026-04-22
 
 ### Added
 - Added `runJavaScript()` and `runJavaScriptReturningResult()` public methods on `MonacoController`. These delegate to the underlying `PlatformWebViewController` and provide a general-purpose escape hatch for configuring language services, injecting plugins, or calling Monaco APIs not yet wrapped by the typed API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.5.0] - 2026-04-22
 
 ### Added
-- Added `runJavaScript()` and `runJavaScriptReturningResult()` public methods on `MonacoController`. These delegate to the underlying `PlatformWebViewController` and provide a general-purpose escape hatch for configuring language services, injecting plugins, or calling Monaco APIs not yet wrapped by the typed API.
+- Added `MonacoController.runJavaScript(String script)` as an advanced fire-and-forget JavaScript escape hatch. It waits for the editor to be ready before executing.
+- Added `MonacoController.evaluateJavaScript<T>(String expression, {T? defaultValue})` for typed JavaScript evaluation with cross-platform result normalization.
+- Added `MonacoController.runJavaScriptReturningResultRaw(String script)` for advanced callers who need the platform-native return value.
+
+### Security
+- Documented that JavaScript escape-hatch methods do not sanitize input and that callers should use `jsonEncode` when embedding dynamic values.
 
 ## [1.4.0] - 2026-01-25
 
@@ -57,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export ordering and analyzer fixes to keep the public API clean.
 
 ## [1.0.0] - 2025-09-15
-- Reliable typing after route/app switches on macOS/Windows — no right‑click needed.
+- Reliable typing after route/app switches on macOS/Windows - no right‑click needed.
 - Optional `MonacoFocusGuard` to auto‑restore focus on resume/route return.
 - New guide: doc/focus-and-platform-views.md with best practices and snippets.
 - Sensible defaults: word wrap ON, minimap OFF, consistent across APIs.

--- a/README.md
+++ b/README.md
@@ -364,6 +364,21 @@ await controller.executeAction(MonacoAction.toggleLineComment);
 // Or use a raw Monaco action id string if needed:
 // await controller.executeAction('editor.action.commentLine');
 
+// Raw JavaScript execution (escape hatch for uncovered APIs)
+await controller.runJavaScript('''
+  monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+    validate: true,
+    schemas: [{
+      uri: 'http://my-schema',
+      fileMatch: ['*'],
+      schema: { type: 'object' }
+    }]
+  });
+''');
+final editorCount = await controller.runJavaScriptReturningResult(
+  'monaco.editor.getEditors().length',
+);
+
 // Live statistics
 controller.liveStats.addListener(() {
   final stats = controller.liveStats.value;

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ String _currentWord(CompletionRequest request) {
 - `position`, `defaultRange`, `lineText` – cursor info plus the word range Monaco wants you to replace.
 - `triggerKind`, `triggerCharacter` – what caused the completion (manual `Ctrl+Space`, character, etc.).
 
-Need to remove a provider? Call `controller.unregisterCompletionSource(id)` at any time. You can register as many providers as you need—Monaco merges them and sorts via each item's `sortText`.
+Need to remove a provider? Call `controller.unregisterCompletionSource(id)` at any time. You can register as many providers as you need. Monaco merges them and sorts via each item's `sortText`.
 
 ## Multiple Editors Example
 
@@ -364,7 +364,7 @@ await controller.executeAction(MonacoAction.toggleLineComment);
 // Or use a raw Monaco action id string if needed:
 // await controller.executeAction('editor.action.commentLine');
 
-// Raw JavaScript execution (escape hatch for uncovered APIs)
+// JavaScript escape hatch for uncovered Monaco APIs
 await controller.runJavaScript('''
   monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
     validate: true,
@@ -375,7 +375,12 @@ await controller.runJavaScript('''
     }]
   });
 ''');
-final editorCount = await controller.runJavaScriptReturningResult(
+
+final editorCount = await controller.evaluateJavaScript<int>(
+  'monaco.editor.getEditors().length',
+);
+
+final rawEditorCount = await controller.runJavaScriptReturningResultRaw(
   'monaco.editor.getEditors().length',
 );
 
@@ -402,6 +407,60 @@ controller.onBlur.listen((_) => print('Editor blurred'));
 
 For a full set of bundled action IDs, use `MonacoAction` (exported by this
 package) to avoid stringly-typed calls.
+
+### JavaScript Escape Hatch
+
+For Monaco APIs not yet wrapped by the typed Dart API, `MonacoController`
+provides an advanced JavaScript escape hatch. Prefer typed methods such as
+`setValue`, `getSelection`, `setMarkers`, and `executeAction` when they cover
+your use case.
+
+| Method | Use case |
+| --- | --- |
+| `runJavaScript(script)` | Fire-and-forget configuration or commands. |
+| `evaluateJavaScript<T>(expression)` | Read a JSON-serializable value with cross-platform type normalization. |
+| `runJavaScriptReturningResultRaw(script)` | Advanced raw platform-native result access. |
+
+```dart
+await controller.runJavaScript('''
+  monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+    validate: true,
+    schemas: [{
+      uri: 'http://my-schema',
+      fileMatch: ['*'],
+      schema: { type: 'object' }
+    }]
+  });
+''');
+
+final editorCount = await controller.evaluateJavaScript<int>(
+  'monaco.editor.getEditors().length',
+);
+```
+
+Use raw result access only when you specifically need platform-native WebView
+behavior:
+
+```dart
+final raw = await controller.runJavaScriptReturningResultRaw(
+  'monaco.editor.getEditors().length',
+);
+```
+
+These methods do not sanitize input. Do not concatenate untrusted strings into
+a script. Use `jsonEncode` to safely embed dynamic values:
+
+```dart
+import 'dart:convert';
+
+// Bad if userInput is attacker-controlled.
+await controller.runJavaScript('window.setName("$userInput")');
+
+// Good: jsonEncode creates a safe JavaScript literal.
+await controller.runJavaScript(
+  'window.setName(${jsonEncode(userInput)})',
+);
+```
 
 ### Advanced Features
 

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -1115,6 +1115,46 @@ class MonacoController {
     );
   }
 
+  // --- RAW JAVASCRIPT EXECUTION ---
+
+  /// Executes arbitrary JavaScript code in the editor's WebView.
+  ///
+  /// This is a general-purpose escape hatch for scenarios not covered by the
+  /// typed API — e.g. configuring language services, injecting plugins, or
+  /// calling Monaco APIs that are not yet wrapped.
+  ///
+  /// The method waits for the editor to be ready before executing the script.
+  ///
+  /// ```dart
+  /// // Configure JSON diagnostics options
+  /// await controller.runJavaScript('''
+  ///   monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+  ///     validate: true,
+  ///     schemas: [{ uri: 'http://schema/example', fileMatch: ['*'], schema: mySchema }]
+  ///   });
+  /// ''');
+  /// ```
+  Future<void> runJavaScript(String script) async {
+    await _ensureReady();
+    await _webViewController.runJavaScript(script);
+  }
+
+  /// Executes JavaScript code and returns the result.
+  ///
+  /// Like [runJavaScript], but captures and returns the evaluation result.
+  /// The return type varies by platform — see [PlatformWebViewController]
+  /// for details.
+  ///
+  /// ```dart
+  /// final version = await controller.runJavaScriptReturningResult(
+  ///   'monaco.editor.getEditors().length',
+  /// );
+  /// ```
+  Future<Object?> runJavaScriptReturningResult(String script) async {
+    await _ensureReady();
+    return _webViewController.runJavaScriptReturningResult(script);
+  }
+
   // --- HELPERS ---
   /// Dispose the controller and clean up resources
   void dispose() {

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -29,6 +29,11 @@ class MonacoController {
     _wireEvents();
   }
 
+  static const String _jsEvalEnvelopeKey = '__flutterMonacoEval';
+  static const String _jsEvalValueKey = 'value';
+  static const String _jsEvalUndefinedKey = 'isUndefined';
+  static const _jsUndefined = _JavaScriptUndefinedValue();
+
   final MonacoBridge _bridge;
   final PlatformWebViewController _webViewController;
   final Completer<void> _onReady = Completer<void>();
@@ -627,6 +632,62 @@ class MonacoController {
     }
   }
 
+  String _wrapJavaScriptEvaluationExpression(String expression) {
+    final envelopeKey = jsonEncode(_jsEvalEnvelopeKey);
+    final valueKey = jsonEncode(_jsEvalValueKey);
+    final undefinedKey = jsonEncode(_jsEvalUndefinedKey);
+
+    return '''
+      (function() {
+        const value = ($expression);
+
+        if (typeof value === 'undefined') {
+          return JSON.stringify({
+            $envelopeKey: true,
+            $undefinedKey: true,
+            $valueKey: null
+          });
+        }
+
+        return JSON.stringify({
+          $envelopeKey: true,
+          $undefinedKey: false,
+          $valueKey: value
+        });
+      })()
+    ''';
+  }
+
+  Object? _decodeJavaScriptEvaluationResult(Object? raw) {
+    Object? current = raw;
+
+    for (var i = 0; i < 3; i++) {
+      if (current is! String) break;
+
+      final trimmed = current.trim();
+      if (trimmed.isEmpty) return null;
+
+      try {
+        current = jsonDecode(trimmed);
+      } catch (_) {
+        break;
+      }
+    }
+
+    final envelope = tryConvertToMap<String, dynamic>(current);
+    if (envelope == null || envelope[_jsEvalEnvelopeKey] != true) {
+      return current;
+    }
+
+    if (envelope[_jsEvalUndefinedKey] == true) {
+      return _jsUndefined;
+    }
+
+    return envelope.containsKey(_jsEvalValueKey)
+        ? envelope[_jsEvalValueKey]
+        : null;
+  }
+
   // --- CONTENT AND SELECTION ---
 
   /// Retrieves the current text content of the editor.
@@ -1115,42 +1176,128 @@ class MonacoController {
     );
   }
 
-  // --- RAW JAVASCRIPT EXECUTION ---
+  // --- JAVASCRIPT ESCAPE HATCH ---
 
-  /// Executes arbitrary JavaScript code in the editor's WebView.
+  /// Executes arbitrary JavaScript in the editor WebView.
   ///
-  /// This is a general-purpose escape hatch for scenarios not covered by the
-  /// typed API — e.g. configuring language services, injecting plugins, or
-  /// calling Monaco APIs that are not yet wrapped.
+  /// This is an advanced escape hatch for scenarios not covered by the typed
+  /// Dart API. Prefer typed [MonacoController] methods such as [setValue],
+  /// [getSelection], [setMarkers], and [executeAction] when they cover your
+  /// use case.
   ///
-  /// The method waits for the editor to be ready before executing the script.
+  /// Useful for configuring Monaco language services, such as JSON schemas or
+  /// TypeScript options, or for calling Monaco APIs not yet wrapped by this
+  /// package.
+  ///
+  /// Loading third-party plugin scripts at runtime requires bundling those
+  /// scripts with your app and respecting the editor page's
+  /// Content-Security-Policy. The default CSP does not allow remote script
+  /// origins.
+  ///
+  /// Waits for the editor to be ready before executing.
+  ///
+  /// ## Security
+  ///
+  /// Do not interpolate untrusted or user-provided values directly into
+  /// [script]. This is raw JavaScript execution and string concatenation can
+  /// create a script-injection vulnerability. Use `jsonEncode` for dynamic
+  /// values:
   ///
   /// ```dart
-  /// // Configure JSON diagnostics options
-  /// await controller.runJavaScript('''
-  ///   monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-  ///     validate: true,
-  ///     schemas: [{ uri: 'http://schema/example', fileMatch: ['*'], schema: mySchema }]
-  ///   });
-  /// ''');
+  /// // Bad if userInput is attacker-controlled.
+  /// await controller.runJavaScript('window.setName("$userInput")');
+  ///
+  /// // Good: jsonEncode creates a safe JavaScript literal.
+  /// await controller.runJavaScript(
+  ///   'window.setName(${jsonEncode(userInput)})',
+  /// );
   /// ```
+  ///
+  /// See also:
+  /// - [evaluateJavaScript] for typed, cross-platform result normalization.
+  /// - [runJavaScriptReturningResultRaw] for raw platform return values.
   Future<void> runJavaScript(String script) async {
     await _ensureReady();
     await _webViewController.runJavaScript(script);
   }
 
-  /// Executes JavaScript code and returns the result.
+  /// Evaluates a JavaScript expression and returns a Dart value of type [T].
   ///
-  /// Like [runJavaScript], but captures and returns the evaluation result.
-  /// The return type varies by platform — see [PlatformWebViewController]
-  /// for details.
+  /// This is the recommended way to read values from the editor's JavaScript
+  /// context. It normalizes platform differences so numeric, boolean, string,
+  /// list, map, and null values behave consistently across supported
+  /// platforms.
+  ///
+  /// [expression] must be a JavaScript expression. For multi-statement logic,
+  /// pass an IIFE expression:
   ///
   /// ```dart
-  /// final version = await controller.runJavaScriptReturningResult(
+  /// final count = await controller.evaluateJavaScript<int>(
+  ///   '(() => { const editors = monaco.editor.getEditors(); return editors.length; })()',
+  /// );
+  /// ```
+  ///
+  /// Returns [defaultValue] when the expression returns `undefined`, when the
+  /// decoded value is `null`, or when the value cannot be converted to [T].
+  ///
+  /// JavaScript execution errors are allowed to propagate. This keeps raw
+  /// JavaScript integrations easier to debug.
+  ///
+  /// ## Security
+  ///
+  /// Same caveat as [runJavaScript]: do not interpolate untrusted input into
+  /// [expression]. Use `jsonEncode` for dynamic values.
+  ///
+  /// ## JSON compatibility
+  ///
+  /// The returned JavaScript value must be JSON-serializable. Values such as
+  /// functions, symbols, BigInts, DOM nodes, and circular objects are not
+  /// supported by this typed evaluator. Use [runJavaScriptReturningResultRaw]
+  /// if you need raw platform behavior.
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// final editorCount = await controller.evaluateJavaScript<int>(
   ///   'monaco.editor.getEditors().length',
   /// );
   /// ```
-  Future<Object?> runJavaScriptReturningResult(String script) async {
+  Future<T?> evaluateJavaScript<T>(
+    String expression, {
+    T? defaultValue,
+  }) async {
+    await _ensureReady();
+
+    final wrapped = _wrapJavaScriptEvaluationExpression(expression);
+    final raw = await _webViewController.runJavaScriptReturningResult(wrapped);
+    final decoded = _decodeJavaScriptEvaluationResult(raw);
+
+    if (decoded == _jsUndefined || decoded == null) {
+      return defaultValue;
+    }
+
+    return tryConvertToType<T>(decoded) ?? defaultValue;
+  }
+
+  /// Executes JavaScript and returns the platform-native result.
+  ///
+  /// Advanced use only. Return types vary by platform:
+  ///
+  /// - iOS, macOS, and Web usually return native Dart values.
+  /// - Android may return JSON-encoded strings.
+  /// - Windows WebView2 may return strings where numeric and boolean literals
+  ///   remain strings.
+  ///
+  /// Prefer [evaluateJavaScript] for cross-platform consistency. Use this
+  /// method only when you specifically need the raw platform return shape, for
+  /// example for debugging or advanced WebView interop.
+  ///
+  /// Waits for the editor to be ready before executing.
+  ///
+  /// ## Security
+  ///
+  /// Same caveat as [runJavaScript].
+  Future<Object?> runJavaScriptReturningResultRaw(String script) async {
     await _ensureReady();
     return _webViewController.runJavaScriptReturningResult(script);
   }
@@ -1181,4 +1328,8 @@ class _RegisteredCompletion {
   final List<String> languages;
   final List<String> triggerCharacters;
   final CompletionProvider provider;
+}
+
+class _JavaScriptUndefinedValue {
+  const _JavaScriptUndefinedValue();
 }

--- a/lib/src/platform/platform_webview_interface.dart
+++ b/lib/src/platform/platform_webview_interface.dart
@@ -53,12 +53,17 @@ abstract class PlatformWebViewController {
 
   /// Executes JavaScript code and returns the result.
   ///
-  /// The return type varies by platform:
-  /// - **webview_flutter:** Returns Dart primitives or JSON-decoded objects
-  /// - **webview_windows:** Returns strings that may need JSON parsing
-  /// - **Web iframe:** Returns dartified JS objects
+  /// Return-type behavior varies by platform:
   ///
-  /// Use [parseWindowsScriptResult] to normalize Windows WebView2 results.
+  /// - iOS and macOS via WKWebView usually return native Dart values.
+  /// - Android WebView may return JSON-encoded strings.
+  /// - Windows WebView2 may return strings where numeric and boolean literals
+  ///   remain strings after platform normalization.
+  /// - Web iframe returns the result of JS interop conversion.
+  ///
+  /// `MonacoController.evaluateJavaScript<T>` normalizes these differences for
+  /// JSON-serializable values. Prefer that method at the controller layer
+  /// unless raw platform output is specifically required.
   ///
   /// Throws platform-specific exceptions if the script fails to execute.
   Future<Object?> runJavaScriptReturningResult(String script);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 1.4.0
+version: 1.5.0
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/core/monaco_controller_test.dart
+++ b/test/core/monaco_controller_test.dart
@@ -1044,5 +1044,51 @@ void main() {
         expect(stats.charCount.value, 50);
       });
     });
+
+    group('runJavaScript', () {
+      test('executes script after ready', () async {
+        final bundle = await _createBundle();
+        await bundle.controller.runJavaScript('console.log("hello")');
+        expect(
+          bundle.webview.executed.any((s) => s.contains('console.log')),
+          true,
+        );
+      });
+
+      test('waits for ready before executing', () async {
+        final bundle = await _createBundle(ready: false);
+        final future = bundle.controller.runJavaScript('myCustomSetup()');
+        expect(bundle.webview.executed, isEmpty);
+        bundle.controller.completeReadyForTesting();
+        await future;
+        expect(
+          bundle.webview.executed.any((s) => s.contains('myCustomSetup')),
+          true,
+        );
+      });
+    });
+
+    group('runJavaScriptReturningResult', () {
+      test('executes script and returns result', () async {
+        final bundle = await _createBundle();
+        bundle.webview.enqueueResult('myQuery()', 42);
+        final result =
+            await bundle.controller.runJavaScriptReturningResult('myQuery()');
+        expect(result, 42);
+      });
+
+      test('waits for ready before executing', () async {
+        final bundle = await _createBundle(ready: false);
+        final future =
+            bundle.controller.runJavaScriptReturningResult('myQuery()');
+        expect(bundle.webview.executed, isEmpty);
+        bundle.controller.completeReadyForTesting();
+        await future;
+        expect(
+          bundle.webview.executed.any((s) => s.contains('myQuery')),
+          true,
+        );
+      });
+    });
   });
 }

--- a/test/core/monaco_controller_test.dart
+++ b/test/core/monaco_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/core/monaco_bridge.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -21,6 +23,17 @@ Future<_TestBundle> _createBundle({bool ready = true}) async {
     markReady: ready,
   );
   return _TestBundle(controller, webview, bridge);
+}
+
+String _evaluationEnvelope({
+  Object? value,
+  bool isUndefined = false,
+}) {
+  return jsonEncode({
+    '__flutterMonacoEval': true,
+    'isUndefined': isUndefined,
+    'value': value,
+  });
 }
 
 void main() {
@@ -1066,27 +1079,263 @@ void main() {
           true,
         );
       });
+
+      test('propagates platform exceptions', () async {
+        final bundle = await _createBundle();
+        bundle.webview.throwOnContains('throw new Error');
+
+        await expectLater(
+          bundle.controller.runJavaScript('throw new Error()'),
+          throwsStateError,
+        );
+      });
     });
 
-    group('runJavaScriptReturningResult', () {
-      test('executes script and returns result', () async {
+    group('evaluateJavaScript', () {
+      test('wraps expression in the evaluation envelope', () async {
         final bundle = await _createBundle();
-        bundle.webview.enqueueResult('myQuery()', 42);
-        final result =
-            await bundle.controller.runJavaScriptReturningResult('myQuery()');
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(value: 42);
+          }
+          return null;
+        };
+
+        await bundle.controller.evaluateJavaScript<int>(
+          'monaco.editor.getEditors().length',
+        );
+
+        final executed = bundle.webview.executed.last;
+        expect(executed, contains('__flutterMonacoEval'));
+        expect(executed, contains('JSON.stringify'));
+        expect(executed, contains('monaco.editor.getEditors().length'));
+      });
+
+      test('normalizes numeric result to int', () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(value: 42);
+          }
+          return null;
+        };
+
+        final result = await bundle.controller.evaluateJavaScript<int>(
+          'myQuery()',
+        );
+
         expect(result, 42);
+        expect(result, isA<int>());
+      });
+
+      test('normalizes double-encoded numeric result to int', () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return jsonEncode(_evaluationEnvelope(value: 42));
+          }
+          return null;
+        };
+
+        final result = await bundle.controller.evaluateJavaScript<int>(
+          'myQuery()',
+        );
+
+        expect(result, 42);
+        expect(result, isA<int>());
+      });
+
+      test('normalizes boolean result to bool', () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(value: true);
+          }
+          return null;
+        };
+
+        final result = await bundle.controller.evaluateJavaScript<bool>(
+          'someFlag',
+        );
+
+        expect(result, true);
+        expect(result, isA<bool>());
+      });
+
+      test('preserves string result', () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(value: 'hello');
+          }
+          return null;
+        };
+
+        final result = await bundle.controller.evaluateJavaScript<String>(
+          '"hello"',
+        );
+
+        expect(result, 'hello');
+      });
+
+      test('preserves numeric-looking string result when T is String',
+          () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(value: '42');
+          }
+          return null;
+        };
+
+        final result = await bundle.controller.evaluateJavaScript<String>(
+          '"42"',
+        );
+
+        expect(result, '42');
+        expect(result, isA<String>());
+      });
+
+      test('returns maps', () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(value: {'count': 2});
+          }
+          return null;
+        };
+
+        final result = await bundle.controller
+            .evaluateJavaScript<Map<String, dynamic>>('({ count: 2 })');
+
+        expect(result, {'count': 2});
+      });
+
+      test('returns lists', () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(value: [1, 2, 3]);
+          }
+          return null;
+        };
+
+        final result = await bundle.controller
+            .evaluateJavaScript<List<dynamic>>('[1, 2, 3]');
+
+        expect(result, [1, 2, 3]);
+      });
+
+      test('returns defaultValue when JavaScript returns null', () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope();
+          }
+          return null;
+        };
+
+        final result = await bundle.controller.evaluateJavaScript<int>(
+          'missingThing',
+          defaultValue: -1,
+        );
+
+        expect(result, -1);
+      });
+
+      test('returns defaultValue when JavaScript returns undefined', () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(isUndefined: true);
+          }
+          return null;
+        };
+
+        final result = await bundle.controller.evaluateJavaScript<int>(
+          'missingThing',
+          defaultValue: -1,
+        );
+
+        expect(result, -1);
+      });
+
+      test('returns defaultValue when value cannot convert to T', () async {
+        final bundle = await _createBundle();
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(value: {'count': 2});
+          }
+          return null;
+        };
+
+        final result = await bundle.controller.evaluateJavaScript<int>(
+          '({ count: 2 })',
+          defaultValue: -1,
+        );
+
+        expect(result, -1);
+      });
+
+      test('waits for ready before executing', () async {
+        final bundle = await _createBundle(ready: false);
+        final future = bundle.controller.evaluateJavaScript<int>('myQuery()');
+        expect(bundle.webview.executed, isEmpty);
+        bundle.webview.resultResolver = (script) {
+          if (script.contains('__flutterMonacoEval')) {
+            return _evaluationEnvelope(value: 7);
+          }
+          return null;
+        };
+        bundle.controller.completeReadyForTesting();
+        final result = await future;
+        expect(result, 7);
+        expect(bundle.webview.executed.any((s) => s.contains('myQuery')), true);
+      });
+
+      test('propagates platform exceptions', () async {
+        final bundle = await _createBundle();
+        bundle.webview.throwOnContains('badExpression');
+
+        await expectLater(
+          bundle.controller.evaluateJavaScript<int>('badExpression()'),
+          throwsStateError,
+        );
+      });
+    });
+
+    group('runJavaScriptReturningResultRaw', () {
+      test('returns platform-native value unchanged', () async {
+        final bundle = await _createBundle();
+        bundle.webview.enqueueResult('myQuery()', '42');
+
+        final result = await bundle.controller
+            .runJavaScriptReturningResultRaw('myQuery()');
+
+        expect(result, '42');
       });
 
       test('waits for ready before executing', () async {
         final bundle = await _createBundle(ready: false);
         final future =
-            bundle.controller.runJavaScriptReturningResult('myQuery()');
+            bundle.controller.runJavaScriptReturningResultRaw('myQuery()');
         expect(bundle.webview.executed, isEmpty);
+
+        bundle.webview.enqueueResult('myQuery()', 42);
         bundle.controller.completeReadyForTesting();
-        await future;
-        expect(
-          bundle.webview.executed.any((s) => s.contains('myQuery')),
-          true,
+
+        final result = await future;
+        expect(result, 42);
+        expect(bundle.webview.executed.any((s) => s.contains('myQuery')), true);
+      });
+
+      test('propagates platform exceptions', () async {
+        final bundle = await _createBundle();
+        bundle.webview.throwOnContains('badQuery');
+
+        await expectLater(
+          bundle.controller.runJavaScriptReturningResultRaw('badQuery()'),
+          throwsStateError,
         );
       });
     });


### PR DESCRIPTION
## Summary
• Expose the underlying WebView's JavaScript execution methods as public API on `MonacoController`, enabling callers to configure Monaco features not yet covered by the typed API. In my cause it is configuration of validation schema for JSON and also usage of third-party `monaco-yaml` plugin. Without these methods being public, I'm able to do so only by hack with using customCss JavaScript injection.

## Changes
• `MonacoController.runJavaScript(String script)` added — fire-and-forget JS execution, waits for editor ready.
• `MonacoController.runJavaScriptReturningResult(String script)` added — JS execution with return value, waits for editor ready.
• Tests added for both methods (ready-gating and immediate execution).
• CHANGELOG updated.
• Version bumped to 1.5.0.

## Testing
- [x] `flutter test`
- [x] `flutter analyze`
- [x] `dart format .`
- [ ] Other (describe):

## Usage

```dart
final controller = await MonacoController.create();

// Configure JSON schema validation
await controller.runJavaScript('''
  monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
    validate: true,
    schemas: [{
      uri: 'http://my-schema',
      fileMatch: ['*'],
      schema: { type: 'object' }
    }]
  });
''');

// Query editor state
final editorCount = await controller.runJavaScriptReturningResult(
  'monaco.editor.getEditors().length',
);
```

## Checklist
- [x] I updated docs or examples if needed.
- [x] I updated `CHANGELOG.md` if needed.
- [ ] Release PR only: `pubspec.yaml` version updated.
