### PR TITLE
v1.6.0: web overlay architecture + mobile keyboard fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,24 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.1] - 2026-05-17
+## [1.6.0] - 2026-05-18
+
+### Added
+- `MonacoOverlayBoundary` widget and `MonacoScaffold` convenience wrapper for static Flutter overlays (FABs, drawers, persistent bars, custom `Stack` children) that previously had pointer events swallowed by the editor iframe on Web. `MonacoScaffold` auto-protects the standard Scaffold overlay slots (`floatingActionButton`, `drawer`, `endDrawer`, `bottomSheet`, `bottomNavigationBar`, `persistentFooterButtons`); `MonacoOverlayBoundary` is the underlying primitive for arbitrary overlay subtrees.
+- `MonacoController.runWithInteractionDisabled(action)` for transient overlays (snackbars, toasts, imperative `Overlay.insert` entries) that are neither route-based nor static enough for `MonacoOverlayBoundary`.
+- Internal `MonacoWebInteractionCoordinator` that ref-counts iframe pointer-events so route overlays (`MonacoFocusGuard`) and static overlays compose without fighting.
 
 ### Fixed
 - Fixed soft keyboard activation for `MonacoEditor` on native Android and iOS by letting the platform view own the tap-to-input gesture path.
 - Fixed Android Flutter Web scroll gestures so scrolling focused Monaco content no longer opens the keyboard on release, while preserving intentional keyboard-open scrolling.
 - Fixed a Flutter Web first-load race by waiting for iframe attachment and retrying transient Monaco load failures.
 - Fixed the example iOS runner build configuration.
-- Wired `MonacoRouteObserver` + `MonacoFocusGuard` and added `pointer_interceptor` for FABs across the example app so popup menus, dialogs, and floating action buttons stay clickable over Monaco on the Web.
+
+### Changed
+- Example app switched to `MonacoScaffold`, wired `MonacoRouteObserver` + `MonacoFocusGuard`, and dropped the `pointer_interceptor` dependency.
 
 ### Docs
-- Expanded the README "Web: Handling Overlays" section to distinguish route overlays (handled by `MonacoFocusGuard`) from static overlays (handled by `PointerInterceptor`).
+- Rewrote the README "Web: Handling Overlays" section to cover route overlays (`MonacoFocusGuard`), static overlays (`MonacoScaffold` / `MonacoOverlayBoundary`), and transient overlays (`runWithInteractionDisabled`).
 
 ## [1.5.0] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-05-16
+
+### Fixed
+- Fixed mobile soft keyboard focus handling for `MonacoEditor` on Android and iOS by letting the WebView own the tap-to-input gesture path.
+- Disabled mobile native programmatic autofocus because Android and iOS soft keyboards require a user gesture to open reliably.
+
 ## [1.5.0] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Android Flutter Web scroll gestures so scrolling focused Monaco content no longer opens the keyboard on release, while preserving intentional keyboard-open scrolling.
 - Fixed a Flutter Web first-load race by waiting for iframe attachment and retrying transient Monaco load failures.
 - Fixed the example iOS runner build configuration.
+- Wired `MonacoRouteObserver` + `MonacoFocusGuard` and added `pointer_interceptor` for FABs across the example app so popup menus, dialogs, and floating action buttons stay clickable over Monaco on the Web.
+
+### Docs
+- Expanded the README "Web: Handling Overlays" section to distinguish route overlays (handled by `MonacoFocusGuard`) from static overlays (handled by `PointerInterceptor`).
 
 ## [1.5.0] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.1] - 2026-05-16
+## [1.5.1] - 2026-05-17
 
 ### Fixed
-- Fixed mobile soft keyboard focus handling for `MonacoEditor` on Android and iOS by letting the WebView own the tap-to-input gesture path.
-- Disabled mobile native programmatic autofocus because Android and iOS soft keyboards require a user gesture to open reliably.
+- Fixed soft keyboard activation for `MonacoEditor` on native Android and iOS by letting the platform view own the tap-to-input gesture path.
+- Fixed Android Flutter Web scroll gestures so scrolling focused Monaco content no longer opens the keyboard on release, while preserving intentional keyboard-open scrolling.
+- Fixed a Flutter Web first-load race by waiting for iframe attachment and retrying transient Monaco load failures.
+- Fixed the example iOS runner build configuration.
 
 ## [1.5.0] - 2026-05-16
 

--- a/README.md
+++ b/README.md
@@ -617,11 +617,11 @@ Common symptoms:
 - Dragging across a dropdown highlights text inside the editor instead of the menu items
 - FloatingActionButtons or other widgets stacked over the editor are unreactive
 
-There are two kinds of overlays, and they need different fixes.
+There are two kinds of overlays, and the package provides one primitive for each.
 
 #### 1. Route overlays (dialogs, popup menus, dropdowns)
 
-Anything pushed as a `ModalRoute` - `showDialog`, `showMenu`, `PopupMenuButton`, `DropdownButton`, `BottomSheet`. Provide a `MonacoRouteObserver` and place a `MonacoFocusGuard` near each editor. The guard listens for route pushes and disables iframe interaction automatically while the overlay is on top.
+Anything pushed as a `ModalRoute` - `showDialog`, `showMenu`, `PopupMenuButton`, `DropdownButton`, modal bottom sheets. Provide a `MonacoRouteObserver` and place a `MonacoFocusGuard` near each editor. The guard listens for route pushes and disables iframe interaction automatically while the overlay is on top.
 
 ```dart
 final MonacoRouteObserver monacoRouteObserver = MonacoRouteObserver();
@@ -640,34 +640,65 @@ MonacoFocusGuard(
 )
 ```
 
-#### 2. Static overlays (FABs, in-tree stacked widgets)
+#### 2. Static overlays (FABs, drawers, in-tree stacked widgets)
 
-Persistent widgets that share the page with the editor - a `floatingActionButton` row, anything inside a `Stack` over the editor - do not push a route, so the focus guard cannot fire for them. Wrap the overlapping subtree with `PointerInterceptor` from [`package:pointer_interceptor`](https://pub.dev/packages/pointer_interceptor). It inserts an invisible DOM element above the iframe at that widget's location so the browser sends the click to Flutter.
+Persistent widgets that share the page with the editor - a `floatingActionButton`, a `Drawer`, a persistent footer, anything inside a `Stack` over the editor - do not push a route, so the focus guard cannot fire for them. The package provides two complementary tools:
 
-```yaml
-dependencies:
-  pointer_interceptor: ^0.10.1
-```
+**`MonacoScaffold`** - drop-in replacement for `Scaffold` that automatically protects the standard overlay slots (`floatingActionButton`, `drawer`, `endDrawer`, `bottomSheet`, `bottomNavigationBar`, `persistentFooterButtons`):
 
 ```dart
-import 'package:pointer_interceptor/pointer_interceptor.dart';
-
-Scaffold(
+MonacoScaffold(
+  appBar: AppBar(...),
   body: MonacoEditor(controller: controller),
-  floatingActionButton: PointerInterceptor(
-    child: FloatingActionButton(
-      onPressed: doSomething,
-      child: const Icon(Icons.add),
-    ),
+  floatingActionButton: FloatingActionButton(
+    onPressed: doSomething,
+    child: const Icon(Icons.add),
   ),
 )
 ```
 
-`PointerInterceptor` is a no-op on non-web platforms, so it is safe to use in shared widget trees.
+**`MonacoOverlayBoundary`** - the underlying primitive. Wrap any custom overlay subtree (e.g. a `Stack` child positioned over the editor):
+
+```dart
+Stack(
+  children: [
+    MonacoEditor(controller: controller),
+    Positioned(
+      right: 24,
+      bottom: 24,
+      child: MonacoOverlayBoundary(
+        child: MyFloatingPalette(),
+      ),
+    ),
+  ],
+)
+```
+
+On web, the boundary creates a transparent DOM `<div>` over the widget's global bounds with maximum z-index, and disables pointer events on any intersecting Monaco iframe while the user is hovering or pressing the overlay. On native platforms it is a pass-through.
+
+Tip: for `floatingActionButton: Row(...)`, set `mainAxisSize: MainAxisSize.min` so the shield only covers the actual buttons rather than the full Scaffold width.
+
+#### Transient overlays (snackbars, toasts, imperative Overlay entries)
+
+For overlays that are neither routes nor static enough for a `MonacoOverlayBoundary` - a `ScaffoldMessenger` snackbar with an action button, a temporary toast, an `Overlay.insert` entry shown for a known duration - use `controller.runWithInteractionDisabled` to scope the interaction toggle to the lifetime of the overlay:
+
+```dart
+await controller.runWithInteractionDisabled(() async {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: const Text('Saved'),
+      action: SnackBarAction(label: 'Undo', onPressed: undo),
+    ),
+  );
+  await Future<void>.delayed(const Duration(seconds: 4));
+});
+```
+
+The previous interaction state is restored in a `finally` block. On native platforms this is a thin pass-through (no behavior change).
 
 #### Manual override
 
-If you cannot use a `RouteObserver` in your app, toggle the editor manually:
+If you cannot use route observers, overlay boundaries, or the convenience helper, toggle the editor manually:
 
 ```dart
 MonacoEditor(

--- a/README.md
+++ b/README.md
@@ -605,18 +605,23 @@ print('File count: ${info['fileCount']}');
 await MonacoAssets.clearCache();
 ```
 
-### Web: Handling Overlays (Dialogs, Dropdowns)
+### Web: Handling Overlays
 
 Web platform only. This does not affect native platforms.
 
-On Flutter Web, Monaco is hosted in an `iframe`. By default, the `iframe` intercepts all pointer events, which means Flutter overlays (like `showDialog` or `DropdownButton`) that visually overlap the editor will not receive clicks.
+On Flutter Web, Monaco is hosted in an `iframe`. The browser routes pointer events inside that iframe to its own document first, so Flutter widgets that visually sit on top of the editor can appear correctly but never receive clicks or drags.
 
 Common symptoms:
 
-- Dialogs appear but buttons do not respond
-- Dropdown menus or popups are visible but not clickable
+- Dialogs and popup menus are visible but their buttons do not respond
+- Dragging across a dropdown highlights text inside the editor instead of the menu items
+- FloatingActionButtons or other widgets stacked over the editor are unreactive
 
-Recommended setup: provide a RouteObserver and let MonacoFocusGuard toggle interaction automatically for popup routes:
+There are two kinds of overlays, and they need different fixes.
+
+#### 1. Route overlays (dialogs, popup menus, dropdowns)
+
+Anything pushed as a `ModalRoute` - `showDialog`, `showMenu`, `PopupMenuButton`, `DropdownButton`, `BottomSheet`. Provide a `MonacoRouteObserver` and place a `MonacoFocusGuard` near each editor. The guard listens for route pushes and disables iframe interaction automatically while the overlay is on top.
 
 ```dart
 final MonacoRouteObserver monacoRouteObserver = MonacoRouteObserver();
@@ -631,11 +636,38 @@ MaterialApp(
 MonacoFocusGuard(
   controller: controller,
   modalRouteObserver: monacoRouteObserver,
-  autoDisableInteraction: true,
+  // autoDisableInteraction defaults to true
 )
 ```
 
-Manual alternative: if you cannot use a RouteObserver in your app, you can still toggle the editor manually:
+#### 2. Static overlays (FABs, in-tree stacked widgets)
+
+Persistent widgets that share the page with the editor - a `floatingActionButton` row, anything inside a `Stack` over the editor - do not push a route, so the focus guard cannot fire for them. Wrap the overlapping subtree with `PointerInterceptor` from [`package:pointer_interceptor`](https://pub.dev/packages/pointer_interceptor). It inserts an invisible DOM element above the iframe at that widget's location so the browser sends the click to Flutter.
+
+```yaml
+dependencies:
+  pointer_interceptor: ^0.10.1
+```
+
+```dart
+import 'package:pointer_interceptor/pointer_interceptor.dart';
+
+Scaffold(
+  body: MonacoEditor(controller: controller),
+  floatingActionButton: PointerInterceptor(
+    child: FloatingActionButton(
+      onPressed: doSomething,
+      child: const Icon(Icons.add),
+    ),
+  ),
+)
+```
+
+`PointerInterceptor` is a no-op on non-web platforms, so it is safe to use in shared widget trees.
+
+#### Manual override
+
+If you cannot use a `RouteObserver` in your app, toggle the editor manually:
 
 ```dart
 MonacoEditor(

--- a/doc/focus-and-platform-views.md
+++ b/doc/focus-and-platform-views.md
@@ -94,8 +94,8 @@ If you need finer control, these hooks make focus rock‑solid:
 
 4) Avoid intercepting clicks above the WebView
 
-- If you render overlays on top, use `HitTestBehavior.translucent` or `pointer_interceptor` so the platform view can
-  still get the primary click.
+- If you render overlays on top, use `HitTestBehavior.translucent` so the platform view can still get the primary click.
+- On Flutter Web specifically, the iframe-backed platform view will swallow pointer events for any Flutter widget visually above it. Use `MonacoFocusGuard` + `MonacoRouteObserver` for dialog/menu routes, `MonacoScaffold` or `MonacoOverlayBoundary` for static overlays (FABs, drawers, persistent bars), and `MonacoController.runWithInteractionDisabled` for transient overlays (snackbars, toasts). See the README's "Web: Handling Overlays" section.
 
 ## Reference Implementation Snippets
 

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/example/lib/complete_example.dart
+++ b/example/lib/complete_example.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
-import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 import 'custom_font_example.dart';
 import 'focus_test_example.dart';
@@ -181,7 +180,7 @@ class _MonacoExamplePageState extends State<MonacoExamplePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return MonacoScaffold(
       appBar: AppBar(
         title: const Text('Flutter Monaco Editor'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
@@ -281,91 +280,84 @@ class _MonacoExamplePageState extends State<MonacoExamplePage> {
           ),
         ],
       ),
-      // Each FAB is wrapped individually with PointerInterceptor so the
-      // underlying Monaco iframe cannot swallow the click on Web. Wrapping
-      // the whole Row does not work reliably - the official pattern is one
-      // interceptor per interactive element.
+      // MonacoScaffold automatically wraps this Row in a MonacoOverlayBoundary
+      // so the underlying Monaco iframe cannot swallow clicks on Web.
+      // mainAxisSize: MainAxisSize.min keeps the shield sized to the actual
+      // buttons rather than the full available width.
       floatingActionButton: Row(
+        mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           // Focus test button
-          PointerInterceptor(
-            child: FloatingActionButton(
-              heroTag: 'focus',
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const FocusTestExample(),
-                  ),
-                );
-              },
-              backgroundColor: Colors.purple,
-              child: const Icon(Icons.bug_report),
-            ),
+          FloatingActionButton(
+            heroTag: 'focus',
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const FocusTestExample(),
+                ),
+              );
+            },
+            backgroundColor: Colors.purple,
+            child: const Icon(Icons.bug_report),
           ),
           const SizedBox(width: 8),
           // Multi-editor demo button
-          PointerInterceptor(
-            child: FloatingActionButton.extended(
-              heroTag: 'multi',
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const MultiEditorExample(),
-                  ),
-                );
-              },
-              label: const Text('Multi-Editor'),
-              icon: const Icon(Icons.view_column),
-              backgroundColor: Colors.green,
-            ),
+          FloatingActionButton.extended(
+            heroTag: 'multi',
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const MultiEditorExample(),
+                ),
+              );
+            },
+            label: const Text('Multi-Editor'),
+            icon: const Icon(Icons.view_column),
+            backgroundColor: Colors.green,
           ),
           const SizedBox(width: 8),
           // Custom font demo button
-          PointerInterceptor(
-            child: FloatingActionButton.extended(
-              heroTag: 'font',
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const CustomFontExample(),
-                  ),
-                );
-              },
-              label: const Text('Custom Fonts'),
-              icon: const Icon(Icons.font_download),
-              backgroundColor: Colors.orange,
-            ),
+          FloatingActionButton.extended(
+            heroTag: 'font',
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const CustomFontExample(),
+                ),
+              );
+            },
+            label: const Text('Custom Fonts'),
+            icon: const Icon(Icons.font_download),
+            backgroundColor: Colors.orange,
           ),
           const SizedBox(width: 16),
           // Get content button
-          PointerInterceptor(
-            child: FloatingActionButton.extended(
-              heroTag: 'content',
-              onPressed: () async {
-                final content = await _controller?.getValue();
-                if (content != null && context.mounted) {
-                  showDialog(
-                    context: context,
-                    builder: (context) => AlertDialog(
-                      title: const Text('Editor Content'),
-                      content: SingleChildScrollView(
-                        child: Text(content.substring(
-                            0, content.length > 500 ? 500 : content.length)),
-                      ),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: const Text('Close'),
-                        ),
-                      ],
+          FloatingActionButton.extended(
+            heroTag: 'content',
+            onPressed: () async {
+              final content = await _controller?.getValue();
+              if (content != null && context.mounted) {
+                showDialog(
+                  context: context,
+                  builder: (context) => AlertDialog(
+                    title: const Text('Editor Content'),
+                    content: SingleChildScrollView(
+                      child: Text(content.substring(
+                          0, content.length > 500 ? 500 : content.length)),
                     ),
-                  );
-                }
-              },
-              label: const Text('Get Content'),
-              icon: const Icon(Icons.download),
-            ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text('Close'),
+                      ),
+                    ],
+                  ),
+                );
+              }
+            },
+            label: const Text('Get Content'),
+            icon: const Icon(Icons.download),
           ),
         ],
       ),

--- a/example/lib/complete_example.dart
+++ b/example/lib/complete_example.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 import 'custom_font_example.dart';
 import 'focus_test_example.dart';
+import 'monaco_observer.dart';
 import 'multi_editor_example.dart';
 
 void main() {
@@ -20,6 +22,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
         useMaterial3: true,
       ),
+      navigatorObservers: [monacoRouteObserver],
       home: const MonacoExamplePage(),
     );
   }
@@ -255,6 +258,12 @@ class _MonacoExamplePageState extends State<MonacoExamplePage> {
               ],
             ),
           ),
+          // Keep Flutter dialogs/menus clickable over the editor on Web.
+          if (_controller != null)
+            MonacoFocusGuard(
+              controller: _controller!,
+              modalRouteObserver: monacoRouteObserver,
+            ),
           // Editor
           Expanded(
             child: _isLoading
@@ -272,79 +281,91 @@ class _MonacoExamplePageState extends State<MonacoExamplePage> {
           ),
         ],
       ),
+      // Each FAB is wrapped individually with PointerInterceptor so the
+      // underlying Monaco iframe cannot swallow the click on Web. Wrapping
+      // the whole Row does not work reliably - the official pattern is one
+      // interceptor per interactive element.
       floatingActionButton: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           // Focus test button
-          FloatingActionButton(
-            heroTag: 'focus',
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const FocusTestExample(),
-                ),
-              );
-            },
-            backgroundColor: Colors.purple,
-            child: const Icon(Icons.bug_report),
+          PointerInterceptor(
+            child: FloatingActionButton(
+              heroTag: 'focus',
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => const FocusTestExample(),
+                  ),
+                );
+              },
+              backgroundColor: Colors.purple,
+              child: const Icon(Icons.bug_report),
+            ),
           ),
           const SizedBox(width: 8),
           // Multi-editor demo button
-          FloatingActionButton.extended(
-            heroTag: 'multi',
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const MultiEditorExample(),
-                ),
-              );
-            },
-            label: const Text('Multi-Editor'),
-            icon: const Icon(Icons.view_column),
-            backgroundColor: Colors.green,
+          PointerInterceptor(
+            child: FloatingActionButton.extended(
+              heroTag: 'multi',
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => const MultiEditorExample(),
+                  ),
+                );
+              },
+              label: const Text('Multi-Editor'),
+              icon: const Icon(Icons.view_column),
+              backgroundColor: Colors.green,
+            ),
           ),
           const SizedBox(width: 8),
           // Custom font demo button
-          FloatingActionButton.extended(
-            heroTag: 'font',
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const CustomFontExample(),
-                ),
-              );
-            },
-            label: const Text('Custom Fonts'),
-            icon: const Icon(Icons.font_download),
-            backgroundColor: Colors.orange,
+          PointerInterceptor(
+            child: FloatingActionButton.extended(
+              heroTag: 'font',
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => const CustomFontExample(),
+                  ),
+                );
+              },
+              label: const Text('Custom Fonts'),
+              icon: const Icon(Icons.font_download),
+              backgroundColor: Colors.orange,
+            ),
           ),
           const SizedBox(width: 16),
           // Get content button
-          FloatingActionButton.extended(
-            heroTag: 'content',
-            onPressed: () async {
-              final content = await _controller?.getValue();
-              if (content != null && context.mounted) {
-                showDialog(
-                  context: context,
-                  builder: (context) => AlertDialog(
-                    title: const Text('Editor Content'),
-                    content: SingleChildScrollView(
-                      child: Text(content.substring(
-                          0, content.length > 500 ? 500 : content.length)),
-                    ),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.of(context).pop(),
-                        child: const Text('Close'),
+          PointerInterceptor(
+            child: FloatingActionButton.extended(
+              heroTag: 'content',
+              onPressed: () async {
+                final content = await _controller?.getValue();
+                if (content != null && context.mounted) {
+                  showDialog(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      title: const Text('Editor Content'),
+                      content: SingleChildScrollView(
+                        child: Text(content.substring(
+                            0, content.length > 500 ? 500 : content.length)),
                       ),
-                    ],
-                  ),
-                );
-              }
-            },
-            label: const Text('Get Content'),
-            icon: const Icon(Icons.download),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: const Text('Close'),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+              },
+              label: const Text('Get Content'),
+              icon: const Icon(Icons.download),
+            ),
           ),
         ],
       ),

--- a/example/lib/focus_test_example.dart
+++ b/example/lib/focus_test_example.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
+
+import 'monaco_observer.dart';
 
 class FocusTestExample extends StatefulWidget {
   const FocusTestExample({super.key});
@@ -46,71 +49,86 @@ class _FocusTestExampleState extends State<FocusTestExample> {
         title: const Text('Focus Test'),
         backgroundColor: Colors.purple,
       ),
-      body: Row(
+      body: Column(
         children: [
-          // Left: Monaco Editor
+          // Keep the dialog clickable over the editor on Web.
+          if (_controller != null)
+            MonacoFocusGuard(
+              controller: _controller!,
+              modalRouteObserver: monacoRouteObserver,
+            ),
           Expanded(
-            child: _controller?.webViewWidget ??
-                const Center(child: CircularProgressIndicator()),
-          ),
-          const VerticalDivider(width: 1),
-          // Right: Flutter TextField
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: TextField(
-                controller: _textController,
-                maxLines: null,
-                expands: true,
-                style: const TextStyle(fontFamily: 'monospace'),
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  hintText: 'Type here...',
+            child: Row(
+              children: [
+                // Left: Monaco Editor
+                Expanded(
+                  child: _controller?.webViewWidget ??
+                      const Center(child: CircularProgressIndicator()),
                 ),
-              ),
+                const VerticalDivider(width: 1),
+                // Right: Flutter TextField
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: TextField(
+                      controller: _textController,
+                      maxLines: null,
+                      expands: true,
+                      style: const TextStyle(fontFamily: 'monospace'),
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        hintText: 'Type here...',
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ],
       ),
-      // Dialog button at bottom
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () {
-          showDialog(
-            context: context,
-            builder: (context) {
-              String dialogText = '';
-              return AlertDialog(
-                title: const Text('Type to Monaco'),
-                content: TextField(
-                  autofocus: true,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    hintText: 'Type here to send to Monaco...',
+      // PointerInterceptor stops the underlying Monaco iframe from stealing
+      // the click on Web so this FAB is reachable over the editor.
+      floatingActionButton: PointerInterceptor(
+        child: FloatingActionButton.extended(
+          onPressed: () {
+            showDialog(
+              context: context,
+              builder: (context) {
+                String dialogText = '';
+                return AlertDialog(
+                  title: const Text('Type to Monaco'),
+                  content: TextField(
+                    autofocus: true,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      hintText: 'Type here to send to Monaco...',
+                    ),
+                    onChanged: (value) => dialogText = value,
                   ),
-                  onChanged: (value) => dialogText = value,
-                ),
-                actions: [
-                  TextButton(
-                    onPressed: () => Navigator.pop(context),
-                    child: const Text('Cancel'),
-                  ),
-                  ElevatedButton(
-                    onPressed: () async {
-                      Navigator.pop(context);
-                      // Send dialog text to Monaco
-                      final current = await _controller?.getValue() ?? '';
-                      await _controller
-                          ?.setValue('$current\n// From dialog: $dialogText');
-                    },
-                    child: const Text('Send to Monaco'),
-                  ),
-                ],
-              );
-            },
-          );
-        },
-        label: const Text('Open Dialog'),
-        icon: const Icon(Icons.open_in_new),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: const Text('Cancel'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () async {
+                        Navigator.pop(context);
+                        // Send dialog text to Monaco
+                        final current = await _controller?.getValue() ?? '';
+                        await _controller
+                            ?.setValue('$current\n// From dialog: $dialogText');
+                      },
+                      child: const Text('Send to Monaco'),
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+          label: const Text('Open Dialog'),
+          icon: const Icon(Icons.open_in_new),
+        ),
       ),
     );
   }

--- a/example/lib/focus_test_example.dart
+++ b/example/lib/focus_test_example.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
-import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 import 'monaco_observer.dart';
 
@@ -44,7 +43,7 @@ class _FocusTestExampleState extends State<FocusTestExample> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return MonacoScaffold(
       appBar: AppBar(
         title: const Text('Focus Test'),
         backgroundColor: Colors.purple,
@@ -87,48 +86,45 @@ class _FocusTestExampleState extends State<FocusTestExample> {
           ),
         ],
       ),
-      // PointerInterceptor stops the underlying Monaco iframe from stealing
-      // the click on Web so this FAB is reachable over the editor.
-      floatingActionButton: PointerInterceptor(
-        child: FloatingActionButton.extended(
-          onPressed: () {
-            showDialog(
-              context: context,
-              builder: (context) {
-                String dialogText = '';
-                return AlertDialog(
-                  title: const Text('Type to Monaco'),
-                  content: TextField(
-                    autofocus: true,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      hintText: 'Type here to send to Monaco...',
-                    ),
-                    onChanged: (value) => dialogText = value,
+      // MonacoScaffold wraps this in a MonacoOverlayBoundary on Web.
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          showDialog(
+            context: context,
+            builder: (context) {
+              String dialogText = '';
+              return AlertDialog(
+                title: const Text('Type to Monaco'),
+                content: TextField(
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    hintText: 'Type here to send to Monaco...',
                   ),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.pop(context),
-                      child: const Text('Cancel'),
-                    ),
-                    ElevatedButton(
-                      onPressed: () async {
-                        Navigator.pop(context);
-                        // Send dialog text to Monaco
-                        final current = await _controller?.getValue() ?? '';
-                        await _controller
-                            ?.setValue('$current\n// From dialog: $dialogText');
-                      },
-                      child: const Text('Send to Monaco'),
-                    ),
-                  ],
-                );
-              },
-            );
-          },
-          label: const Text('Open Dialog'),
-          icon: const Icon(Icons.open_in_new),
-        ),
+                  onChanged: (value) => dialogText = value,
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Cancel'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () async {
+                      Navigator.pop(context);
+                      // Send dialog text to Monaco
+                      final current = await _controller?.getValue() ?? '';
+                      await _controller
+                          ?.setValue('$current\n// From dialog: $dialogText');
+                    },
+                    child: const Text('Send to Monaco'),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+        label: const Text('Open Dialog'),
+        icon: const Icon(Icons.open_in_new),
       ),
     );
   }

--- a/example/lib/monaco_observer.dart
+++ b/example/lib/monaco_observer.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_monaco/flutter_monaco.dart';
+
+/// Shared route observer for the example app.
+///
+/// Register once on [MaterialApp.navigatorObservers] (done in
+/// `complete_example.dart`) and pass to [MonacoFocusGuard.modalRouteObserver]
+/// in every page that hosts a [MonacoEditor]. The guard uses it to detect
+/// dialog/popup pushes and toggle iframe interaction on the web so overlays
+/// stay clickable.
+final MonacoRouteObserver monacoRouteObserver = MonacoRouteObserver();

--- a/example/lib/multi_editor_example.dart
+++ b/example/lib/multi_editor_example.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
+
+import 'monaco_observer.dart';
 
 class MultiEditorExample extends StatefulWidget {
   const MultiEditorExample({super.key});
@@ -162,6 +165,19 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
       ),
       body: Column(
         children: [
+          // Keep Flutter dialogs/menus clickable over each editor on Web.
+          MonacoFocusGuard(
+            controller: _leftController!,
+            modalRouteObserver: monacoRouteObserver,
+          ),
+          MonacoFocusGuard(
+            controller: _rightController!,
+            modalRouteObserver: monacoRouteObserver,
+          ),
+          MonacoFocusGuard(
+            controller: _bottomController!,
+            modalRouteObserver: monacoRouteObserver,
+          ),
           // Top section - Split view
           Expanded(
             flex: 2,
@@ -220,43 +236,47 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () async {
-          // Get content from all editors
-          final dartContent = await _leftController!.getValue();
-          final jsContent = await _rightController!.getValue();
-          final mdContent = await _bottomController!.getValue();
+      // PointerInterceptor stops the underlying Monaco iframes from stealing
+      // the click on Web so this FAB is reachable over the editors.
+      floatingActionButton: PointerInterceptor(
+        child: FloatingActionButton.extended(
+          onPressed: () async {
+            // Get content from all editors
+            final dartContent = await _leftController!.getValue();
+            final jsContent = await _rightController!.getValue();
+            final mdContent = await _bottomController!.getValue();
 
-          if (context.mounted) {
-            showDialog(
-              context: context,
-              builder: (context) => AlertDialog(
-                title: const Text('All Editor Contents'),
-                content: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text('Dart (${dartContent.length} chars)'),
-                      const SizedBox(height: 8),
-                      Text('JavaScript (${jsContent.length} chars)'),
-                      const SizedBox(height: 8),
-                      Text('Markdown (${mdContent.length} chars)'),
-                    ],
+            if (context.mounted) {
+              showDialog(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('All Editor Contents'),
+                  content: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text('Dart (${dartContent.length} chars)'),
+                        const SizedBox(height: 8),
+                        Text('JavaScript (${jsContent.length} chars)'),
+                        const SizedBox(height: 8),
+                        Text('Markdown (${mdContent.length} chars)'),
+                      ],
+                    ),
                   ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: const Text('Close'),
+                    ),
+                  ],
                 ),
-                actions: [
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: const Text('Close'),
-                  ),
-                ],
-              ),
-            );
-          }
-        },
-        label: const Text('Get All Content'),
-        icon: const Icon(Icons.download),
+              );
+            }
+          },
+          label: const Text('Get All Content'),
+          icon: const Icon(Icons.download),
+        ),
       ),
     );
   }

--- a/example/lib/multi_editor_example.dart
+++ b/example/lib/multi_editor_example.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
-import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 import 'monaco_observer.dart';
 
@@ -118,7 +117,7 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
       );
     }
 
-    return Scaffold(
+    return MonacoScaffold(
       appBar: AppBar(
         title: const Text('Multi-Editor Example'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
@@ -236,47 +235,45 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
           ),
         ],
       ),
-      // PointerInterceptor stops the underlying Monaco iframes from stealing
-      // the click on Web so this FAB is reachable over the editors.
-      floatingActionButton: PointerInterceptor(
-        child: FloatingActionButton.extended(
-          onPressed: () async {
-            // Get content from all editors
-            final dartContent = await _leftController!.getValue();
-            final jsContent = await _rightController!.getValue();
-            final mdContent = await _bottomController!.getValue();
+      // MonacoScaffold wraps this in a MonacoOverlayBoundary on Web so the
+      // underlying Monaco iframes do not swallow the click.
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () async {
+          // Get content from all editors
+          final dartContent = await _leftController!.getValue();
+          final jsContent = await _rightController!.getValue();
+          final mdContent = await _bottomController!.getValue();
 
-            if (context.mounted) {
-              showDialog(
-                context: context,
-                builder: (context) => AlertDialog(
-                  title: const Text('All Editor Contents'),
-                  content: SingleChildScrollView(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text('Dart (${dartContent.length} chars)'),
-                        const SizedBox(height: 8),
-                        Text('JavaScript (${jsContent.length} chars)'),
-                        const SizedBox(height: 8),
-                        Text('Markdown (${mdContent.length} chars)'),
-                      ],
-                    ),
+          if (context.mounted) {
+            showDialog(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: const Text('All Editor Contents'),
+                content: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text('Dart (${dartContent.length} chars)'),
+                      const SizedBox(height: 8),
+                      Text('JavaScript (${jsContent.length} chars)'),
+                      const SizedBox(height: 8),
+                      Text('Markdown (${mdContent.length} chars)'),
+                    ],
                   ),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: const Text('Close'),
-                    ),
-                  ],
                 ),
-              );
-            }
-          },
-          label: const Text('Get All Content'),
-          icon: const Icon(Icons.download),
-        ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('Close'),
+                  ),
+                ],
+              ),
+            );
+          }
+        },
+        label: const Text('Get All Content'),
+        icon: const Icon(Icons.download),
       ),
     );
   }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   url_launcher: ^6.3.2
   flutter_svg: ^2.2.3
   package_info_plus: ^9.0.0
-  pointer_interceptor: ^0.10.1
   flutter_monaco:
     path: ../
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   url_launcher: ^6.3.2
   flutter_svg: ^2.2.3
   package_info_plus: ^9.0.0
+  pointer_interceptor: ^0.10.1
   flutter_monaco:
     path: ../
 

--- a/lib/flutter_monaco.dart
+++ b/lib/flutter_monaco.dart
@@ -97,4 +97,6 @@ export 'src/models/monaco_types.dart'
 // Widget exports
 export 'src/widgets/monaco_editor_view.dart' show MonacoEditor;
 export 'src/widgets/monaco_focus_guard.dart' show MonacoFocusGuard;
+export 'src/widgets/monaco_overlay_boundary.dart' show MonacoOverlayBoundary;
 export 'src/widgets/monaco_route_observer.dart' show MonacoRouteObserver;
+export 'src/widgets/monaco_scaffold.dart' show MonacoScaffold;

--- a/lib/src/core/monaco_assets.dart
+++ b/lib/src/core/monaco_assets.dart
@@ -440,6 +440,7 @@ class MonacoAssets {
     String? messageToken,
     String? customCss,
     bool allowCdnFonts = false,
+    bool gestureDebugEnabled = false,
   }) {
     // Platform-specific initialization scripts
     String platformScript = '';
@@ -948,16 +949,67 @@ class MonacoAssets {
                       const ownerWindow = ownerDocument.defaultView || window;
                       const ua = navigator.userAgent || '';
                       const isAndroid = /Android/i.test(ua);
+                      const isFlutterWebEmbed = (() => {
+                        try {
+                          return ownerWindow.parent && ownerWindow.parent !== ownerWindow;
+                        } catch (_) {
+                          return false;
+                        }
+                      })();
                       const tapMoveThreshold = 8;
                       const tapTimeThreshold = 650;
                       const compatibilityEventSuppressMs = 1200;
                       let gesture = null;
+                      let androidTouchScrollGesture = null;
                       let lastFocusAt = 0;
                       let suppressUntil = 0;
+                      let suppressFocusUntil = 0;
                       const supportsPointerEvents = !!ownerWindow.PointerEvent;
                       const usePointerTapBridge = supportsPointerEvents && isAndroid;
                       const useTouchTapBridge = !usePointerTapBridge;
+                      const useAndroidWebFocusGuard = usePointerTapBridge && isFlutterWebEmbed;
                       const now = () => Date.now();
+                      const debugModeFromSearch = (search) => {
+                        try {
+                          const match = /(?:^|[?&])monacoGestureDebug(?:=([^&]*))?/.exec(search || '');
+                          if (!match) return '';
+                          const value = decodeURIComponent(match[1] || '1');
+                          return value && value !== '0' && value !== 'false' ? value : '';
+                        } catch (_) {
+                          return '';
+                        }
+                      };
+                      const debugModeFromStorage = (storage) => {
+                        try {
+                          const value =
+                            storage?.getItem('flutterMonacoGestureDebug') ||
+                            storage?.getItem('monacoGestureDebug') ||
+                            '';
+                          return value && value !== '0' && value !== 'false' ? value : '';
+                        } catch (_) {
+                          return '';
+                        }
+                      };
+                      const getGestureDebugMode = () => {
+                        let mode =
+                          debugModeFromSearch(ownerWindow.location?.search) ||
+                          debugModeFromStorage(ownerWindow.localStorage);
+                        try {
+                          if (!mode && ownerWindow.parent && ownerWindow.parent !== ownerWindow) {
+                            mode =
+                              debugModeFromSearch(ownerWindow.parent.location?.search) ||
+                              debugModeFromStorage(ownerWindow.parent.localStorage);
+                          }
+                        } catch (_) {}
+                        if (mode) return mode;
+                        return ${gestureDebugEnabled ? 'true' : 'false'} ? '1' : '';
+                      };
+                      const mobileGestureDebugMode = getGestureDebugMode();
+                      const mobileGestureDebugEnabled = mobileGestureDebugMode !== '';
+                      const mobileGestureDebugVerbose =
+                        mobileGestureDebugMode === '2' ||
+                        mobileGestureDebugMode === 'verbose';
+                      const mobileGestureDebugLog = [];
                       const eventPoint = (event) => {
                         const touch =
                           event.changedTouches?.[0] || event.touches?.[0];
@@ -997,6 +1049,20 @@ class MonacoAssets {
                         return Math.abs(scroll.top - gesture.scrollTop) > 0 ||
                           Math.abs(scroll.left - gesture.scrollLeft) > 0;
                       };
+                      const hasTouchScrollMovedFromStart = (event) => {
+                        if (!androidTouchScrollGesture) return false;
+                        const point = eventPoint(event);
+                        if (point) {
+                          const dx = point.x - androidTouchScrollGesture.x;
+                          const dy = point.y - androidTouchScrollGesture.y;
+                          if ((dx * dx + dy * dy) > tapMoveThreshold * tapMoveThreshold) {
+                            return true;
+                          }
+                        }
+                        const scroll = getScrollSnapshot();
+                        return Math.abs(scroll.top - androidTouchScrollGesture.scrollTop) > 0 ||
+                          Math.abs(scroll.left - androidTouchScrollGesture.scrollLeft) > 0;
+                      };
                       const blockEvent = (event) => {
                         try {
                           if (event.cancelable && event.preventDefault) {
@@ -1011,12 +1077,238 @@ class MonacoAssets {
                       };
                       const suppressAndBlock = (event) => {
                         suppressCompatibilityEvents();
+                        debugMobileGesture('suppress-and-block', {}, event);
                         blockEvent(event);
                       };
                       const shouldBlockSuppressedEvent = () => now() < suppressUntil;
                       const blockSuppressedCompatibilityEvent = (event) => {
                         if (shouldBlockSuppressedEvent()) {
+                          debugMobileGesture('compatibility-event-blocked', {}, event);
                           blockEvent(event);
+                        }
+                      };
+                      const editorInputSelector =
+                        'textarea.inputarea, .native-edit-context';
+                      const isEditorInputElement = (element) => {
+                        try {
+                          return !!(
+                            element &&
+                            element.matches &&
+                            element.matches(editorInputSelector)
+                          );
+                        } catch (_) {
+                          return false;
+                        }
+                      };
+                      const getEditorInputElement = () => {
+                        try {
+                          const active = ownerDocument.activeElement;
+                          if (isEditorInputElement(active)) {
+                            return active;
+                          }
+                          return node.querySelector(editorInputSelector);
+                        } catch (_) {
+                          return null;
+                        }
+                      };
+                      const isTextAreaFocused = () => {
+                        try {
+                          return isEditorInputElement(ownerDocument.activeElement);
+                        } catch (_) {
+                          return false;
+                        }
+                      };
+                      const shouldSuppressFocus = () => now() < suppressFocusUntil;
+                      let maxObservedViewportHeight = 0;
+                      const getViewportHeightForKeyboard = () => {
+                        const readHeight = (win) => {
+                          try {
+                            return win?.visualViewport?.height || win?.innerHeight || 0;
+                          } catch (_) {
+                            return 0;
+                          }
+                        };
+                        let height = readHeight(ownerWindow);
+                        try {
+                          if (ownerWindow.parent && ownerWindow.parent !== ownerWindow) {
+                            height = readHeight(ownerWindow.parent) || height;
+                          }
+                        } catch (_) {}
+                        return height || 0;
+                      };
+                      const updateViewportKeyboardBaseline = () => {
+                        const height = getViewportHeightForKeyboard();
+                        if (height > maxObservedViewportHeight) {
+                          maxObservedViewportHeight = height;
+                        }
+                        return height;
+                      };
+                      const isKeyboardLikelyVisible = () => {
+                        const height = updateViewportKeyboardBaseline();
+                        const baseline = maxObservedViewportHeight || height;
+                        if (!height || !baseline) return false;
+                        const hiddenHeight = baseline - height;
+                        return hiddenHeight > Math.max(120, baseline * 0.18);
+                      };
+                      updateViewportKeyboardBaseline();
+                      try {
+                        ownerWindow.visualViewport?.addEventListener(
+                          'resize',
+                          updateViewportKeyboardBaseline,
+                          { passive: true }
+                        );
+                      } catch (_) {}
+                      try {
+                        if (ownerWindow.parent && ownerWindow.parent !== ownerWindow) {
+                          ownerWindow.parent.visualViewport?.addEventListener(
+                            'resize',
+                            updateViewportKeyboardBaseline,
+                            { passive: true }
+                          );
+                        }
+                      } catch (_) {}
+                      const elementLabel = (element) => {
+                        if (!element) return 'null';
+                        try {
+                          let label = element.tagName ? element.tagName.toLowerCase() : String(element);
+                          const className = typeof element.className === 'string'
+                            ? element.className.trim()
+                            : '';
+                          if (className) {
+                            label += '.' + className.split(/\\s+/).slice(0, 4).join('.');
+                          }
+                          return label;
+                        } catch (_) {
+                          return 'unknown';
+                        }
+                      };
+                      const gestureSummary = (value) => value ? {
+                        id: value.id,
+                        kind: value.kind,
+                        moved: !!value.moved,
+                        cancelled: !!value.cancelled,
+                        hadInputFocusAtStart: !!value.hadInputFocusAtStart,
+                        ageMs: now() - value.startedAt,
+                      } : null;
+                      const touchGuardSummary = (value) => value ? {
+                        id: value.id,
+                        moved: !!value.moved,
+                        hadInputFocusAtStart: !!value.hadInputFocusAtStart,
+                      } : null;
+                      const eventSummary = (event) => {
+                        const point = event ? eventPoint(event) : null;
+                        const scroll = getScrollSnapshot();
+                        return {
+                          type: event?.type,
+                          cancelable: !!event?.cancelable,
+                          defaultPrevented: !!event?.defaultPrevented,
+                          pointerType: event?.pointerType,
+                          pointerId: event?.pointerId,
+                          isPrimary: event?.isPrimary,
+                          touches: event?.touches?.length,
+                          changedTouches: event?.changedTouches?.length,
+                          x: point?.x,
+                          y: point?.y,
+                          scrollTop: scroll.top,
+                          scrollLeft: scroll.left,
+                          activeElement: elementLabel(ownerDocument.activeElement),
+                          textAreaFocused: isTextAreaFocused(),
+                          keyboardLikelyVisible: isKeyboardLikelyVisible(),
+                          suppressUntilMs: Math.max(0, suppressUntil - now()),
+                          suppressFocusUntilMs: Math.max(0, suppressFocusUntil - now()),
+                        };
+                      };
+                      const debugMobileGesture = (phase, payload, event) => {
+                        if (!mobileGestureDebugEnabled) return;
+                        try {
+                          const entry = {
+                            event: 'mobileGestureDebug',
+                            phase,
+                            t: now(),
+                            mode: mobileGestureDebugMode,
+                            platform: {
+                              isAndroid,
+                              isFlutterWebEmbed,
+                              supportsPointerEvents,
+                              usePointerTapBridge,
+                              useTouchTapBridge,
+                              useAndroidWebFocusGuard,
+                            },
+                            state: {
+                              gesture: gestureSummary(gesture),
+                              androidTouchScrollGesture:
+                                touchGuardSummary(androidTouchScrollGesture),
+                            },
+                            input: event ? eventSummary(event) : undefined,
+                            data: payload || {},
+                          };
+                          mobileGestureDebugLog.push(entry);
+                          if (mobileGestureDebugLog.length > 250) {
+                            mobileGestureDebugLog.shift();
+                          }
+                          try {
+                            ownerWindow.flutterMonacoGestureDebugLog =
+                              mobileGestureDebugLog;
+                          } catch (_) {}
+                          try {
+                            console.log('[flutter_monaco][gesture]', JSON.stringify(entry));
+                          } catch (_) {
+                            try { console.log('[flutter_monaco][gesture]', entry); } catch (_) {}
+                          }
+                          try { postMessageToFlutter(entry); } catch (_) {}
+                        } catch (_) {}
+                      };
+                      try {
+                        window.flutterMonaco.getGestureDebugLog =
+                          () => mobileGestureDebugLog.slice();
+                        window.flutterMonaco.clearGestureDebugLog =
+                          () => { mobileGestureDebugLog.length = 0; };
+                      } catch (_) {}
+                      const blurTextAreaIfFocusSuppressed = () => {
+                        if (!shouldSuppressFocus()) return;
+                        try {
+                          const input = getEditorInputElement();
+                          if (input && ownerDocument.activeElement === input) {
+                            debugMobileGesture('blur-suppressed-textarea', {
+                              reason: 'focus suppressed after scroll',
+                            });
+                            input.blur();
+                          }
+                        } catch (_) {}
+                      };
+                      const scheduleSuppressedTextAreaBlur = () => {
+                        blurTextAreaIfFocusSuppressed();
+                        try { ownerWindow.setTimeout(blurTextAreaIfFocusSuppressed, 0); } catch (_) {}
+                        try { ownerWindow.setTimeout(blurTextAreaIfFocusSuppressed, 50); } catch (_) {}
+                      };
+                      const suppressScrollFocusIfNeeded = (hadInputFocusAtStart) => {
+                        if (!useAndroidWebFocusGuard) return;
+                        suppressFocusUntil = now() + compatibilityEventSuppressMs;
+                        const keyboardVisible = isKeyboardLikelyVisible();
+                        debugMobileGesture('suppress-scroll-focus', {
+                          suppressForMs: compatibilityEventSuppressMs,
+                          hadInputFocusAtStart: !!hadInputFocusAtStart,
+                          keyboardLikelyVisible: keyboardVisible,
+                          willBlurEditorInput: !keyboardVisible,
+                        });
+                        if (!keyboardVisible) {
+                          scheduleSuppressedTextAreaBlur();
+                        }
+                      };
+                      const guardSuppressedTextAreaFocus = (event) => {
+                        if (!useAndroidWebFocusGuard || !shouldSuppressFocus()) return;
+                        const target = event?.target;
+                        if (isEditorInputElement(target)) {
+                          debugMobileGesture('guard-blocked-textarea-focus', {}, event);
+                          blurTextAreaIfFocusSuppressed();
+                          blockEvent(event);
+                        }
+                      };
+                      const logTextAreaFocusEvent = (event) => {
+                        if (!mobileGestureDebugEnabled) return;
+                        const target = event?.target;
+                        if (isEditorInputElement(target)) {
+                          debugMobileGesture('textarea-' + event.type, {}, event);
                         }
                       };
                       const beginGesture = (event, id, kind) => {
@@ -1031,19 +1323,31 @@ class MonacoAssets {
                           startedAt: now(),
                           moved: false,
                           cancelled: false,
+                          hadInputFocusAtStart: isTextAreaFocused(),
                           scrollTop: scroll.top,
                           scrollLeft: scroll.left,
                         };
+                        debugMobileGesture('gesture-begin', { id, kind }, event);
                       };
                       const updateGesture = (event, id, kind) => {
                         if (!gesture || gesture.id !== id || gesture.kind !== kind) return;
                         if (hasMovedFromStart(event)) {
+                          const firstMove = !gesture.moved;
                           gesture.moved = true;
+                          if (firstMove || mobileGestureDebugVerbose) {
+                            debugMobileGesture('gesture-moved', { id, kind }, event);
+                          }
+                          if (useAndroidWebFocusGuard) {
+                            suppressCompatibilityEvents();
+                            suppressScrollFocusIfNeeded(gesture.hadInputFocusAtStart);
+                          }
                         }
                       };
                       const cancelGesture = (event, id, kind) => {
                         if (!gesture || gesture.id !== id || gesture.kind !== kind) return;
                         gesture.cancelled = true;
+                        debugMobileGesture('gesture-cancel', { id, kind }, event);
+                        suppressScrollFocusIfNeeded(gesture.hadInputFocusAtStart);
                         suppressAndBlock(event);
                         gesture = null;
                       };
@@ -1060,15 +1364,26 @@ class MonacoAssets {
                           !gesture.cancelled &&
                           !gesture.moved &&
                           elapsed <= tapTimeThreshold;
+                        const hadInputFocusAtStart = gesture.hadInputFocusAtStart;
+                        debugMobileGesture('gesture-end', {
+                          id,
+                          kind,
+                          elapsed,
+                          shouldFocus,
+                          hadInputFocusAtStart,
+                        }, event);
                         gesture = null;
                         if (!shouldFocus) {
+                          suppressScrollFocusIfNeeded(hadInputFocusAtStart);
                           suppressAndBlock(event);
                           return;
                         }
                         suppressUntil = 0;
+                        suppressFocusUntil = 0;
                         const currentTime = now();
                         if (currentTime - lastFocusAt < 150) return;
                         lastFocusAt = currentTime;
+                        debugMobileGesture('focus-from-gesture', { id, kind }, event);
                         focusEditorTextAreaNow();
                       };
                       const pointerId = (event) =>
@@ -1111,15 +1426,106 @@ class MonacoAssets {
                         if (!touch) return;
                         cancelGesture(event, touch.identifier, 'touch');
                       };
+                      const beginAndroidTouchScrollGuard = (event) => {
+                        if (!useAndroidWebFocusGuard) return;
+                        const touch = firstActiveTouch(event) || firstChangedTouch(event);
+                        if (!touch) return;
+                        const point = eventPoint(event);
+                        if (!point) return;
+                        const scroll = getScrollSnapshot();
+                        androidTouchScrollGesture = {
+                          id: touch.identifier,
+                          x: point.x,
+                          y: point.y,
+                          moved: false,
+                          hadInputFocusAtStart: isTextAreaFocused(),
+                          scrollTop: scroll.top,
+                          scrollLeft: scroll.left,
+                        };
+                        debugMobileGesture('android-touch-guard-begin', {
+                          id: touch.identifier,
+                        }, event);
+                      };
+                      const updateAndroidTouchScrollGuard = (event) => {
+                        if (!useAndroidWebFocusGuard || !androidTouchScrollGesture) return;
+                        if (hasTouchScrollMovedFromStart(event)) {
+                          const firstMove = !androidTouchScrollGesture.moved;
+                          androidTouchScrollGesture.moved = true;
+                          if (firstMove || mobileGestureDebugVerbose) {
+                            debugMobileGesture('android-touch-guard-moved', {
+                              id: androidTouchScrollGesture.id,
+                            }, event);
+                          }
+                          suppressCompatibilityEvents();
+                          suppressScrollFocusIfNeeded(
+                            androidTouchScrollGesture.hadInputFocusAtStart
+                          );
+                        }
+                      };
+                      const endAndroidTouchScrollGuard = (event) => {
+                        if (!useAndroidWebFocusGuard) return;
+                        if (!androidTouchScrollGesture) {
+                          if (shouldBlockSuppressedEvent()) {
+                            blockEvent(event);
+                          }
+                          return;
+                        }
+                        updateAndroidTouchScrollGuard(event);
+                        const shouldBlock =
+                          androidTouchScrollGesture.moved ||
+                          shouldBlockSuppressedEvent();
+                        debugMobileGesture('android-touch-guard-end', {
+                          id: androidTouchScrollGesture.id,
+                          shouldBlock,
+                        }, event);
+                        androidTouchScrollGesture = null;
+                        if (shouldBlock) {
+                          blockEvent(event);
+                        }
+                      };
+                      const cancelAndroidTouchScrollGuard = (event) => {
+                        if (!useAndroidWebFocusGuard || !androidTouchScrollGesture) return;
+                        debugMobileGesture('android-touch-guard-cancel', {
+                          id: androidTouchScrollGesture.id,
+                        }, event);
+                        suppressCompatibilityEvents();
+                        suppressScrollFocusIfNeeded(
+                          androidTouchScrollGesture.hadInputFocusAtStart
+                        );
+                        androidTouchScrollGesture = null;
+                        blockEvent(event);
+                      };
                       const capturePassiveFalse = { capture: true, passive: false };
                       const capturePassiveTrue = { capture: true, passive: true };
                       const captureOnly = { capture: true };
+                      debugMobileGesture('bridge-init', {
+                        ua,
+                        tapMoveThreshold,
+                        tapTimeThreshold,
+                        compatibilityEventSuppressMs,
+                      });
+
+                      try {
+                        E().onDidFocusEditorWidget(() => debugMobileGesture('monaco-focus', {}));
+                        E().onDidBlurEditorWidget(() => debugMobileGesture('monaco-blur', {}));
+                      } catch (_) {}
 
                       if (usePointerTapBridge) {
                         ownerDocument.addEventListener('pointerdown', onPointerDown, captureOnly);
                         ownerDocument.addEventListener('pointermove', onPointerMove, capturePassiveFalse);
                         ownerDocument.addEventListener('pointerup', onPointerUp, capturePassiveFalse);
                         ownerDocument.addEventListener('pointercancel', onPointerCancel, capturePassiveFalse);
+                      }
+
+                      if (useAndroidWebFocusGuard) {
+                        ownerDocument.addEventListener('touchstart', beginAndroidTouchScrollGuard, capturePassiveTrue);
+                        ownerDocument.addEventListener('touchmove', updateAndroidTouchScrollGuard, capturePassiveFalse);
+                        ownerDocument.addEventListener('touchend', endAndroidTouchScrollGuard, capturePassiveFalse);
+                        ownerDocument.addEventListener('touchcancel', cancelAndroidTouchScrollGuard, capturePassiveFalse);
+                        ownerDocument.addEventListener('focusin', logTextAreaFocusEvent, captureOnly);
+                        ownerDocument.addEventListener('focusout', logTextAreaFocusEvent, captureOnly);
+                        ownerDocument.addEventListener('focus', guardSuppressedTextAreaFocus, captureOnly);
+                        ownerDocument.addEventListener('focusin', guardSuppressedTextAreaFocus, captureOnly);
                       }
 
                       if (useTouchTapBridge) {

--- a/lib/src/core/monaco_assets.dart
+++ b/lib/src/core/monaco_assets.dart
@@ -552,6 +552,7 @@ class MonacoAssets {
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self' file: 'unsafe-inline' 'unsafe-eval'; script-src 'self' file: 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'${allowCdnFonts ? ' https:' : ''}; font-src 'self' file: data:${allowCdnFonts ? ' https:' : ''}; img-src 'self' data: blob: file:; worker-src 'self' blob:; connect-src 'self' blob:;"
@@ -664,6 +665,33 @@ class MonacoAssets {
               // Set up typed API
               (function () {
                 const E = () => window.editor;
+                const isMobileInputPlatform = () => {
+                  const ua = navigator.userAgent || '';
+                  return /Android|iPhone|iPad|iPod/i.test(ua) ||
+                    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+                };
+                const getEditorNode = () => {
+                  const ed = E();
+                  if (!ed) return null;
+                  return (ed.getDomNode && ed.getDomNode()) ||
+                    (ed.getContainerDomNode && ed.getContainerDomNode()) ||
+                    null;
+                };
+                const focusEditorTextAreaNow = () => {
+                  try {
+                    const ed = E();
+                    const node = getEditorNode();
+                    if (!ed || !node) return;
+                    try { ed.layout && ed.layout(); } catch (_) {}
+                    try { ed.focus && ed.focus(); } catch (_) {}
+                    try {
+                      const ta = node.querySelector('textarea.inputarea');
+                      if (ta && document.activeElement !== ta) {
+                        ta.focus();
+                      }
+                    } catch (_) {}
+                  } catch (_) {}
+                };
                 const serialize = (obj) => JSON.stringify(obj);
                 
 
@@ -696,16 +724,19 @@ class MonacoAssets {
                   forceFocus: () => {
                     try {
                       const ed = E();
-                      if (!ed) return;
-                      const node = (ed.getDomNode && ed.getDomNode()) || (ed.getContainerDomNode && ed.getContainerDomNode());
-                      if (!node) return;
+                      const node = getEditorNode();
+                      if (!ed || !node) return;
+
+                      if (isMobileInputPlatform()) {
+                        focusEditorTextAreaNow();
+                        return;
+                      }
+
                       const attempt = () => {
                         const rect = node.getBoundingClientRect();
                         if (!rect.width || !rect.height) {
-                          // Defer until container has size
                           return requestAnimationFrame(attempt);
                         }
-                        // Try to ensure the page/window is active (helps WKWebView on macOS)
                         try { window.focus && window.focus(); } catch (_) {}
                         try {
                           if (document.body && !document.body.hasAttribute('tabindex')) {
@@ -715,17 +746,16 @@ class MonacoAssets {
                         } catch (_) {}
                         try { ed.layout && ed.layout(); } catch (_) {}
                         try { ed.focus && ed.focus(); } catch (_) {}
-                        // Ensure the hidden textarea owns focus for keyboard input
                         try {
                           const ta = node.querySelector('textarea.inputarea');
                           if (ta && document.activeElement !== ta) {
                             ta.focus({ preventScroll: true });
-                            // One more tick for WKWebView
-                            setTimeout(() => { try { ta.focus({ preventScroll: true }); } catch (_) {} }, 16);
+                            setTimeout(() => {
+                              try { ta.focus({ preventScroll: true }); } catch (_) {}
+                            }, 16);
                           }
                         } catch (_) {}
                       };
-                      // Defer past any mousedown handlers
                       setTimeout(() => requestAnimationFrame(attempt), 0);
                     } catch (_) {}
                   },
@@ -908,6 +938,121 @@ class MonacoAssets {
                   },
                   listModels: () => monaco.editor.getModels().map(m => m.uri.toString()),
                 };
+
+                if (isMobileInputPlatform()) {
+                  try {
+                    const node = getEditorNode();
+                    if (node && !node.__flutterMonacoMobileFocusBound) {
+                      node.__flutterMonacoMobileFocusBound = true;
+                      const tapMoveThreshold = 12;
+                      const tapTimeThreshold = 800;
+                      const compatibilityEventSuppressMs = 1200;
+                      let tapCandidate = null;
+                      let lastFocusAt = 0;
+                      let suppressClickUntil = 0;
+                      const eventPoint = (event) => {
+                        const touch =
+                          event.changedTouches?.[0] || event.touches?.[0];
+                        if (touch) {
+                          return { x: touch.clientX, y: touch.clientY };
+                        }
+                        if (typeof event.clientX === 'number') {
+                          return { x: event.clientX, y: event.clientY };
+                        }
+                        return null;
+                      };
+                      const beginTapCandidate = (event) => {
+                        const point = eventPoint(event);
+                        if (!point) return;
+                        tapCandidate = {
+                          x: point.x,
+                          y: point.y,
+                          startedAt: Date.now(),
+                          moved: false,
+                        };
+                      };
+                      const updateTapCandidate = (event) => {
+                        if (!tapCandidate) return;
+                        const point = eventPoint(event);
+                        if (!point) return;
+                        const dx = point.x - tapCandidate.x;
+                        const dy = point.y - tapCandidate.y;
+                        if ((dx * dx + dy * dy) > tapMoveThreshold * tapMoveThreshold) {
+                          tapCandidate.moved = true;
+                        }
+                      };
+                      const blockEvent = (event) => {
+                        try { event.preventDefault && event.preventDefault(); } catch (_) {}
+                        try { event.stopImmediatePropagation && event.stopImmediatePropagation(); } catch (_) {}
+                        try { event.stopPropagation && event.stopPropagation(); } catch (_) {}
+                      };
+                      const suppressSyntheticClick = () => {
+                        suppressClickUntil = Date.now() + compatibilityEventSuppressMs;
+                      };
+                      const cancelTapCandidate = () => {
+                        tapCandidate = null;
+                        suppressSyntheticClick();
+                      };
+                      const focusIfTapCandidate = (event) => {
+                        if (!tapCandidate) return;
+                        updateTapCandidate(event);
+                        const elapsed = Date.now() - tapCandidate.startedAt;
+                        const shouldFocus =
+                          !tapCandidate.moved && elapsed <= tapTimeThreshold;
+                        tapCandidate = null;
+                        if (!shouldFocus) {
+                          suppressSyntheticClick();
+                          return;
+                        }
+                        const now = Date.now();
+                        if (now - lastFocusAt < 150) return;
+                        lastFocusAt = now;
+                        focusEditorTextAreaNow();
+                      };
+                      const suppressCompatibilityMouseEvent = (event) => {
+                        const now = Date.now();
+                        if (now >= suppressClickUntil) return;
+                        blockEvent(event);
+                      };
+                      const focusFromClick = (event) => {
+                        const now = Date.now();
+                        if (now < suppressClickUntil) {
+                          blockEvent(event);
+                          return;
+                        }
+                        if (now - lastFocusAt < 150) return;
+                        lastFocusAt = now;
+                        focusEditorTextAreaNow();
+                      };
+                      node.addEventListener('pointerdown', beginTapCandidate, { capture: true });
+                      node.addEventListener('pointermove', updateTapCandidate, {
+                        capture: true,
+                        passive: true,
+                      });
+                      node.addEventListener('pointerup', focusIfTapCandidate, { capture: true });
+                      node.addEventListener('pointercancel', cancelTapCandidate, { capture: true });
+                      node.addEventListener('touchstart', beginTapCandidate, {
+                        capture: true,
+                        passive: true,
+                      });
+                      node.addEventListener('touchmove', updateTapCandidate, {
+                        capture: true,
+                        passive: true,
+                      });
+                      node.addEventListener('touchend', focusIfTapCandidate, {
+                        capture: true,
+                        passive: true,
+                      });
+                      node.addEventListener('touchcancel', cancelTapCandidate, {
+                        capture: true,
+                        passive: true,
+                      });
+                      node.addEventListener('mousedown', suppressCompatibilityMouseEvent, { capture: true });
+                      node.addEventListener('mouseup', suppressCompatibilityMouseEvent, { capture: true });
+                      node.addEventListener('click', focusFromClick, { capture: true });
+                    }
+                  } catch (_) {}
+                }
 
                 // Completion bridge: JS stays dumb, Flutter drives the data
                 (function () {

--- a/lib/src/core/monaco_assets.dart
+++ b/lib/src/core/monaco_assets.dart
@@ -944,12 +944,20 @@ class MonacoAssets {
                     const node = getEditorNode();
                     if (node && !node.__flutterMonacoMobileFocusBound) {
                       node.__flutterMonacoMobileFocusBound = true;
-                      const tapMoveThreshold = 12;
-                      const tapTimeThreshold = 800;
+                      const ownerDocument = node.ownerDocument || document;
+                      const ownerWindow = ownerDocument.defaultView || window;
+                      const ua = navigator.userAgent || '';
+                      const isAndroid = /Android/i.test(ua);
+                      const tapMoveThreshold = 8;
+                      const tapTimeThreshold = 650;
                       const compatibilityEventSuppressMs = 1200;
-                      let tapCandidate = null;
+                      let gesture = null;
                       let lastFocusAt = 0;
-                      let suppressClickUntil = 0;
+                      let suppressUntil = 0;
+                      const supportsPointerEvents = !!ownerWindow.PointerEvent;
+                      const usePointerTapBridge = supportsPointerEvents && isAndroid;
+                      const useTouchTapBridge = !usePointerTapBridge;
+                      const now = () => Date.now();
                       const eventPoint = (event) => {
                         const touch =
                           event.changedTouches?.[0] || event.touches?.[0];
@@ -961,95 +969,172 @@ class MonacoAssets {
                         }
                         return null;
                       };
-                      const beginTapCandidate = (event) => {
-                        const point = eventPoint(event);
-                        if (!point) return;
-                        tapCandidate = {
-                          x: point.x,
-                          y: point.y,
-                          startedAt: Date.now(),
-                          moved: false,
-                        };
-                      };
-                      const updateTapCandidate = (event) => {
-                        if (!tapCandidate) return;
-                        const point = eventPoint(event);
-                        if (!point) return;
-                        const dx = point.x - tapCandidate.x;
-                        const dy = point.y - tapCandidate.y;
-                        if ((dx * dx + dy * dy) > tapMoveThreshold * tapMoveThreshold) {
-                          tapCandidate.moved = true;
+                      const getScrollSnapshot = () => {
+                        try {
+                          const ed = E();
+                          if (!ed || !ed.getScrollTop || !ed.getScrollLeft) {
+                            return { top: 0, left: 0 };
+                          }
+                          return {
+                            top: ed.getScrollTop(),
+                            left: ed.getScrollLeft(),
+                          };
+                        } catch (_) {
+                          return { top: 0, left: 0 };
                         }
                       };
+                      const hasMovedFromStart = (event) => {
+                        if (!gesture) return false;
+                        const point = eventPoint(event);
+                        if (point) {
+                          const dx = point.x - gesture.x;
+                          const dy = point.y - gesture.y;
+                          if ((dx * dx + dy * dy) > tapMoveThreshold * tapMoveThreshold) {
+                            return true;
+                          }
+                        }
+                        const scroll = getScrollSnapshot();
+                        return Math.abs(scroll.top - gesture.scrollTop) > 0 ||
+                          Math.abs(scroll.left - gesture.scrollLeft) > 0;
+                      };
                       const blockEvent = (event) => {
-                        try { event.preventDefault && event.preventDefault(); } catch (_) {}
+                        try {
+                          if (event.cancelable && event.preventDefault) {
+                            event.preventDefault();
+                          }
+                        } catch (_) {}
                         try { event.stopImmediatePropagation && event.stopImmediatePropagation(); } catch (_) {}
                         try { event.stopPropagation && event.stopPropagation(); } catch (_) {}
                       };
-                      const suppressSyntheticClick = () => {
-                        suppressClickUntil = Date.now() + compatibilityEventSuppressMs;
+                      const suppressCompatibilityEvents = () => {
+                        suppressUntil = now() + compatibilityEventSuppressMs;
                       };
-                      const cancelTapCandidate = () => {
-                        tapCandidate = null;
-                        suppressSyntheticClick();
-                      };
-                      const focusIfTapCandidate = (event) => {
-                        if (!tapCandidate) return;
-                        updateTapCandidate(event);
-                        const elapsed = Date.now() - tapCandidate.startedAt;
-                        const shouldFocus =
-                          !tapCandidate.moved && elapsed <= tapTimeThreshold;
-                        tapCandidate = null;
-                        if (!shouldFocus) {
-                          suppressSyntheticClick();
-                          return;
-                        }
-                        const now = Date.now();
-                        if (now - lastFocusAt < 150) return;
-                        lastFocusAt = now;
-                        focusEditorTextAreaNow();
-                      };
-                      const suppressCompatibilityMouseEvent = (event) => {
-                        const now = Date.now();
-                        if (now >= suppressClickUntil) return;
+                      const suppressAndBlock = (event) => {
+                        suppressCompatibilityEvents();
                         blockEvent(event);
                       };
-                      const focusFromClick = (event) => {
-                        const now = Date.now();
-                        if (now < suppressClickUntil) {
+                      const shouldBlockSuppressedEvent = () => now() < suppressUntil;
+                      const blockSuppressedCompatibilityEvent = (event) => {
+                        if (shouldBlockSuppressedEvent()) {
                           blockEvent(event);
+                        }
+                      };
+                      const beginGesture = (event, id, kind) => {
+                        const point = eventPoint(event);
+                        if (!point) return;
+                        const scroll = getScrollSnapshot();
+                        gesture = {
+                          id,
+                          kind,
+                          x: point.x,
+                          y: point.y,
+                          startedAt: now(),
+                          moved: false,
+                          cancelled: false,
+                          scrollTop: scroll.top,
+                          scrollLeft: scroll.left,
+                        };
+                      };
+                      const updateGesture = (event, id, kind) => {
+                        if (!gesture || gesture.id !== id || gesture.kind !== kind) return;
+                        if (hasMovedFromStart(event)) {
+                          gesture.moved = true;
+                        }
+                      };
+                      const cancelGesture = (event, id, kind) => {
+                        if (!gesture || gesture.id !== id || gesture.kind !== kind) return;
+                        gesture.cancelled = true;
+                        suppressAndBlock(event);
+                        gesture = null;
+                      };
+                      const endGesture = (event, id, kind) => {
+                        if (!gesture || gesture.id !== id || gesture.kind !== kind) {
+                          if (shouldBlockSuppressedEvent()) {
+                            blockEvent(event);
+                          }
                           return;
                         }
-                        if (now - lastFocusAt < 150) return;
-                        lastFocusAt = now;
+                        updateGesture(event, id, kind);
+                        const elapsed = now() - gesture.startedAt;
+                        const shouldFocus =
+                          !gesture.cancelled &&
+                          !gesture.moved &&
+                          elapsed <= tapTimeThreshold;
+                        gesture = null;
+                        if (!shouldFocus) {
+                          suppressAndBlock(event);
+                          return;
+                        }
+                        suppressUntil = 0;
+                        const currentTime = now();
+                        if (currentTime - lastFocusAt < 150) return;
+                        lastFocusAt = currentTime;
                         focusEditorTextAreaNow();
                       };
-                      node.addEventListener('pointerdown', beginTapCandidate, { capture: true });
-                      node.addEventListener('pointermove', updateTapCandidate, {
-                        capture: true,
-                        passive: true,
-                      });
-                      node.addEventListener('pointerup', focusIfTapCandidate, { capture: true });
-                      node.addEventListener('pointercancel', cancelTapCandidate, { capture: true });
-                      node.addEventListener('touchstart', beginTapCandidate, {
-                        capture: true,
-                        passive: true,
-                      });
-                      node.addEventListener('touchmove', updateTapCandidate, {
-                        capture: true,
-                        passive: true,
-                      });
-                      node.addEventListener('touchend', focusIfTapCandidate, {
-                        capture: true,
-                        passive: true,
-                      });
-                      node.addEventListener('touchcancel', cancelTapCandidate, {
-                        capture: true,
-                        passive: true,
-                      });
-                      node.addEventListener('mousedown', suppressCompatibilityMouseEvent, { capture: true });
-                      node.addEventListener('mouseup', suppressCompatibilityMouseEvent, { capture: true });
-                      node.addEventListener('click', focusFromClick, { capture: true });
+                      const pointerId = (event) =>
+                        typeof event.pointerId === 'number' ? event.pointerId : 1;
+                      const onPointerDown = (event) => {
+                        if (!event.isPrimary || event.pointerType !== 'touch') return;
+                        beginGesture(event, pointerId(event), 'pointer');
+                      };
+                      const onPointerMove = (event) => {
+                        if (!event.isPrimary || event.pointerType !== 'touch') return;
+                        updateGesture(event, pointerId(event), 'pointer');
+                      };
+                      const onPointerUp = (event) => {
+                        if (!event.isPrimary || event.pointerType !== 'touch') return;
+                        endGesture(event, pointerId(event), 'pointer');
+                      };
+                      const onPointerCancel = (event) => {
+                        if (!event.isPrimary || event.pointerType !== 'touch') return;
+                        cancelGesture(event, pointerId(event), 'pointer');
+                      };
+                      const firstChangedTouch = (event) => event.changedTouches?.[0] || null;
+                      const firstActiveTouch = (event) => event.touches?.[0] || null;
+                      const onTouchStart = (event) => {
+                        const touch = firstActiveTouch(event) || firstChangedTouch(event);
+                        if (!touch) return;
+                        beginGesture(event, touch.identifier, 'touch');
+                      };
+                      const onTouchMove = (event) => {
+                        const touch = firstChangedTouch(event) || firstActiveTouch(event);
+                        if (!touch) return;
+                        updateGesture(event, touch.identifier, 'touch');
+                      };
+                      const onTouchEnd = (event) => {
+                        const touch = firstChangedTouch(event);
+                        if (!touch) return;
+                        endGesture(event, touch.identifier, 'touch');
+                      };
+                      const onTouchCancel = (event) => {
+                        const touch = firstChangedTouch(event);
+                        if (!touch) return;
+                        cancelGesture(event, touch.identifier, 'touch');
+                      };
+                      const capturePassiveFalse = { capture: true, passive: false };
+                      const capturePassiveTrue = { capture: true, passive: true };
+                      const captureOnly = { capture: true };
+
+                      if (usePointerTapBridge) {
+                        ownerDocument.addEventListener('pointerdown', onPointerDown, captureOnly);
+                        ownerDocument.addEventListener('pointermove', onPointerMove, capturePassiveFalse);
+                        ownerDocument.addEventListener('pointerup', onPointerUp, capturePassiveFalse);
+                        ownerDocument.addEventListener('pointercancel', onPointerCancel, capturePassiveFalse);
+                      }
+
+                      if (useTouchTapBridge) {
+                        ownerDocument.addEventListener('touchstart', onTouchStart, capturePassiveTrue);
+                        ownerDocument.addEventListener('touchmove', onTouchMove, capturePassiveFalse);
+                        ownerDocument.addEventListener('touchend', onTouchEnd, capturePassiveFalse);
+                        ownerDocument.addEventListener('touchcancel', onTouchCancel, capturePassiveFalse);
+                      }
+
+                      ownerDocument.addEventListener('mousedown', blockSuppressedCompatibilityEvent, captureOnly);
+                      ownerDocument.addEventListener('mouseup', blockSuppressedCompatibilityEvent, captureOnly);
+                      ownerDocument.addEventListener('click', blockSuppressedCompatibilityEvent, captureOnly);
+                      try {
+                        node.style.touchAction = node.style.touchAction || 'manipulation';
+                      } catch (_) {}
                     }
                   } catch (_) {}
                 }

--- a/lib/src/core/monaco_assets.dart
+++ b/lib/src/core/monaco_assets.dart
@@ -440,7 +440,6 @@ class MonacoAssets {
     String? messageToken,
     String? customCss,
     bool allowCdnFonts = false,
-    bool gestureDebugEnabled = false,
   }) {
     // Platform-specific initialization scripts
     String platformScript = '';
@@ -969,47 +968,6 @@ class MonacoAssets {
                       const useTouchTapBridge = !usePointerTapBridge;
                       const useAndroidWebFocusGuard = usePointerTapBridge && isFlutterWebEmbed;
                       const now = () => Date.now();
-                      const debugModeFromSearch = (search) => {
-                        try {
-                          const match = /(?:^|[?&])monacoGestureDebug(?:=([^&]*))?/.exec(search || '');
-                          if (!match) return '';
-                          const value = decodeURIComponent(match[1] || '1');
-                          return value && value !== '0' && value !== 'false' ? value : '';
-                        } catch (_) {
-                          return '';
-                        }
-                      };
-                      const debugModeFromStorage = (storage) => {
-                        try {
-                          const value =
-                            storage?.getItem('flutterMonacoGestureDebug') ||
-                            storage?.getItem('monacoGestureDebug') ||
-                            '';
-                          return value && value !== '0' && value !== 'false' ? value : '';
-                        } catch (_) {
-                          return '';
-                        }
-                      };
-                      const getGestureDebugMode = () => {
-                        let mode =
-                          debugModeFromSearch(ownerWindow.location?.search) ||
-                          debugModeFromStorage(ownerWindow.localStorage);
-                        try {
-                          if (!mode && ownerWindow.parent && ownerWindow.parent !== ownerWindow) {
-                            mode =
-                              debugModeFromSearch(ownerWindow.parent.location?.search) ||
-                              debugModeFromStorage(ownerWindow.parent.localStorage);
-                          }
-                        } catch (_) {}
-                        if (mode) return mode;
-                        return ${gestureDebugEnabled ? 'true' : 'false'} ? '1' : '';
-                      };
-                      const mobileGestureDebugMode = getGestureDebugMode();
-                      const mobileGestureDebugEnabled = mobileGestureDebugMode !== '';
-                      const mobileGestureDebugVerbose =
-                        mobileGestureDebugMode === '2' ||
-                        mobileGestureDebugMode === 'verbose';
-                      const mobileGestureDebugLog = [];
                       const eventPoint = (event) => {
                         const touch =
                           event.changedTouches?.[0] || event.touches?.[0];
@@ -1077,13 +1035,11 @@ class MonacoAssets {
                       };
                       const suppressAndBlock = (event) => {
                         suppressCompatibilityEvents();
-                        debugMobileGesture('suppress-and-block', {}, event);
                         blockEvent(event);
                       };
                       const shouldBlockSuppressedEvent = () => now() < suppressUntil;
                       const blockSuppressedCompatibilityEvent = (event) => {
                         if (shouldBlockSuppressedEvent()) {
-                          debugMobileGesture('compatibility-event-blocked', {}, event);
                           blockEvent(event);
                         }
                       };
@@ -1109,13 +1065,6 @@ class MonacoAssets {
                           return node.querySelector(editorInputSelector);
                         } catch (_) {
                           return null;
-                        }
-                      };
-                      const isTextAreaFocused = () => {
-                        try {
-                          return isEditorInputElement(ownerDocument.activeElement);
-                        } catch (_) {
-                          return false;
                         }
                       };
                       const shouldSuppressFocus = () => now() < suppressFocusUntil;
@@ -1167,111 +1116,11 @@ class MonacoAssets {
                           );
                         }
                       } catch (_) {}
-                      const elementLabel = (element) => {
-                        if (!element) return 'null';
-                        try {
-                          let label = element.tagName ? element.tagName.toLowerCase() : String(element);
-                          const className = typeof element.className === 'string'
-                            ? element.className.trim()
-                            : '';
-                          if (className) {
-                            label += '.' + className.split(/\\s+/).slice(0, 4).join('.');
-                          }
-                          return label;
-                        } catch (_) {
-                          return 'unknown';
-                        }
-                      };
-                      const gestureSummary = (value) => value ? {
-                        id: value.id,
-                        kind: value.kind,
-                        moved: !!value.moved,
-                        cancelled: !!value.cancelled,
-                        hadInputFocusAtStart: !!value.hadInputFocusAtStart,
-                        ageMs: now() - value.startedAt,
-                      } : null;
-                      const touchGuardSummary = (value) => value ? {
-                        id: value.id,
-                        moved: !!value.moved,
-                        hadInputFocusAtStart: !!value.hadInputFocusAtStart,
-                      } : null;
-                      const eventSummary = (event) => {
-                        const point = event ? eventPoint(event) : null;
-                        const scroll = getScrollSnapshot();
-                        return {
-                          type: event?.type,
-                          cancelable: !!event?.cancelable,
-                          defaultPrevented: !!event?.defaultPrevented,
-                          pointerType: event?.pointerType,
-                          pointerId: event?.pointerId,
-                          isPrimary: event?.isPrimary,
-                          touches: event?.touches?.length,
-                          changedTouches: event?.changedTouches?.length,
-                          x: point?.x,
-                          y: point?.y,
-                          scrollTop: scroll.top,
-                          scrollLeft: scroll.left,
-                          activeElement: elementLabel(ownerDocument.activeElement),
-                          textAreaFocused: isTextAreaFocused(),
-                          keyboardLikelyVisible: isKeyboardLikelyVisible(),
-                          suppressUntilMs: Math.max(0, suppressUntil - now()),
-                          suppressFocusUntilMs: Math.max(0, suppressFocusUntil - now()),
-                        };
-                      };
-                      const debugMobileGesture = (phase, payload, event) => {
-                        if (!mobileGestureDebugEnabled) return;
-                        try {
-                          const entry = {
-                            event: 'mobileGestureDebug',
-                            phase,
-                            t: now(),
-                            mode: mobileGestureDebugMode,
-                            platform: {
-                              isAndroid,
-                              isFlutterWebEmbed,
-                              supportsPointerEvents,
-                              usePointerTapBridge,
-                              useTouchTapBridge,
-                              useAndroidWebFocusGuard,
-                            },
-                            state: {
-                              gesture: gestureSummary(gesture),
-                              androidTouchScrollGesture:
-                                touchGuardSummary(androidTouchScrollGesture),
-                            },
-                            input: event ? eventSummary(event) : undefined,
-                            data: payload || {},
-                          };
-                          mobileGestureDebugLog.push(entry);
-                          if (mobileGestureDebugLog.length > 250) {
-                            mobileGestureDebugLog.shift();
-                          }
-                          try {
-                            ownerWindow.flutterMonacoGestureDebugLog =
-                              mobileGestureDebugLog;
-                          } catch (_) {}
-                          try {
-                            console.log('[flutter_monaco][gesture]', JSON.stringify(entry));
-                          } catch (_) {
-                            try { console.log('[flutter_monaco][gesture]', entry); } catch (_) {}
-                          }
-                          try { postMessageToFlutter(entry); } catch (_) {}
-                        } catch (_) {}
-                      };
-                      try {
-                        window.flutterMonaco.getGestureDebugLog =
-                          () => mobileGestureDebugLog.slice();
-                        window.flutterMonaco.clearGestureDebugLog =
-                          () => { mobileGestureDebugLog.length = 0; };
-                      } catch (_) {}
                       const blurTextAreaIfFocusSuppressed = () => {
                         if (!shouldSuppressFocus()) return;
                         try {
                           const input = getEditorInputElement();
                           if (input && ownerDocument.activeElement === input) {
-                            debugMobileGesture('blur-suppressed-textarea', {
-                              reason: 'focus suppressed after scroll',
-                            });
                             input.blur();
                           }
                         } catch (_) {}
@@ -1281,16 +1130,10 @@ class MonacoAssets {
                         try { ownerWindow.setTimeout(blurTextAreaIfFocusSuppressed, 0); } catch (_) {}
                         try { ownerWindow.setTimeout(blurTextAreaIfFocusSuppressed, 50); } catch (_) {}
                       };
-                      const suppressScrollFocusIfNeeded = (hadInputFocusAtStart) => {
+                      const suppressScrollFocusIfNeeded = () => {
                         if (!useAndroidWebFocusGuard) return;
                         suppressFocusUntil = now() + compatibilityEventSuppressMs;
                         const keyboardVisible = isKeyboardLikelyVisible();
-                        debugMobileGesture('suppress-scroll-focus', {
-                          suppressForMs: compatibilityEventSuppressMs,
-                          hadInputFocusAtStart: !!hadInputFocusAtStart,
-                          keyboardLikelyVisible: keyboardVisible,
-                          willBlurEditorInput: !keyboardVisible,
-                        });
                         if (!keyboardVisible) {
                           scheduleSuppressedTextAreaBlur();
                         }
@@ -1299,16 +1142,8 @@ class MonacoAssets {
                         if (!useAndroidWebFocusGuard || !shouldSuppressFocus()) return;
                         const target = event?.target;
                         if (isEditorInputElement(target)) {
-                          debugMobileGesture('guard-blocked-textarea-focus', {}, event);
                           blurTextAreaIfFocusSuppressed();
                           blockEvent(event);
-                        }
-                      };
-                      const logTextAreaFocusEvent = (event) => {
-                        if (!mobileGestureDebugEnabled) return;
-                        const target = event?.target;
-                        if (isEditorInputElement(target)) {
-                          debugMobileGesture('textarea-' + event.type, {}, event);
                         }
                       };
                       const beginGesture = (event, id, kind) => {
@@ -1323,31 +1158,24 @@ class MonacoAssets {
                           startedAt: now(),
                           moved: false,
                           cancelled: false,
-                          hadInputFocusAtStart: isTextAreaFocused(),
                           scrollTop: scroll.top,
                           scrollLeft: scroll.left,
                         };
-                        debugMobileGesture('gesture-begin', { id, kind }, event);
                       };
                       const updateGesture = (event, id, kind) => {
                         if (!gesture || gesture.id !== id || gesture.kind !== kind) return;
                         if (hasMovedFromStart(event)) {
-                          const firstMove = !gesture.moved;
                           gesture.moved = true;
-                          if (firstMove || mobileGestureDebugVerbose) {
-                            debugMobileGesture('gesture-moved', { id, kind }, event);
-                          }
                           if (useAndroidWebFocusGuard) {
                             suppressCompatibilityEvents();
-                            suppressScrollFocusIfNeeded(gesture.hadInputFocusAtStart);
+                            suppressScrollFocusIfNeeded();
                           }
                         }
                       };
                       const cancelGesture = (event, id, kind) => {
                         if (!gesture || gesture.id !== id || gesture.kind !== kind) return;
                         gesture.cancelled = true;
-                        debugMobileGesture('gesture-cancel', { id, kind }, event);
-                        suppressScrollFocusIfNeeded(gesture.hadInputFocusAtStart);
+                        suppressScrollFocusIfNeeded();
                         suppressAndBlock(event);
                         gesture = null;
                       };
@@ -1364,17 +1192,9 @@ class MonacoAssets {
                           !gesture.cancelled &&
                           !gesture.moved &&
                           elapsed <= tapTimeThreshold;
-                        const hadInputFocusAtStart = gesture.hadInputFocusAtStart;
-                        debugMobileGesture('gesture-end', {
-                          id,
-                          kind,
-                          elapsed,
-                          shouldFocus,
-                          hadInputFocusAtStart,
-                        }, event);
                         gesture = null;
                         if (!shouldFocus) {
-                          suppressScrollFocusIfNeeded(hadInputFocusAtStart);
+                          suppressScrollFocusIfNeeded();
                           suppressAndBlock(event);
                           return;
                         }
@@ -1383,7 +1203,6 @@ class MonacoAssets {
                         const currentTime = now();
                         if (currentTime - lastFocusAt < 150) return;
                         lastFocusAt = currentTime;
-                        debugMobileGesture('focus-from-gesture', { id, kind }, event);
                         focusEditorTextAreaNow();
                       };
                       const pointerId = (event) =>
@@ -1438,28 +1257,16 @@ class MonacoAssets {
                           x: point.x,
                           y: point.y,
                           moved: false,
-                          hadInputFocusAtStart: isTextAreaFocused(),
                           scrollTop: scroll.top,
                           scrollLeft: scroll.left,
                         };
-                        debugMobileGesture('android-touch-guard-begin', {
-                          id: touch.identifier,
-                        }, event);
                       };
                       const updateAndroidTouchScrollGuard = (event) => {
                         if (!useAndroidWebFocusGuard || !androidTouchScrollGesture) return;
                         if (hasTouchScrollMovedFromStart(event)) {
-                          const firstMove = !androidTouchScrollGesture.moved;
                           androidTouchScrollGesture.moved = true;
-                          if (firstMove || mobileGestureDebugVerbose) {
-                            debugMobileGesture('android-touch-guard-moved', {
-                              id: androidTouchScrollGesture.id,
-                            }, event);
-                          }
                           suppressCompatibilityEvents();
-                          suppressScrollFocusIfNeeded(
-                            androidTouchScrollGesture.hadInputFocusAtStart
-                          );
+                          suppressScrollFocusIfNeeded();
                         }
                       };
                       const endAndroidTouchScrollGuard = (event) => {
@@ -1474,10 +1281,6 @@ class MonacoAssets {
                         const shouldBlock =
                           androidTouchScrollGesture.moved ||
                           shouldBlockSuppressedEvent();
-                        debugMobileGesture('android-touch-guard-end', {
-                          id: androidTouchScrollGesture.id,
-                          shouldBlock,
-                        }, event);
                         androidTouchScrollGesture = null;
                         if (shouldBlock) {
                           blockEvent(event);
@@ -1485,30 +1288,14 @@ class MonacoAssets {
                       };
                       const cancelAndroidTouchScrollGuard = (event) => {
                         if (!useAndroidWebFocusGuard || !androidTouchScrollGesture) return;
-                        debugMobileGesture('android-touch-guard-cancel', {
-                          id: androidTouchScrollGesture.id,
-                        }, event);
                         suppressCompatibilityEvents();
-                        suppressScrollFocusIfNeeded(
-                          androidTouchScrollGesture.hadInputFocusAtStart
-                        );
+                        suppressScrollFocusIfNeeded();
                         androidTouchScrollGesture = null;
                         blockEvent(event);
                       };
                       const capturePassiveFalse = { capture: true, passive: false };
                       const capturePassiveTrue = { capture: true, passive: true };
                       const captureOnly = { capture: true };
-                      debugMobileGesture('bridge-init', {
-                        ua,
-                        tapMoveThreshold,
-                        tapTimeThreshold,
-                        compatibilityEventSuppressMs,
-                      });
-
-                      try {
-                        E().onDidFocusEditorWidget(() => debugMobileGesture('monaco-focus', {}));
-                        E().onDidBlurEditorWidget(() => debugMobileGesture('monaco-blur', {}));
-                      } catch (_) {}
 
                       if (usePointerTapBridge) {
                         ownerDocument.addEventListener('pointerdown', onPointerDown, captureOnly);
@@ -1522,8 +1309,6 @@ class MonacoAssets {
                         ownerDocument.addEventListener('touchmove', updateAndroidTouchScrollGuard, capturePassiveFalse);
                         ownerDocument.addEventListener('touchend', endAndroidTouchScrollGuard, capturePassiveFalse);
                         ownerDocument.addEventListener('touchcancel', cancelAndroidTouchScrollGuard, capturePassiveFalse);
-                        ownerDocument.addEventListener('focusin', logTextAreaFocusEvent, captureOnly);
-                        ownerDocument.addEventListener('focusout', logTextAreaFocusEvent, captureOnly);
                         ownerDocument.addEventListener('focus', guardSuppressedTextAreaFocus, captureOnly);
                         ownerDocument.addEventListener('focusin', guardSuppressedTextAreaFocus, captureOnly);
                       }

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -311,6 +311,51 @@ class MonacoController {
     await _webViewController.setInteractionEnabled(enabled);
   }
 
+  /// Runs [action] with editor interaction temporarily disabled, restoring the
+  /// previous state in a `finally` block.
+  ///
+  /// Useful for transient Flutter overlays that are NOT pushed as routes (so
+  /// [`MonacoFocusGuard`] cannot detect them) and that are NOT static enough
+  /// to wrap in a [`MonacoOverlayBoundary`] - typically `ScaffoldMessenger`
+  /// snackbars with action buttons, toasts, or imperative `Overlay.insert`
+  /// entries shown for a known duration.
+  ///
+  /// On native platforms `setInteractionEnabled` is a no-op, so this is a
+  /// thin wrapper around the [action] there.
+  ///
+  /// Example:
+  /// ```dart
+  /// await controller.runWithInteractionDisabled(() async {
+  ///   ScaffoldMessenger.of(context).showSnackBar(
+  ///     SnackBar(
+  ///       content: const Text('Saved'),
+  ///       action: SnackBarAction(label: 'Undo', onPressed: undo),
+  ///     ),
+  ///   );
+  ///   await Future<void>.delayed(const Duration(seconds: 4));
+  /// });
+  /// ```
+  Future<T> runWithInteractionDisabled<T>(
+    FutureOr<T> Function() action,
+  ) async {
+    if (_disposed) {
+      return await Future<T>.value(action());
+    }
+
+    final wasEnabled = _interactionEnabled;
+    if (wasEnabled) {
+      await setInteractionEnabled(false);
+    }
+
+    try {
+      return await Future<T>.value(action());
+    } finally {
+      if (wasEnabled && !_disposed) {
+        await setInteractionEnabled(true);
+      }
+    }
+  }
+
   /// Updates the editor configuration options.
   ///
   /// Only the fields present in [options] will be updated; others remain unchanged.

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -425,6 +425,8 @@ class MonacoController {
   /// Requests focus for the editor widget.
   ///
   /// Uses a robust method that waits for visibility and layout before attempting focus.
+  /// On Android and iOS, the OS soft keyboard may only appear after a user tap
+  /// inside the editor.
   Future<void> focus() async {
     if (!_interactionEnabled) return;
     await _ensureReady();
@@ -441,12 +443,19 @@ class MonacoController {
       Duration interval = const Duration(milliseconds: 24)}) async {
     if (!_interactionEnabled) return;
     await _ensureReady();
-    for (var i = 0; i < attempts; i++) {
+
+    // On mobile, multiple async focus() calls interrupt the IME lifecycle.
+    final isMobileNative = !kIsWeb &&
+        (defaultTargetPlatform == TargetPlatform.android ||
+            defaultTargetPlatform == TargetPlatform.iOS);
+    final effectiveAttempts = isMobileNative ? 1 : attempts;
+
+    for (var i = 0; i < effectiveAttempts; i++) {
       try {
         await _webViewController.runJavaScript(
             'window.flutterMonaco && window.flutterMonaco.forceFocus && window.flutterMonaco.forceFocus()');
       } catch (_) {}
-      if (i + 1 < attempts) {
+      if (i + 1 < effectiveAttempts) {
         await Future<void>.delayed(interval);
       }
     }

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -251,6 +251,7 @@ class MonacoController {
   Future<void> setLanguage(MonacoLanguage language) async {
     if (!_onReady.isCompleted) {
       _queuedLanguage = language;
+      if (kIsWeb) return;
       await _ensureReady();
       if (_queuedLanguage == language) {
         // Only use queued value if it hasn't been overwritten
@@ -732,6 +733,7 @@ class MonacoController {
   Future<void> setValue(String value) async {
     if (!_onReady.isCompleted) {
       _queuedValue = value;
+      if (kIsWeb) return;
       await _ensureReady();
       if (_queuedValue == value) {
         // Only use queued value if it hasn't been overwritten

--- a/lib/src/platform/overlay_shield/overlay_shield.dart
+++ b/lib/src/platform/overlay_shield/overlay_shield.dart
@@ -1,0 +1,2 @@
+export 'overlay_shield_stub.dart'
+    if (dart.library.js_interop) 'overlay_shield_web.dart';

--- a/lib/src/platform/overlay_shield/overlay_shield_stub.dart
+++ b/lib/src/platform/overlay_shield/overlay_shield_stub.dart
@@ -1,0 +1,24 @@
+import 'dart:ui' show Rect;
+
+/// Native and unsupported-platform no-op shield.
+///
+/// All methods are inert. [`MonacoOverlayBoundary`] checks [`isSupported`] and
+/// avoids construction on non-web platforms, but this stub remains as a safety
+/// net so accidental construction does nothing.
+class MonacoOverlayDomShield {
+  /// `false` on this platform - the shield is web-only.
+  static const bool isSupported = false;
+
+  /// No-op constructor. Construction is permitted so callers can share the
+  /// same code path on web and native, but no DOM work happens.
+  MonacoOverlayDomShield({
+    required int flutterViewId,
+    required bool debug,
+  });
+
+  /// Update the shield's tracked rect. No-op on native.
+  void update(Rect rect) {}
+
+  /// Release any resources. No-op on native.
+  void dispose() {}
+}

--- a/lib/src/platform/overlay_shield/overlay_shield_web.dart
+++ b/lib/src/platform/overlay_shield/overlay_shield_web.dart
@@ -1,0 +1,248 @@
+import 'dart:js_interop';
+import 'dart:ui' show Rect;
+import 'dart:ui_web' as ui_web;
+
+import 'package:flutter_monaco/src/platform/web_interaction_coordinator.dart';
+import 'package:web/web.dart' as web;
+
+/// A manually managed transparent DOM shield over a Flutter overlay region.
+///
+/// Deliberately NOT an [`HtmlElementView`]: routing this through Flutter's
+/// platform-view system reintroduces the very ordering bug we are trying to
+/// fix (two platform views fighting for hit-test priority). Instead, the
+/// shield is a normal absolutely-positioned `<div>` appended to the Flutter
+/// host element with `z-index: 2147483647`. Plain DOM beats platform views
+/// in browser hit-testing, so the shield reliably becomes the event target
+/// at the overlay's rect.
+///
+/// The shield does not call `stopPropagation()`. After the browser picks the
+/// shield as the hit target, the event still bubbles up to Flutter's listener
+/// on the host. Flutter then hit-tests the widget tree and dispatches to the
+/// widget visually at that position - normally the overlay child wrapped by
+/// [`MonacoOverlayBoundary`].
+class MonacoOverlayDomShield {
+  /// `true` on web. Callers gate construction on this flag.
+  static const bool isSupported = true;
+
+  /// Create a shield attached to the Flutter view with the given [flutterViewId].
+  ///
+  /// Set [debug] to render the shield as a translucent green rectangle while
+  /// developing.
+  MonacoOverlayDomShield({
+    required int flutterViewId,
+    required bool debug,
+  })  : _debug = debug,
+        _lockId = 'flutter-monaco-overlay-${_nextLockId()}' {
+    _host = ui_web.views.getHostElement(flutterViewId) as web.Element?;
+    _createElement();
+  }
+
+  static int _lockCounter = 0;
+  static int _nextLockId() {
+    _lockCounter++;
+    return DateTime.now().microsecondsSinceEpoch * 1000 + _lockCounter;
+  }
+
+  final bool _debug;
+  final String _lockId;
+
+  web.Element? _host;
+  web.HTMLDivElement? _element;
+  Rect _rect = Rect.zero;
+
+  bool _hovering = false;
+  bool _pointerDown = false;
+  bool _disposed = false;
+
+  final List<_DomListener> _listeners = <_DomListener>[];
+
+  /// Reposition / resize the shield to match a new overlay rect.
+  ///
+  /// Pass [Rect.zero] to hide the shield without disposing it. While the
+  /// pointer is hovering or pressing the shield, the coordinator keeps
+  /// intersecting Monaco iframes locked.
+  void update(Rect rect) {
+    if (_disposed) return;
+
+    _rect = rect;
+    final element = _element;
+    if (element == null) return;
+
+    if (rect.isEmpty || rect.width <= 0 || rect.height <= 0) {
+      element.style.pointerEvents = 'none';
+      element.style.left = '-10000px';
+      element.style.top = '-10000px';
+      element.style.width = '0px';
+      element.style.height = '0px';
+      MonacoWebInteractionCoordinator.instance.unlock(_lockId);
+      return;
+    }
+
+    element.style.pointerEvents = 'auto';
+    element.style.left = '${rect.left}px';
+    element.style.top = '${rect.top}px';
+    element.style.width = '${rect.width}px';
+    element.style.height = '${rect.height}px';
+
+    if (_hovering || _pointerDown) {
+      _lockIntersectingEditors();
+    }
+  }
+
+  /// Remove the shield's DOM element, release any held iframe locks, and
+  /// unregister all event listeners. Safe to call multiple times.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+
+    MonacoWebInteractionCoordinator.instance.unlock(_lockId);
+
+    for (final listener in _listeners) {
+      listener.target.removeEventListener(listener.type, listener.callback);
+    }
+    _listeners.clear();
+
+    _element?.remove();
+    _element = null;
+    _host = null;
+  }
+
+  void _createElement() {
+    final host = _host;
+    if (host == null) return;
+
+    final element = web.document.createElement('div') as web.HTMLDivElement;
+    _element = element;
+
+    element
+      ..setAttribute('data-flutter-monaco-overlay-shield', _lockId)
+      ..setAttribute('aria-hidden', 'true')
+      ..setAttribute('tabindex', '-1');
+
+    element.style.position = 'fixed';
+    element.style.left = '-10000px';
+    element.style.top = '-10000px';
+    element.style.width = '0px';
+    element.style.height = '0px';
+    element.style.margin = '0';
+    element.style.padding = '0';
+    element.style.border = '0';
+    element.style.pointerEvents = 'none';
+    element.style.backgroundColor =
+        _debug ? 'rgba(0, 255, 0, 0.18)' : 'transparent';
+    element.style.outline = _debug ? '1px solid rgba(0, 128, 0, 0.7)' : 'none';
+
+    // Max z-index so the shield beats platform-view wrappers in DOM stacking.
+    element.style.zIndex = '2147483647';
+
+    // Let Flutter own the gesture sequence.
+    element.style.touchAction = 'manipulation';
+
+    host.appendChild(element);
+
+    _listen(element, 'pointerenter', _onPointerEnter);
+    _listen(element, 'pointerleave', _onPointerLeave);
+    _listen(element, 'pointerdown', _onPointerDown);
+    _listen(element, 'pointermove', _onPointerMove);
+    _listen(element, 'mousedown', _onMouseDown);
+    _listen(element, 'touchstart', _onTouchStart);
+    _listen(element, 'contextmenu', _onContextMenu);
+
+    _listen(web.document, 'pointerup', _onGlobalPointerRelease);
+    _listen(web.document, 'pointercancel', _onGlobalPointerRelease);
+    _listen(web.document, 'mouseup', _onGlobalPointerRelease);
+    _listen(web.document, 'touchend', _onGlobalPointerRelease);
+    _listen(web.document, 'touchcancel', _onGlobalPointerRelease);
+    _listen(web.document, 'visibilitychange', _onVisibilityChange);
+  }
+
+  void _listen(
+    web.EventTarget target,
+    String type,
+    void Function(web.Event event) handler,
+  ) {
+    final callback = handler.toJS;
+    target.addEventListener(type, callback);
+    _listeners.add(_DomListener(target, type, callback));
+  }
+
+  void _onPointerEnter(web.Event event) {
+    _hovering = true;
+    _lockIntersectingEditors();
+  }
+
+  void _onPointerLeave(web.Event event) {
+    _hovering = false;
+    if (!_pointerDown) {
+      MonacoWebInteractionCoordinator.instance.unlock(_lockId);
+    }
+  }
+
+  void _onPointerDown(web.Event event) {
+    _pointerDown = true;
+    _preventBrowserDefault(event);
+    _lockIntersectingEditors();
+  }
+
+  void _onPointerMove(web.Event event) {
+    if (_pointerDown) {
+      _preventBrowserDefault(event);
+      _lockIntersectingEditors();
+    }
+  }
+
+  void _onMouseDown(web.Event event) {
+    _preventBrowserDefault(event);
+    _lockIntersectingEditors();
+  }
+
+  void _onTouchStart(web.Event event) {
+    _pointerDown = true;
+    _preventBrowserDefault(event);
+    _lockIntersectingEditors();
+  }
+
+  void _onContextMenu(web.Event event) {
+    _preventBrowserDefault(event);
+    _lockIntersectingEditors();
+  }
+
+  void _onGlobalPointerRelease(web.Event event) {
+    if (!_pointerDown) return;
+
+    _pointerDown = false;
+    if (_hovering) {
+      _lockIntersectingEditors();
+    } else {
+      MonacoWebInteractionCoordinator.instance.unlock(_lockId);
+    }
+  }
+
+  void _onVisibilityChange(web.Event event) {
+    _pointerDown = false;
+    _hovering = false;
+    MonacoWebInteractionCoordinator.instance.unlock(_lockId);
+  }
+
+  void _lockIntersectingEditors() {
+    MonacoWebInteractionCoordinator.instance.lockEditorsForRect(_lockId, _rect);
+  }
+
+  void _preventBrowserDefault(web.Event event) {
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+
+    // Deliberately do NOT call stopPropagation / stopImmediatePropagation.
+    // Flutter still needs the event to bubble up so it can hit-test the
+    // widget visually at the click position.
+  }
+}
+
+class _DomListener {
+  _DomListener(this.target, this.type, this.callback);
+
+  final web.EventTarget target;
+  final String type;
+  final JSFunction callback;
+}

--- a/lib/src/platform/web_interaction_coordinator.dart
+++ b/lib/src/platform/web_interaction_coordinator.dart
@@ -1,0 +1,165 @@
+import 'dart:ui' show Rect;
+
+import 'package:web/web.dart' as web;
+
+/// Web-only coordinator for Monaco iframe pointer-event state.
+///
+/// Each registered iframe has a `baseEnabled` flag (controlled by
+/// [`MonacoController.setInteractionEnabled`]) and a set of overlay locks
+/// owned by [`MonacoOverlayBoundary`] instances. The iframe is interactive
+/// only when both conditions hold:
+///
+/// ```
+/// baseEnabled == true && locks.isEmpty
+/// ```
+///
+/// This composes cleanly with [`MonacoFocusGuard`] (which manages the base
+/// state for route overlays) and the new static-overlay shields. Releasing
+/// a static overlay lock does not re-enable an iframe that a route observer
+/// has disabled.
+class MonacoWebInteractionCoordinator {
+  MonacoWebInteractionCoordinator._();
+
+  /// Process-wide singleton. The web platform controller registers each
+  /// Monaco iframe here, and [`MonacoOverlayBoundary`] adds and removes
+  /// pointer-event locks.
+  static final MonacoWebInteractionCoordinator instance =
+      MonacoWebInteractionCoordinator._();
+
+  final Map<String, _EditorEntry> _editors = <String, _EditorEntry>{};
+  final Map<String, Set<String>> _lockOwners = <String, Set<String>>{};
+
+  /// Register or re-register an editor's iframe. Preserves any existing base
+  /// state and locks if the same id is re-registered (defensive against hot
+  /// reload).
+  void registerEditor(String id, web.HTMLIFrameElement iframe) {
+    final previous = _editors[id];
+
+    _editors[id] = _EditorEntry(
+      id: id,
+      iframe: iframe,
+      baseEnabled: previous?.baseEnabled ?? true,
+      locks: previous?.locks ?? <String>{},
+    );
+
+    _apply(_editors[id]!);
+  }
+
+  /// Remove an editor and any locks pointing at it.
+  void unregisterEditor(String id) {
+    _editors.remove(id);
+
+    for (final owner in List<String>.from(_lockOwners.keys)) {
+      final lockedEditors = _lockOwners[owner]!;
+      lockedEditors.remove(id);
+      if (lockedEditors.isEmpty) {
+        _lockOwners.remove(owner);
+      }
+    }
+  }
+
+  /// Sets the base interactive state for an editor. Called by
+  /// [`MonacoController.setInteractionEnabled`].
+  void setBaseEnabled(String id, bool enabled) {
+    final entry = _editors[id];
+    if (entry == null) return;
+
+    entry.baseEnabled = enabled;
+    _apply(entry);
+  }
+
+  /// Locks every iframe whose DOM rect intersects [rect]. Lock ownership is
+  /// keyed by [owner]; calling this again with the same owner replaces the
+  /// previous set of locked editors (so a moving overlay tracks correctly).
+  void lockEditorsForRect(String owner, Rect rect) {
+    if (rect.isEmpty || rect.width <= 0 || rect.height <= 0) {
+      unlock(owner);
+      return;
+    }
+
+    final nextEditors = <String>{};
+
+    for (final entry in _editors.values) {
+      if (!entry.iframe.isConnected) continue;
+
+      final editorRect = _rectForElement(entry.iframe);
+      if (editorRect.overlaps(rect)) {
+        nextEditors.add(entry.id);
+      }
+    }
+
+    final previousEditors = _lockOwners[owner] ?? <String>{};
+
+    for (final id in previousEditors.difference(nextEditors)) {
+      final entry = _editors[id];
+      if (entry == null) continue;
+
+      entry.locks.remove(owner);
+      _apply(entry);
+    }
+
+    for (final id in nextEditors.difference(previousEditors)) {
+      final entry = _editors[id];
+      if (entry == null) continue;
+
+      entry.locks.add(owner);
+      _apply(entry);
+    }
+
+    if (nextEditors.isEmpty) {
+      _lockOwners.remove(owner);
+    } else {
+      _lockOwners[owner] = nextEditors;
+    }
+  }
+
+  /// Release any locks held by [owner].
+  void unlock(String owner) {
+    final editorIds = _lockOwners.remove(owner);
+    if (editorIds == null) return;
+
+    for (final id in editorIds) {
+      final entry = _editors[id];
+      if (entry == null) continue;
+
+      entry.locks.remove(owner);
+      _apply(entry);
+    }
+  }
+
+  /// Release every overlay lock (does not touch base state).
+  void releaseAllOverlayLocks() {
+    for (final owner in List<String>.from(_lockOwners.keys)) {
+      unlock(owner);
+    }
+  }
+
+  Rect _rectForElement(web.Element element) {
+    final rect = element.getBoundingClientRect();
+    return Rect.fromLTWH(
+      rect.left,
+      rect.top,
+      rect.width,
+      rect.height,
+    );
+  }
+
+  void _apply(_EditorEntry entry) {
+    entry.iframe.style.pointerEvents =
+        entry.baseEnabled && entry.locks.isEmpty ? 'auto' : 'none';
+  }
+}
+
+class _EditorEntry {
+  _EditorEntry({
+    required this.id,
+    required this.iframe,
+    required this.baseEnabled,
+    required this.locks,
+  });
+
+  final String id;
+  final web.HTMLIFrameElement iframe;
+  bool baseEnabled;
+  final Set<String> locks;
+}

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -50,7 +50,7 @@ class WebViewController implements PlatformWebViewController {
   bool _disposed = false;
   bool _interactionEnabled = true;
 
-  final Completer<void> _readyCompleter = Completer<void>();
+  Completer<void> _readyCompleter = Completer<void>();
   bool _isReady = false;
 
   web.HTMLIFrameElement? _iframe;
@@ -135,14 +135,18 @@ class WebViewController implements PlatformWebViewController {
     }
 
     // Check if this is the ready event
-    if (message == 'ready' ||
-        message.contains('"event":"onEditorReady"') ||
-        message.contains('"event": "onEditorReady"')) {
+    final eventName = json?['event'];
+    if (message == 'ready' || eventName == 'onEditorReady') {
       _isReady = true;
       if (!_readyCompleter.isCompleted) {
         _readyCompleter.complete();
       }
       debugPrint('[WebViewController] Monaco ready!');
+    } else if (eventName == 'error' && !_isReady) {
+      final errorMessage = json?['message'] ?? 'Unknown Monaco load error';
+      if (!_readyCompleter.isCompleted) {
+        _readyCompleter.completeError(StateError(errorMessage.toString()));
+      }
     }
 
     // When Monaco reports focus, unfocus Flutter widgets.
@@ -272,33 +276,64 @@ class WebViewController implements PlatformWebViewController {
   @override
   Future<void> load({String? customCss, bool allowCdnFonts = false}) async {
     debugPrint('[WebViewController] Loading Monaco in iframe');
+    await _waitForIframeAttachment();
 
     // Resolve path against base URI to support subpaths
     final vsPath = Uri.base
         .resolve('assets/${MonacoAssets.assetBaseDir}/min/vs')
         .toString();
 
-    final html = MonacoAssets.generateIndexHtml(
-      vsPath,
-      isWindows: false,
-      isIosOrMacOS: false,
-      isWeb: true,
-      messageToken: _messageToken,
-      customCss: customCss,
-      allowCdnFonts: allowCdnFonts,
-    );
+    Object? lastError;
+    const maxLoadAttempts = 2;
+    for (var attempt = 1; attempt <= maxLoadAttempts; attempt++) {
+      _isReady = false;
+      _readyCompleter = Completer<void>();
 
-    // Create a blob URL for the HTML content
-    final blobUrl = web.URL.createObjectURL(web.Blob(
-      [html.toJS].toJS,
-      web.BlobPropertyBag(type: 'text/html'),
-    ));
-    _iframe!.src = blobUrl;
+      final html = MonacoAssets.generateIndexHtml(
+        vsPath,
+        isWindows: false,
+        isIosOrMacOS: false,
+        isWeb: true,
+        messageToken: _messageToken,
+        customCss: customCss,
+        allowCdnFonts: allowCdnFonts,
+      );
 
-    await _ensureReady();
+      final blobUrl = web.URL.createObjectURL(web.Blob(
+        [html.toJS].toJS,
+        web.BlobPropertyBag(type: 'text/html'),
+      ));
 
-    // Clean up blob URL after Monaco is ready
-    web.URL.revokeObjectURL(blobUrl);
+      try {
+        _iframe!.src = blobUrl;
+        await _ensureReady();
+        web.URL.revokeObjectURL(blobUrl);
+        return;
+      } catch (e) {
+        lastError = e;
+        web.URL.revokeObjectURL(blobUrl);
+        if (attempt == maxLoadAttempts) {
+          rethrow;
+        }
+        debugPrint(
+          '[WebViewController] Monaco load attempt $attempt failed, retrying: $e',
+        );
+        _iframe?.src = 'about:blank';
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }
+    }
+
+    throw StateError('Monaco iframe failed to load: $lastError');
+  }
+
+  Future<void> _waitForIframeAttachment() async {
+    final iframe = _iframe;
+    if (iframe == null || iframe.isConnected) return;
+
+    const maxFrames = 120;
+    for (var i = 0; i < maxFrames && !iframe.isConnected; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 16));
+    }
   }
 
   @override

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -4,6 +4,7 @@ import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 import 'dart:ui_web' as ui_web;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/src/core/monaco_assets.dart';
 import 'package:flutter_monaco/src/platform/platform_webview.dart';
@@ -37,7 +38,8 @@ import 'package:web/web.dart' as web;
 ///
 /// Web focus is tricky because the iframe is a separate browsing context.
 /// When Monaco reports focus events, this controller unfocuses Flutter
-/// widgets and uses `forceFocus()` to ensure Monaco retains keyboard input.
+/// widgets. Desktop web also reasserts Monaco focus while mobile web avoids
+/// amplifying accidental focus during scroll gestures.
 ///
 /// See also:
 /// - [MonacoAssets.generateIndexHtml] for HTML generation with web-specific
@@ -143,18 +145,19 @@ class WebViewController implements PlatformWebViewController {
       debugPrint('[WebViewController] Monaco ready!');
     }
 
-    // When Monaco reports focus, unfocus Flutter widgets and ensure Monaco keeps focus.
+    // When Monaco reports focus, unfocus Flutter widgets.
     // This is gated by _interactionEnabled to avoid focus stealing when interaction is disabled.
     if (_interactionEnabled &&
         (message.contains('"event":"focus"') ||
             message.contains('"event": "focus"'))) {
       // Unfocus any Flutter widget
       FocusManager.instance.primaryFocus?.unfocus();
-      // Use Monaco's forceFocus to ensure editor keeps focus
-      _iframe?.contentWindow?.callMethod(
-        'eval'.toJS,
-        'window.flutterMonaco && window.flutterMonaco.forceFocus()'.toJS,
-      );
+      if (!_isMobileInputPlatform()) {
+        _iframe?.contentWindow?.callMethod(
+          'eval'.toJS,
+          'window.flutterMonaco && window.flutterMonaco.forceFocus()'.toJS,
+        );
+      }
     }
 
     // Forward to all channels
@@ -172,6 +175,11 @@ class WebViewController implements PlatformWebViewController {
         },
       );
     }
+  }
+
+  bool _isMobileInputPlatform() {
+    return defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS;
   }
 
   @override

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -297,8 +297,6 @@ class WebViewController implements PlatformWebViewController {
         messageToken: _messageToken,
         customCss: customCss,
         allowCdnFonts: allowCdnFonts,
-        gestureDebugEnabled:
-            Uri.base.queryParameters.containsKey('monacoGestureDebug'),
       );
 
       final blobUrl = web.URL.createObjectURL(web.Blob(

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -297,6 +297,8 @@ class WebViewController implements PlatformWebViewController {
         messageToken: _messageToken,
         customCss: customCss,
         allowCdnFonts: allowCdnFonts,
+        gestureDebugEnabled:
+            Uri.base.queryParameters.containsKey('monacoGestureDebug'),
       );
 
       final blobUrl = web.URL.createObjectURL(web.Blob(

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/src/core/monaco_assets.dart';
 import 'package:flutter_monaco/src/platform/platform_webview.dart';
+import 'package:flutter_monaco/src/platform/web_interaction_coordinator.dart';
 import 'package:web/web.dart' as web;
 
 /// WebView implementation for Flutter Web using an iframe.
@@ -78,6 +79,11 @@ class WebViewController implements PlatformWebViewController {
       ..style.height = '100%'
       ..style.border = 'none'
       ..allow = 'clipboard-read; clipboard-write';
+
+    MonacoWebInteractionCoordinator.instance.registerEditor(
+      _viewId!,
+      _iframe!,
+    );
     _applyInteractionEnabled();
 
     // Register the view factory.
@@ -197,7 +203,15 @@ class WebViewController implements PlatformWebViewController {
   void _applyInteractionEnabled() {
     final iframe = _iframe;
     if (iframe == null) return;
-    iframe.style.pointerEvents = _interactionEnabled ? 'auto' : 'none';
+    final viewId = _viewId;
+    if (viewId == null) {
+      iframe.style.pointerEvents = _interactionEnabled ? 'auto' : 'none';
+      return;
+    }
+    MonacoWebInteractionCoordinator.instance.setBaseEnabled(
+      viewId,
+      _interactionEnabled,
+    );
   }
 
   @override
@@ -342,6 +356,10 @@ class WebViewController implements PlatformWebViewController {
     _disposed = true;
 
     debugPrint('[WebViewController] Disposing...');
+    final viewId = _viewId;
+    if (viewId != null) {
+      MonacoWebInteractionCoordinator.instance.unregisterEditor(viewId);
+    }
     if (_messageHandler != null) {
       web.window.removeEventListener('message', _messageHandler!);
       _messageHandler = null;

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -339,15 +339,9 @@ class _MonacoEditorState extends State<MonacoEditor> {
           return;
         }
       }
-      // On mobile native, programmatic autofocus without a user gesture
-      // will never produce a keyboard - skip it entirely.
-      final isMobileNativeBootstrap = !kIsWeb &&
-          (defaultTargetPlatform == TargetPlatform.android ||
-              defaultTargetPlatform == TargetPlatform.iOS);
-
       if (widget.autofocus &&
           widget.interactionEnabled &&
-          !isMobileNativeBootstrap) {
+          !_isMobileInputPlatform()) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!_isBootstrapCurrent(bootstrapToken)) return;
           _webFocusNode.requestFocus();
@@ -373,6 +367,11 @@ class _MonacoEditorState extends State<MonacoEditor> {
   }
 
   bool _isBootstrapCurrent(int token) => mounted && token == _bootstrapSeq;
+
+  bool _isMobileInputPlatform() {
+    return defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS;
+  }
 
   /// Subscribes to all relevant event streams from the controller.
   void _wireListeners() {
@@ -495,15 +494,13 @@ class _MonacoEditorState extends State<MonacoEditor> {
       return widget.loadingBuilder?.call(context) ?? const _DefaultLoading();
     }
 
-    // On mobile native, let the WebView own the full tap-to-keyboard chain.
+    // On mobile, let the WebView own the full tap-to-keyboard chain.
     // Flutter's Focus/Listener wrapper steals the gesture context, which
     // causes the OS to refuse the soft keyboard.
-    final isMobileNative = !kIsWeb &&
-        (defaultTargetPlatform == TargetPlatform.android ||
-            defaultTargetPlatform == TargetPlatform.iOS);
+    final isMobileInputPlatform = _isMobileInputPlatform();
 
     final Widget webView;
-    if (isMobileNative) {
+    if (isMobileInputPlatform) {
       webView = SizedBox.expand(child: _controller!.webViewWidget);
     } else {
       webView = SizedBox.expand(

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
@@ -338,12 +339,18 @@ class _MonacoEditorState extends State<MonacoEditor> {
           return;
         }
       }
-      if (widget.autofocus && widget.interactionEnabled) {
-        // Defer to next frame to ensure visibility, request Flutter focus, and then enforce Monaco focus
+      // On mobile native, programmatic autofocus without a user gesture
+      // will never produce a keyboard - skip it entirely.
+      final isMobileNativeBootstrap = !kIsWeb &&
+          (defaultTargetPlatform == TargetPlatform.android ||
+              defaultTargetPlatform == TargetPlatform.iOS);
+
+      if (widget.autofocus &&
+          widget.interactionEnabled &&
+          !isMobileNativeBootstrap) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!_isBootstrapCurrent(bootstrapToken)) return;
           _webFocusNode.requestFocus();
-          // Retry a few times to survive competing focus layout
           unawaited(_controller!.ensureEditorFocus(attempts: 3));
         });
       }
@@ -488,30 +495,42 @@ class _MonacoEditorState extends State<MonacoEditor> {
       return widget.loadingBuilder?.call(context) ?? const _DefaultLoading();
     }
 
-    final webView = SizedBox.expand(
-      child: Focus(
-        focusNode: _webFocusNode,
-        canRequestFocus: widget.interactionEnabled,
-        autofocus: widget.autofocus && widget.interactionEnabled,
-        onKeyEvent: (node, event) {
-          if (event is KeyDownEvent) {
-            return KeyEventResult.skipRemainingHandlers;
-          }
-          return KeyEventResult.ignored;
-        },
-        child: Listener(
-          behavior: HitTestBehavior.translucent,
-          onPointerDown: (_) {
-            if (!widget.interactionEnabled) return;
-            if (!_webFocusNode.hasFocus) {
-              _webFocusNode.requestFocus();
+    // On mobile native, let the WebView own the full tap-to-keyboard chain.
+    // Flutter's Focus/Listener wrapper steals the gesture context, which
+    // causes the OS to refuse the soft keyboard.
+    final isMobileNative = !kIsWeb &&
+        (defaultTargetPlatform == TargetPlatform.android ||
+            defaultTargetPlatform == TargetPlatform.iOS);
+
+    final Widget webView;
+    if (isMobileNative) {
+      webView = SizedBox.expand(child: _controller!.webViewWidget);
+    } else {
+      webView = SizedBox.expand(
+        child: Focus(
+          focusNode: _webFocusNode,
+          canRequestFocus: widget.interactionEnabled,
+          autofocus: widget.autofocus && widget.interactionEnabled,
+          onKeyEvent: (node, event) {
+            if (event is KeyDownEvent) {
+              return KeyEventResult.skipRemainingHandlers;
             }
-            unawaited(_controller!.ensureEditorFocus(attempts: 1));
+            return KeyEventResult.ignored;
           },
-          child: _controller!.webViewWidget,
+          child: Listener(
+            behavior: HitTestBehavior.translucent,
+            onPointerDown: (_) {
+              if (!widget.interactionEnabled) return;
+              if (!_webFocusNode.hasFocus) {
+                _webFocusNode.requestFocus();
+              }
+              unawaited(_controller!.ensureEditorFocus(attempts: 1));
+            },
+            child: _controller!.webViewWidget,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     Widget content = webView;
     if (_connectionState == _ConnectionState.connecting) {

--- a/lib/src/widgets/monaco_overlay_boundary.dart
+++ b/lib/src/widgets/monaco_overlay_boundary.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_monaco/src/platform/overlay_shield/overlay_shield.dart';
+
+/// Marks a Flutter widget subtree as a static overlay above Monaco on Web.
+///
+/// On Flutter Web, Monaco runs inside an `<iframe>` registered via
+/// `HtmlElementView`. The browser routes pointer events into the iframe
+/// before Flutter sees them, so static overlays (FABs, in-tree stacked
+/// widgets, custom panels) appear visible but are unclickable.
+///
+/// Wrap such overlays with [`MonacoOverlayBoundary`]. On web, this creates
+/// a transparent DOM shield over the widget's global bounds and disables
+/// pointer events on any intersecting Monaco iframe while the user is
+/// hovering or pressing the overlay. On native platforms this is a no-op
+/// wrapper.
+///
+/// For route-based overlays (dialogs, popup menus, dropdown menus, modal
+/// bottom sheets), keep using [`MonacoFocusGuard`] with a
+/// [`MonacoRouteObserver`] - that path was already correct and remains
+/// the recommended fix for `ModalRoute`s.
+///
+/// Most apps will not construct this directly. [`MonacoScaffold`] wraps
+/// the common Scaffold overlay slots automatically.
+class MonacoOverlayBoundary extends StatefulWidget {
+  /// Create an overlay boundary that protects [child] from being swallowed by
+  /// Monaco iframes underneath on web.
+  const MonacoOverlayBoundary({
+    super.key,
+    required this.child,
+    this.enabled = true,
+    this.debug = false,
+    this.margin = EdgeInsets.zero,
+  });
+
+  /// The overlay widget that should be reachable on web.
+  final Widget child;
+
+  /// Disables the DOM shield entirely (useful when you know there is no
+  /// editor underneath, or to opt out of the overlay protection).
+  final bool enabled;
+
+  /// Renders the shield as a translucent green rectangle on web. Useful when
+  /// validating that the shield's rect matches the visible overlay bounds.
+  final bool debug;
+
+  /// Expands the shield rect beyond the child's measured bounds. Use sparingly;
+  /// large margins lock more editor area than necessary.
+  final EdgeInsetsGeometry margin;
+
+  @override
+  State<MonacoOverlayBoundary> createState() => _MonacoOverlayBoundaryState();
+}
+
+class _MonacoOverlayBoundaryState extends State<MonacoOverlayBoundary>
+    with WidgetsBindingObserver, SingleTickerProviderStateMixin {
+  MonacoOverlayDomShield? _shield;
+  Ticker? _ticker;
+  int? _flutterViewId;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+
+    if (MonacoOverlayDomShield.isSupported) {
+      _ticker = createTicker((_) => _syncShield());
+      _ticker!.start();
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _flutterViewId = View.of(context).viewId;
+    _ensureShield();
+    _scheduleSync();
+  }
+
+  @override
+  void didUpdateWidget(covariant MonacoOverlayBoundary oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.debug != widget.debug ||
+        oldWidget.enabled != widget.enabled) {
+      _disposeShield();
+      _ensureShield();
+    }
+
+    _scheduleSync();
+  }
+
+  @override
+  void didChangeMetrics() {
+    _scheduleSync();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _ensureShield();
+    _scheduleSync();
+    return widget.child;
+  }
+
+  void _ensureShield() {
+    if (!MonacoOverlayDomShield.isSupported) return;
+    if (!widget.enabled) return;
+    if (_shield != null) return;
+
+    final viewId = _flutterViewId;
+    if (viewId == null) return;
+
+    _shield = MonacoOverlayDomShield(
+      flutterViewId: viewId,
+      debug: widget.debug,
+    );
+  }
+
+  void _scheduleSync() {
+    if (!MonacoOverlayDomShield.isSupported) return;
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _syncShield();
+    });
+  }
+
+  void _syncShield() {
+    final shield = _shield;
+    if (shield == null) return;
+
+    if (!mounted || !widget.enabled) {
+      shield.update(Rect.zero);
+      return;
+    }
+
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox ||
+        !renderObject.attached ||
+        renderObject.size.width <= 0 ||
+        renderObject.size.height <= 0) {
+      shield.update(Rect.zero);
+      return;
+    }
+
+    final topLeft = renderObject.localToGlobal(Offset.zero);
+    var rect = topLeft & renderObject.size;
+
+    final textDirection = Directionality.maybeOf(context) ?? TextDirection.ltr;
+    final margin = widget.margin.resolve(textDirection);
+
+    rect = Rect.fromLTRB(
+      rect.left - margin.left,
+      rect.top - margin.top,
+      rect.right + margin.right,
+      rect.bottom + margin.bottom,
+    );
+
+    shield.update(rect);
+  }
+
+  void _disposeShield() {
+    _shield?.dispose();
+    _shield = null;
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _ticker?.dispose();
+    _ticker = null;
+    _disposeShield();
+    super.dispose();
+  }
+}

--- a/lib/src/widgets/monaco_scaffold.dart
+++ b/lib/src/widgets/monaco_scaffold.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_monaco/src/widgets/monaco_overlay_boundary.dart';
+
+/// Drop-in [`Scaffold`] replacement that automatically protects common
+/// static overlay slots from iframe-backed Monaco editors on Web.
+///
+/// On web, each of the `floatingActionButton`, `drawer`, `endDrawer`,
+/// `bottomSheet`, `bottomNavigationBar`, and `persistentFooterButtons`
+/// slots is wrapped in [`MonacoOverlayBoundary`] so pointer events land on
+/// Flutter widgets instead of the editor iframe underneath. The `appBar`
+/// is left alone by default (AppBars typically sit above the editor in the
+/// layout, not over it); enable [`shieldAppBar`] for translucent /
+/// `extendBodyBehindAppBar` layouts.
+///
+/// `MonacoScaffold` does NOT replace [`MonacoFocusGuard`]. Route overlays
+/// (dialogs, popup menus, dropdown menus, modal bottom sheets) should still
+/// be handled by [`MonacoFocusGuard`] + [`MonacoRouteObserver`].
+///
+/// On native platforms, all overlay boundaries are no-op pass-throughs.
+class MonacoScaffold extends StatelessWidget {
+  /// Construct a Monaco-aware [Scaffold]. Every parameter except the three
+  /// at the end (`shieldStaticOverlays`, `shieldAppBar`, `overlayDebug`)
+  /// behaves identically to the corresponding [Scaffold] parameter.
+  const MonacoScaffold({
+    super.key,
+    this.appBar,
+    this.body,
+    this.floatingActionButton,
+    this.floatingActionButtonLocation,
+    this.floatingActionButtonAnimator,
+    this.persistentFooterButtons,
+    this.persistentFooterAlignment = AlignmentDirectional.centerEnd,
+    this.drawer,
+    this.onDrawerChanged,
+    this.endDrawer,
+    this.onEndDrawerChanged,
+    this.bottomNavigationBar,
+    this.bottomSheet,
+    this.backgroundColor,
+    this.resizeToAvoidBottomInset,
+    this.extendBody = false,
+    this.extendBodyBehindAppBar = false,
+    this.drawerScrimColor,
+    this.drawerEdgeDragWidth,
+    this.drawerEnableOpenDragGesture = true,
+    this.endDrawerEnableOpenDragGesture = true,
+    this.restorationId,
+    this.shieldStaticOverlays = true,
+    this.shieldAppBar = false,
+    this.overlayDebug = false,
+  });
+
+  /// See [Scaffold.appBar].
+  final PreferredSizeWidget? appBar;
+
+  /// See [Scaffold.body].
+  final Widget? body;
+
+  /// See [Scaffold.floatingActionButton].
+  final Widget? floatingActionButton;
+
+  /// See [Scaffold.floatingActionButtonLocation].
+  final FloatingActionButtonLocation? floatingActionButtonLocation;
+
+  /// See [Scaffold.floatingActionButtonAnimator].
+  final FloatingActionButtonAnimator? floatingActionButtonAnimator;
+
+  /// See [Scaffold.persistentFooterButtons].
+  final List<Widget>? persistentFooterButtons;
+
+  /// See [Scaffold.persistentFooterAlignment].
+  final AlignmentDirectional persistentFooterAlignment;
+
+  /// See [Scaffold.drawer].
+  final Widget? drawer;
+
+  /// See [Scaffold.onDrawerChanged].
+  final DrawerCallback? onDrawerChanged;
+
+  /// See [Scaffold.endDrawer].
+  final Widget? endDrawer;
+
+  /// See [Scaffold.onEndDrawerChanged].
+  final DrawerCallback? onEndDrawerChanged;
+
+  /// See [Scaffold.bottomNavigationBar].
+  final Widget? bottomNavigationBar;
+
+  /// See [Scaffold.bottomSheet].
+  final Widget? bottomSheet;
+
+  /// See [Scaffold.backgroundColor].
+  final Color? backgroundColor;
+
+  /// See [Scaffold.resizeToAvoidBottomInset].
+  final bool? resizeToAvoidBottomInset;
+
+  /// See [Scaffold.extendBody].
+  final bool extendBody;
+
+  /// See [Scaffold.extendBodyBehindAppBar].
+  final bool extendBodyBehindAppBar;
+
+  /// See [Scaffold.drawerScrimColor].
+  final Color? drawerScrimColor;
+
+  /// See [Scaffold.drawerEdgeDragWidth].
+  final double? drawerEdgeDragWidth;
+
+  /// See [Scaffold.drawerEnableOpenDragGesture].
+  final bool drawerEnableOpenDragGesture;
+
+  /// See [Scaffold.endDrawerEnableOpenDragGesture].
+  final bool endDrawerEnableOpenDragGesture;
+
+  /// See [Scaffold.restorationId].
+  final String? restorationId;
+
+  /// When false, this behaves like a plain Scaffold (no shielding).
+  final bool shieldStaticOverlays;
+
+  /// AppBars usually sit above the editor in the layout. Enable this for
+  /// translucent AppBars or `extendBodyBehindAppBar: true` layouts where the
+  /// AppBar visually overlaps the editor.
+  final bool shieldAppBar;
+
+  /// Shows the web shield rectangles in translucent green for debugging.
+  final bool overlayDebug;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: shieldAppBar ? _shieldPreferredSize(appBar) : appBar,
+      body: body,
+      floatingActionButton: _shield(floatingActionButton),
+      floatingActionButtonLocation: floatingActionButtonLocation,
+      floatingActionButtonAnimator: floatingActionButtonAnimator,
+      persistentFooterButtons:
+          persistentFooterButtons?.map((button) => _shield(button)!).toList(),
+      persistentFooterAlignment: persistentFooterAlignment,
+      drawer: _shield(drawer),
+      onDrawerChanged: onDrawerChanged,
+      endDrawer: _shield(endDrawer),
+      onEndDrawerChanged: onEndDrawerChanged,
+      bottomNavigationBar: _shield(bottomNavigationBar),
+      bottomSheet: _shield(bottomSheet),
+      backgroundColor: backgroundColor,
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+      extendBody: extendBody,
+      extendBodyBehindAppBar: extendBodyBehindAppBar,
+      drawerScrimColor: drawerScrimColor,
+      drawerEdgeDragWidth: drawerEdgeDragWidth,
+      drawerEnableOpenDragGesture: drawerEnableOpenDragGesture,
+      endDrawerEnableOpenDragGesture: endDrawerEnableOpenDragGesture,
+      restorationId: restorationId,
+    );
+  }
+
+  Widget? _shield(Widget? child) {
+    if (child == null) return null;
+    if (!shieldStaticOverlays) return child;
+
+    return MonacoOverlayBoundary(
+      debug: overlayDebug,
+      child: child,
+    );
+  }
+
+  PreferredSizeWidget? _shieldPreferredSize(PreferredSizeWidget? child) {
+    if (child == null) return null;
+    if (!shieldStaticOverlays) return child;
+
+    return _PreferredMonacoOverlayBoundary(
+      debug: overlayDebug,
+      child: child,
+    );
+  }
+}
+
+class _PreferredMonacoOverlayBoundary extends StatelessWidget
+    implements PreferredSizeWidget {
+  const _PreferredMonacoOverlayBoundary({
+    required this.child,
+    required this.debug,
+  });
+
+  final PreferredSizeWidget child;
+  final bool debug;
+
+  @override
+  Size get preferredSize => child.preferredSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return MonacoOverlayBoundary(
+      debug: debug,
+      child: child,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 1.5.0
+version: 1.5.1
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 1.5.1
+version: 1.6.0
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/core/monaco_assets_test.dart
+++ b/test/core/monaco_assets_test.dart
@@ -104,18 +104,43 @@ void main() {
       expect(html, contains('const ownerDocument = node.ownerDocument'));
       expect(html, contains('const ownerWindow = ownerDocument.defaultView'));
       expect(html, contains('const isAndroid = /Android/i.test(ua)'));
+      expect(html, contains('const isFlutterWebEmbed = (() =>'));
       expect(html, contains('const tapMoveThreshold = 8'));
       expect(html, contains('const tapTimeThreshold = 650'));
       expect(html, contains('const compatibilityEventSuppressMs = 1200'));
+      expect(html, contains('let androidTouchScrollGesture = null'));
+      expect(html, contains('let suppressFocusUntil = 0'));
       expect(html, contains('const usePointerTapBridge ='));
       expect(html, contains('supportsPointerEvents && isAndroid'));
       expect(html, contains('const useTouchTapBridge = !usePointerTapBridge'));
+      expect(html, contains('const useAndroidWebFocusGuard ='));
+      expect(html,
+          contains('const mobileGestureDebugMode = getGestureDebugMode();'));
+      expect(html, contains('const debugMobileGesture ='));
+      expect(html, contains("event: 'mobileGestureDebug'"));
+      expect(html, contains('window.flutterMonaco.getGestureDebugLog'));
       expect(html, contains('const getScrollSnapshot = () =>'));
       expect(html, contains('ed.getScrollTop'));
       expect(html, contains('ed.getScrollLeft'));
       expect(html, contains('const hasMovedFromStart = (event) =>'));
+      expect(
+        html,
+        contains('const hasTouchScrollMovedFromStart = (event) =>'),
+      );
       expect(html, contains('const blockEvent = (event) =>'));
       expect(html, contains('const suppressAndBlock = (event) =>'));
+      expect(html, contains('const editorInputSelector ='));
+      expect(html, contains('textarea.inputarea, .native-edit-context'));
+      expect(html, contains('const isEditorInputElement ='));
+      expect(html, contains('const getEditorInputElement ='));
+      expect(html, contains('let maxObservedViewportHeight = 0'));
+      expect(html, contains('const isKeyboardLikelyVisible ='));
+      expect(
+          html, contains('keyboardLikelyVisible: isKeyboardLikelyVisible()'));
+      expect(html, contains('const suppressScrollFocusIfNeeded ='));
+      expect(html, contains('willBlurEditorInput: !keyboardVisible'));
+      expect(html, contains('const guardSuppressedTextAreaFocus ='));
+      expect(html, contains('const logTextAreaFocusEvent ='));
       expect(html, contains('const endGesture = (event, id, kind) =>'));
       expect(html, contains('suppressAndBlock(event);'));
       expect(html, contains('const capturePassiveFalse ='));
@@ -135,14 +160,40 @@ void main() {
       expect(
         html,
         contains(
+          "ownerDocument.addEventListener('touchend', endAndroidTouchScrollGuard, capturePassiveFalse",
+        ),
+      );
+      expect(
+        html,
+        contains(
+          "ownerDocument.addEventListener('focusin', guardSuppressedTextAreaFocus",
+        ),
+      );
+      expect(
+        html,
+        contains(
+          "ownerDocument.addEventListener('focusin', logTextAreaFocusEvent",
+        ),
+      );
+      expect(
+        html,
+        contains(
           "ownerDocument.addEventListener('click', blockSuppressedCompatibilityEvent",
         ),
       );
       expect(html, contains('node.style.touchAction'));
       expect(html, isNot(contains('focusFromClick')));
-      expect(html, isNot(contains('guardTextareaFocus')));
-      expect(html, isNot(contains('__flutterMonacoScrollFocusGuard')));
-      expect(html, isNot(contains('new MutationObserver(guardTextareaFocus)')));
+    });
+
+    test('generated html can compile-enable mobile gesture debug logging', () {
+      final html = MonacoAssets.generateIndexHtml(
+        'min/vs',
+        gestureDebugEnabled: true,
+      );
+
+      expect(html, contains("return true ? '1' : '';"));
+      expect(html, contains('[flutter_monaco][gesture]'));
+      expect(html, contains('postMessageToFlutter(entry);'));
     });
 
     test('generated html keeps desktop preventScroll focus retry', () {

--- a/test/core/monaco_assets_test.dart
+++ b/test/core/monaco_assets_test.dart
@@ -114,11 +114,6 @@ void main() {
       expect(html, contains('supportsPointerEvents && isAndroid'));
       expect(html, contains('const useTouchTapBridge = !usePointerTapBridge'));
       expect(html, contains('const useAndroidWebFocusGuard ='));
-      expect(html,
-          contains('const mobileGestureDebugMode = getGestureDebugMode();'));
-      expect(html, contains('const debugMobileGesture ='));
-      expect(html, contains("event: 'mobileGestureDebug'"));
-      expect(html, contains('window.flutterMonaco.getGestureDebugLog'));
       expect(html, contains('const getScrollSnapshot = () =>'));
       expect(html, contains('ed.getScrollTop'));
       expect(html, contains('ed.getScrollLeft'));
@@ -135,12 +130,8 @@ void main() {
       expect(html, contains('const getEditorInputElement ='));
       expect(html, contains('let maxObservedViewportHeight = 0'));
       expect(html, contains('const isKeyboardLikelyVisible ='));
-      expect(
-          html, contains('keyboardLikelyVisible: isKeyboardLikelyVisible()'));
       expect(html, contains('const suppressScrollFocusIfNeeded ='));
-      expect(html, contains('willBlurEditorInput: !keyboardVisible'));
       expect(html, contains('const guardSuppressedTextAreaFocus ='));
-      expect(html, contains('const logTextAreaFocusEvent ='));
       expect(html, contains('const endGesture = (event, id, kind) =>'));
       expect(html, contains('suppressAndBlock(event);'));
       expect(html, contains('const capturePassiveFalse ='));
@@ -172,28 +163,13 @@ void main() {
       expect(
         html,
         contains(
-          "ownerDocument.addEventListener('focusin', logTextAreaFocusEvent",
-        ),
-      );
-      expect(
-        html,
-        contains(
           "ownerDocument.addEventListener('click', blockSuppressedCompatibilityEvent",
         ),
       );
       expect(html, contains('node.style.touchAction'));
       expect(html, isNot(contains('focusFromClick')));
-    });
-
-    test('generated html can compile-enable mobile gesture debug logging', () {
-      final html = MonacoAssets.generateIndexHtml(
-        'min/vs',
-        gestureDebugEnabled: true,
-      );
-
-      expect(html, contains("return true ? '1' : '';"));
-      expect(html, contains('[flutter_monaco][gesture]'));
-      expect(html, contains('postMessageToFlutter(entry);'));
+      expect(html, isNot(contains('mobileGestureDebug')));
+      expect(html, isNot(contains('monacoGestureDebug')));
     });
 
     test('generated html keeps desktop preventScroll focus retry', () {

--- a/test/core/monaco_assets_test.dart
+++ b/test/core/monaco_assets_test.dart
@@ -101,30 +101,48 @@ void main() {
       expect(html, contains("navigator.platform === 'MacIntel'"));
       expect(html, contains('navigator.maxTouchPoints > 1'));
       expect(html, contains('const focusEditorTextAreaNow = () =>'));
-      expect(html, contains('const tapMoveThreshold = 12'));
+      expect(html, contains('const ownerDocument = node.ownerDocument'));
+      expect(html, contains('const ownerWindow = ownerDocument.defaultView'));
+      expect(html, contains('const isAndroid = /Android/i.test(ua)'));
+      expect(html, contains('const tapMoveThreshold = 8'));
+      expect(html, contains('const tapTimeThreshold = 650'));
       expect(html, contains('const compatibilityEventSuppressMs = 1200'));
-      expect(html, contains('const beginTapCandidate = (event) =>'));
-      expect(html, contains('const updateTapCandidate = (event) =>'));
+      expect(html, contains('const usePointerTapBridge ='));
+      expect(html, contains('supportsPointerEvents && isAndroid'));
+      expect(html, contains('const useTouchTapBridge = !usePointerTapBridge'));
+      expect(html, contains('const getScrollSnapshot = () =>'));
+      expect(html, contains('ed.getScrollTop'));
+      expect(html, contains('ed.getScrollLeft'));
+      expect(html, contains('const hasMovedFromStart = (event) =>'));
       expect(html, contains('const blockEvent = (event) =>'));
-      expect(html, contains('let suppressClickUntil = 0'));
-      expect(html, contains('const suppressSyntheticClick = () =>'));
-      expect(html, contains('const focusIfTapCandidate = (event) =>'));
-      expect(html, contains('if (now < suppressClickUntil) {'));
+      expect(html, contains('const suppressAndBlock = (event) =>'));
+      expect(html, contains('const endGesture = (event, id, kind) =>'));
+      expect(html, contains('suppressAndBlock(event);'));
+      expect(html, contains('const capturePassiveFalse ='));
+      expect(html, contains("ownerDocument.addEventListener('pointerdown'"));
       expect(
         html,
-        contains('const suppressCompatibilityMouseEvent = (event) =>'),
+        contains(
+          "ownerDocument.addEventListener('pointerup', onPointerUp, capturePassiveFalse",
+        ),
       );
-      expect(html, contains("node.addEventListener('pointerdown'"));
-      expect(html, contains("node.addEventListener('pointermove'"));
-      expect(html, contains("node.addEventListener('pointerup'"));
-      expect(html, contains("node.addEventListener('pointercancel'"));
-      expect(html, contains("node.addEventListener('touchstart'"));
-      expect(html, contains("node.addEventListener('touchmove'"));
-      expect(html, contains("node.addEventListener('touchend'"));
-      expect(html, contains("node.addEventListener('touchcancel'"));
-      expect(html, contains("node.addEventListener('mousedown'"));
-      expect(html, contains("node.addEventListener('mouseup'"));
-      expect(html, contains("node.addEventListener('click'"));
+      expect(
+        html,
+        contains(
+          "ownerDocument.addEventListener('touchend', onTouchEnd, capturePassiveFalse",
+        ),
+      );
+      expect(
+        html,
+        contains(
+          "ownerDocument.addEventListener('click', blockSuppressedCompatibilityEvent",
+        ),
+      );
+      expect(html, contains('node.style.touchAction'));
+      expect(html, isNot(contains('focusFromClick')));
+      expect(html, isNot(contains('guardTextareaFocus')));
+      expect(html, isNot(contains('__flutterMonacoScrollFocusGuard')));
+      expect(html, isNot(contains('new MutationObserver(guardTextareaFocus)')));
     });
 
     test('generated html keeps desktop preventScroll focus retry', () {

--- a/test/core/monaco_assets_test.dart
+++ b/test/core/monaco_assets_test.dart
@@ -74,5 +74,65 @@ void main() {
       final infoAfter = await MonacoAssets.assetInfo();
       expect(infoAfter['exists'], false);
     });
+
+    test('generated html includes mobile viewport metadata', () {
+      final html = MonacoAssets.generateIndexHtml('min/vs');
+
+      expect(html, contains('name="viewport"'));
+      expect(
+        html,
+        contains(
+          'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no',
+        ),
+      );
+    });
+
+    test('generated html does not override Monaco inputarea layout', () {
+      final html = MonacoAssets.generateIndexHtml('min/vs');
+
+      expect(html, isNot(contains('.monaco-editor .inputarea')));
+      expect(html, isNot(contains('@media (pointer: coarse)')));
+    });
+
+    test('generated html includes tap-gated mobile gesture focus bridge', () {
+      final html = MonacoAssets.generateIndexHtml('min/vs');
+
+      expect(html, contains('const isMobileInputPlatform = () =>'));
+      expect(html, contains("navigator.platform === 'MacIntel'"));
+      expect(html, contains('navigator.maxTouchPoints > 1'));
+      expect(html, contains('const focusEditorTextAreaNow = () =>'));
+      expect(html, contains('const tapMoveThreshold = 12'));
+      expect(html, contains('const compatibilityEventSuppressMs = 1200'));
+      expect(html, contains('const beginTapCandidate = (event) =>'));
+      expect(html, contains('const updateTapCandidate = (event) =>'));
+      expect(html, contains('const blockEvent = (event) =>'));
+      expect(html, contains('let suppressClickUntil = 0'));
+      expect(html, contains('const suppressSyntheticClick = () =>'));
+      expect(html, contains('const focusIfTapCandidate = (event) =>'));
+      expect(html, contains('if (now < suppressClickUntil) {'));
+      expect(
+        html,
+        contains('const suppressCompatibilityMouseEvent = (event) =>'),
+      );
+      expect(html, contains("node.addEventListener('pointerdown'"));
+      expect(html, contains("node.addEventListener('pointermove'"));
+      expect(html, contains("node.addEventListener('pointerup'"));
+      expect(html, contains("node.addEventListener('pointercancel'"));
+      expect(html, contains("node.addEventListener('touchstart'"));
+      expect(html, contains("node.addEventListener('touchmove'"));
+      expect(html, contains("node.addEventListener('touchend'"));
+      expect(html, contains("node.addEventListener('touchcancel'"));
+      expect(html, contains("node.addEventListener('mousedown'"));
+      expect(html, contains("node.addEventListener('mouseup'"));
+      expect(html, contains("node.addEventListener('click'"));
+    });
+
+    test('generated html keeps desktop preventScroll focus retry', () {
+      final html = MonacoAssets.generateIndexHtml('min/vs');
+
+      expect(html, contains('if (isMobileInputPlatform())'));
+      expect(html, contains('focusEditorTextAreaNow();'));
+      expect(html, contains('ta.focus({ preventScroll: true });'));
+    });
   });
 }

--- a/test/core/monaco_controller_source_test.dart
+++ b/test/core/monaco_controller_source_test.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('web queued setters return before editor readiness', () {
+    final source =
+        File('lib/src/core/monaco_controller.dart').readAsStringSync();
+
+    expect(source, contains('_queuedLanguage = language;'));
+    expect(source, contains('_queuedValue = value;'));
+    expect(source, contains('if (kIsWeb) return;'));
+  });
+}

--- a/test/core/monaco_controller_test.dart
+++ b/test/core/monaco_controller_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/core/monaco_bridge.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -902,16 +903,38 @@ void main() {
         expect(bundle.webview.executed.join('\n'), contains('forceFocus'));
       });
 
-      test('ensureEditorFocus retries multiple times', () async {
-        final bundle = await _createBundle();
-        await bundle.controller.ensureEditorFocus(
-          attempts: 3,
-          interval: Duration.zero,
-        );
-        final count = bundle.webview.executed
-            .where((s) => s.contains('forceFocus'))
-            .length;
-        expect(count, 3);
+      test('ensureEditorFocus retries multiple times on desktop', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        try {
+          final bundle = await _createBundle();
+          await bundle.controller.ensureEditorFocus(
+            attempts: 3,
+            interval: Duration.zero,
+          );
+          final count = bundle.webview.executed
+              .where((s) => s.contains('forceFocus'))
+              .length;
+          expect(count, 3);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      test('ensureEditorFocus uses one attempt on mobile', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        try {
+          final bundle = await _createBundle();
+          await bundle.controller.ensureEditorFocus(
+            attempts: 3,
+            interval: Duration.zero,
+          );
+          final count = bundle.webview.executed
+              .where((s) => s.contains('forceFocus'))
+              .length;
+          expect(count, 1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
       });
 
       test('layout calls layout', () async {

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -41,6 +41,8 @@ void main() {
     expect(source, contains('const maxLoadAttempts = 2'));
     expect(source, contains('_readyCompleter = Completer<void>();'));
     expect(source, contains("_iframe?.src = 'about:blank';"));
+    expect(source, contains("containsKey('monacoGestureDebug')"));
+    expect(source, contains('gestureDebugEnabled:'));
     expect(source, contains(r'Monaco load attempt $attempt failed, retrying'));
   });
 

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -3,9 +3,11 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  String webControllerSource() =>
+      File('lib/src/platform/web_view_controller/web.dart').readAsStringSync();
+
   test('web focus handler only amplifies Monaco focus on desktop', () {
-    final source = File('lib/src/platform/web_view_controller/web.dart')
-        .readAsStringSync();
+    final source = webControllerSource();
     final focusBlockStart = source
         .indexOf('// When Monaco reports focus, unfocus Flutter widgets.');
     final focusBlockEnd = source.indexOf('// Forward to all channels');
@@ -23,5 +25,30 @@ void main() {
     expect(source, contains('bool _isMobileInputPlatform()'));
     expect(source, contains('TargetPlatform.android'));
     expect(source, contains('TargetPlatform.iOS'));
+  });
+
+  test('web load waits for iframe attachment before assigning blob URL', () {
+    final source = webControllerSource();
+
+    expect(source, contains('await _waitForIframeAttachment();'));
+    expect(source, contains('Future<void> _waitForIframeAttachment() async'));
+    expect(source, contains('iframe.isConnected'));
+  });
+
+  test('web load retries transient Monaco iframe load failures', () {
+    final source = webControllerSource();
+
+    expect(source, contains('const maxLoadAttempts = 2'));
+    expect(source, contains('_readyCompleter = Completer<void>();'));
+    expect(source, contains("_iframe?.src = 'about:blank';"));
+    expect(source, contains(r'Monaco load attempt $attempt failed, retrying'));
+  });
+
+  test('web error messages fail the current load attempt', () {
+    final source = webControllerSource();
+
+    expect(source, contains("eventName == 'error' && !_isReady"));
+    expect(source, contains('_readyCompleter.completeError'));
+    expect(source, contains('Unknown Monaco load error'));
   });
 }

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -41,8 +41,6 @@ void main() {
     expect(source, contains('const maxLoadAttempts = 2'));
     expect(source, contains('_readyCompleter = Completer<void>();'));
     expect(source, contains("_iframe?.src = 'about:blank';"));
-    expect(source, contains("containsKey('monacoGestureDebug')"));
-    expect(source, contains('gestureDebugEnabled:'));
     expect(source, contains(r'Monaco load attempt $attempt failed, retrying'));
   });
 

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('web focus handler only amplifies Monaco focus on desktop', () {
+    final source = File('lib/src/platform/web_view_controller/web.dart')
+        .readAsStringSync();
+    final focusBlockStart = source
+        .indexOf('// When Monaco reports focus, unfocus Flutter widgets.');
+    final focusBlockEnd = source.indexOf('// Forward to all channels');
+
+    expect(focusBlockStart, isNonNegative);
+    expect(focusBlockEnd, greaterThan(focusBlockStart));
+
+    final focusBlock = source.substring(focusBlockStart, focusBlockEnd);
+    expect(
+      focusBlock,
+      contains('FocusManager.instance.primaryFocus?.unfocus();'),
+    );
+    expect(focusBlock, contains('if (!_isMobileInputPlatform())'));
+    expect(focusBlock, contains('forceFocus()'));
+    expect(source, contains('bool _isMobileInputPlatform()'));
+    expect(source, contains('TargetPlatform.android'));
+    expect(source, contains('TargetPlatform.iOS'));
+  });
+}

--- a/test/widgets/monaco_editor_test.dart
+++ b/test/widgets/monaco_editor_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -261,17 +262,40 @@ void main() {
     });
 
     group('autofocus', () {
-      testWidgets('autofocus triggers ensureEditorFocus', (tester) async {
-        final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          autofocus: true,
-        )));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
-        await tester.pumpAndSettle();
+      testWidgets('autofocus triggers ensureEditorFocus on desktop',
+          (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        try {
+          final bundle = await _createBundle();
+          await tester.pumpWidget(_wrap(MonacoEditor(
+            controller: bundle.controller,
+            autofocus: true,
+          )));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+          await tester.pumpAndSettle();
 
-        bundle.webview.assertExecuted('forceFocus');
+          bundle.webview.assertExecuted('forceFocus');
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets('autofocus skips programmatic focus on mobile',
+          (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        try {
+          final bundle = await _createBundle();
+          await tester.pumpWidget(_wrap(MonacoEditor(
+            controller: bundle.controller,
+            autofocus: true,
+          )));
+          await tester.pumpAndSettle();
+
+          bundle.webview.assertNotExecuted('forceFocus');
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
       });
 
       testWidgets('autofocus false does not trigger focus', (tester) async {

--- a/test/widgets/monaco_editor_test.dart
+++ b/test/widgets/monaco_editor_test.dart
@@ -310,6 +310,68 @@ void main() {
       });
     });
 
+    group('mobile input wrapper policy', () {
+      final monacoFocusWrapper = find.byWidgetPredicate(
+        (widget) =>
+            widget is Focus &&
+            widget.focusNode?.debugLabel == 'MonacoWebViewFocus',
+      );
+      final monacoPointerWrapper = find.byWidgetPredicate(
+        (widget) =>
+            widget is Listener &&
+            widget.behavior == HitTestBehavior.translucent,
+      );
+
+      testWidgets('mobile renders bare webview without focus wrappers',
+          (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        try {
+          final bundle = await _createBundle();
+          await tester.pumpWidget(_wrap(MonacoEditor(
+            controller: bundle.controller,
+          )));
+          await tester.pumpAndSettle();
+
+          final webview = find.byKey(const Key('webview'));
+          expect(webview, findsOneWidget);
+          expect(
+            find.ancestor(of: webview, matching: monacoFocusWrapper),
+            findsNothing,
+          );
+          expect(
+            find.ancestor(of: webview, matching: monacoPointerWrapper),
+            findsNothing,
+          );
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets('desktop keeps focus wrappers', (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        try {
+          final bundle = await _createBundle();
+          await tester.pumpWidget(_wrap(MonacoEditor(
+            controller: bundle.controller,
+          )));
+          await tester.pumpAndSettle();
+
+          final webview = find.byKey(const Key('webview'));
+          expect(webview, findsOneWidget);
+          expect(
+            find.ancestor(of: webview, matching: monacoFocusWrapper),
+            findsOneWidget,
+          );
+          expect(
+            find.ancestor(of: webview, matching: monacoPointerWrapper),
+            findsOneWidget,
+          );
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+    });
+
     group('content change callbacks', () {
       testWidgets('onContentChanged debounces non-flush events',
           (tester) async {


### PR DESCRIPTION
## Summary

This PR ships v1.6.0, combining the mobile keyboard bug-fix work (the original scope) with a new Web overlay architecture that lets Flutter widgets stacked over Monaco actually receive pointer events.

### Added
- **`MonacoOverlayBoundary`** widget and **`MonacoScaffold`** convenience wrapper for static Flutter overlays (FABs, drawers, persistent bars, custom `Stack` children) that previously had pointer events swallowed by the editor iframe on Web.
- **`MonacoController.runWithInteractionDisabled(action)`** for transient overlays (snackbars, toasts, imperative `Overlay.insert` entries) that are neither route-based nor static.
- **Internal `MonacoWebInteractionCoordinator`** that ref-counts iframe pointer-events so route overlays (`MonacoFocusGuard`) and static overlays compose without fighting each other.

### Fixed
- Soft keyboard activation on Android and iOS native (platform view owns the tap-to-input gesture path).
- Android web scroll gestures (scrolling focused Monaco no longer reopens the keyboard on release).
- Flutter Web first-load race (waits for iframe attachment, retries transient load failures).
- Example iOS runner build configuration.

### Changed
- Example app switched to `MonacoScaffold`, wired `MonacoRouteObserver` + `MonacoFocusGuard`, dropped the `pointer_interceptor` dependency.

### Docs
- Rewrote README "Web: Handling Overlays" section to cover route overlays (`MonacoFocusGuard`), static overlays (`MonacoScaffold` / `MonacoOverlayBoundary`), and transient overlays (`runWithInteractionDisabled`).

## Why a new architecture instead of `pointer_interceptor`

`pointer_interceptor` is the documented workaround for clicks over iframe-backed platform views. Its mechanism is another `HtmlElementView` (a `<div>` shield) positioned behind the child it wraps. In practice this competes with Monaco's iframe for platform-view stacking order, and the iframe can still win the browser hit-test even when each FAB is individually wrapped per the official Flutter team example.

The new approach uses a plain DOM `<div>` (not a platform view) appended directly to the Flutter host element via `ui_web.views.getHostElement(...).appendChild(...)` with `z-index: 2147483647`. Plain DOM with explicit z-index reliably beats platform views in browser hit-testing regardless of creation order, so the shield works as expected.

## Test plan

- [x] `flutter analyze` clean (root + example)
- [x] `flutter test` - 286/286 passing
- [x] `dart pub publish --dry-run` clean (0 warnings, 4 MB archive)
- [x] `pana` - 150/160 (Linux not supported by design, accounts for the lost points; meets CI's 150 minimum)
- [ ] Manual UAT in Chrome: dropdowns, dialogs, FABs all clickable over the editor
- [ ] Native regression check (macOS): no behavior change, all shields no-op