### PR TITLE
fix(web): resolve Monaco vs path from <base href> (path URL strategy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-06-20
+
+### Fixed
+- **Flutter Web: Monaco failed to load under path URL strategy (#14).** With `usePathUrlStrategy()` (or any non-root route such as GoRouter `/canvas/:id`), the bundled `vs/` URL was built from the browser route, so `loader.js` 404'd and the editor surfaced "Failed to load Monaco loader.js". Asset URLs now resolve through Flutter's asset manager against the document `<base href>`, independent of the current route - so Monaco loads correctly under deep routes, a sub-path `<base href>`, and a CDN `assetBase`.
+
 ## [1.7.0] - 2026-05-19
 
 ### Added

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -9,23 +9,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter_monaco/src/core/monaco_assets.dart';
 import 'package:flutter_monaco/src/platform/platform_webview.dart';
 import 'package:flutter_monaco/src/platform/web_interaction_coordinator.dart';
+import 'package:flutter_monaco/src/platform/web_view_controller/web_asset_resolver.dart';
 import 'package:web/web.dart' as web;
 
-/// Resolves the bundled Monaco `vs/` directory on Flutter Web.
+/// Resolves the bundled Monaco `vs/` directory URL on Flutter Web.
 ///
-/// [Uri.base] follows the browser URL, so with path URL strategy (e.g.
-/// `/canvas/:id`) resolving `assets/...` against it incorrectly yields
-/// `/canvas/.../assets/...`. Packaged assets are served from the app root
-/// implied by `<base href>` in `web/index.html`, same as other `/assets/...`
-/// scripts.
+/// Monaco's files are ordinary Flutter assets, so the URL comes from Flutter's
+/// own resolver (`ui_web.assetManager`) - the single source of truth that
+/// already honors `<base href>`, a CDN `assetBase`, a custom `assetsDir`, and
+/// URL-encoding. The resolver may return a `<base href>`-relative URL, so it is
+/// absolutized against `web.document.baseURI` - the page's `<base href>`, which
+/// (unlike the raw page URL) excludes the active single-page route under path
+/// URL strategy, so the path stays correct and still resolves inside the
+/// blob-URL iframe that hosts Monaco (see issue #14).
 String _monacoVsAssetUrl() {
-  final origin = Uri.base.origin;
-  final baseHref =
-      web.document.querySelector('base')?.getAttribute('href') ?? '/';
-  final appRoot = Uri.parse(origin).resolve(baseHref);
-  return appRoot
-      .resolve('assets/${MonacoAssets.assetBaseDir}/min/vs')
-      .toString();
+  final assetUrl =
+      ui_web.assetManager.getAssetUrl('${MonacoAssets.assetBaseDir}/min/vs');
+  return resolveWebAssetUrl(web.document.baseURI, assetUrl);
 }
 
 /// WebView implementation for Flutter Web using an iframe.

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -11,6 +11,23 @@ import 'package:flutter_monaco/src/platform/platform_webview.dart';
 import 'package:flutter_monaco/src/platform/web_interaction_coordinator.dart';
 import 'package:web/web.dart' as web;
 
+/// Resolves the bundled Monaco `vs/` directory on Flutter Web.
+///
+/// [Uri.base] follows the browser URL, so with path URL strategy (e.g.
+/// `/canvas/:id`) resolving `assets/...` against it incorrectly yields
+/// `/canvas/.../assets/...`. Packaged assets are served from the app root
+/// implied by `<base href>` in `web/index.html`, same as other `/assets/...`
+/// scripts.
+String _monacoVsAssetUrl() {
+  final origin = Uri.base.origin;
+  final baseHref =
+      web.document.querySelector('base')?.getAttribute('href') ?? '/';
+  final appRoot = Uri.parse(origin).resolve(baseHref);
+  return appRoot
+      .resolve('assets/${MonacoAssets.assetBaseDir}/min/vs')
+      .toString();
+}
+
 /// WebView implementation for Flutter Web using an iframe.
 ///
 /// On web platforms, native WebViews aren't available, so Monaco is hosted
@@ -292,10 +309,7 @@ class WebViewController implements PlatformWebViewController {
     debugPrint('[WebViewController] Loading Monaco in iframe');
     await _waitForIframeAttachment();
 
-    // Resolve path against base URI to support subpaths
-    final vsPath = Uri.base
-        .resolve('assets/${MonacoAssets.assetBaseDir}/min/vs')
-        .toString();
+    final vsPath = _monacoVsAssetUrl();
 
     Object? lastError;
     const maxLoadAttempts = 2;

--- a/lib/src/platform/web_view_controller/web_asset_resolver.dart
+++ b/lib/src/platform/web_view_controller/web_asset_resolver.dart
@@ -1,0 +1,15 @@
+/// Resolves a Flutter Web asset URL to an absolute URL.
+///
+/// [assetUrl] is the value `ui_web.assetManager.getAssetUrl` returns for a
+/// packaged asset: either already absolute (when a CDN `assetBase` is
+/// configured through `initializeEngine`) or relative to `<base href>` (the
+/// default). [documentBaseUri] must be `web.document.baseURI` - the page's
+/// `<base href>` - and not `Uri.base`, which carries the active single-page
+/// route under path URL strategy and would nest the asset under that route
+/// (see issue #14).
+///
+/// Resolution follows the same rules the browser applies to every other asset
+/// reference, so an absolute [assetUrl] is returned unchanged and a relative
+/// one is anchored at the app root.
+String resolveWebAssetUrl(String documentBaseUri, String assetUrl) =>
+    Uri.parse(documentBaseUri).resolve(assetUrl).toString();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 1.7.0
+version: 1.7.1
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/platform/web_asset_resolver_test.dart
+++ b/test/platform/web_asset_resolver_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_monaco/src/platform/web_view_controller/web_asset_resolver.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // The URL ui_web.assetManager.getAssetUrl returns by default for Monaco's
+  // bundled vs/ directory: relative to <base href>, no leading slash.
+  const monacoVsAssetUrl =
+      'assets/packages/flutter_monaco/assets/monaco/min/vs';
+
+  group('resolveWebAssetUrl', () {
+    test(
+      'resolves against the document base URI, ignoring the SPA route (#14)',
+      () {
+        // Under usePathUrlStrategy(), Uri.base carries the route (e.g.
+        // /canvas/123) while web.document.baseURI is the <base href> root.
+        // Resolving the asset against the route would nest it under the route
+        // - this is the original bug:
+        expect(
+          resolveWebAssetUrl(
+            'https://app.example/canvas/123',
+            monacoVsAssetUrl,
+          ),
+          'https://app.example/canvas/$monacoVsAssetUrl',
+        );
+        // Resolving against the document base URI (what the fix passes) yields
+        // the correct root-relative asset URL, independent of the route:
+        expect(
+          resolveWebAssetUrl('https://app.example/', monacoVsAssetUrl),
+          'https://app.example/$monacoVsAssetUrl',
+        );
+      },
+    );
+
+    test('honors a non-root <base href> (sub-path deployment)', () {
+      expect(
+        resolveWebAssetUrl('https://app.example/app/', monacoVsAssetUrl),
+        'https://app.example/app/$monacoVsAssetUrl',
+      );
+    });
+
+    test('passes through an absolute asset URL (CDN assetBase)', () {
+      const cdnAssetUrl =
+          'https://cdn.example/x/assets/packages/flutter_monaco/assets/monaco/min/vs';
+      expect(
+        resolveWebAssetUrl('https://app.example/', cdnAssetUrl),
+        cdnAssetUrl,
+      );
+    });
+  });
+}

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -52,15 +52,18 @@ void main() {
     expect(source, contains('Unknown Monaco load error'));
   });
 
-  test('web Monaco vs path uses base href, not full route Uri.base', () {
+  test(
+      'web Monaco vs path resolves via the Flutter asset manager, not '
+      'Uri.base', () {
     final source = webControllerSource();
 
     expect(source, contains('String _monacoVsAssetUrl()'));
     expect(source, contains('final vsPath = _monacoVsAssetUrl();'));
-    expect(source, contains("querySelector('base')"));
-    expect(
-      source,
-      isNot(contains('Uri.base\n        .resolve(')),
-    );
+    // Delegate to Flutter's own asset resolver (the single source of truth)
+    // and absolutize against the document base href, not the SPA route.
+    expect(source, contains('ui_web.assetManager.getAssetUrl('));
+    expect(source, contains('resolveWebAssetUrl(web.document.baseURI'));
+    // The route-bearing Uri.base must never drive asset resolution (#14).
+    expect(source, isNot(contains('Uri.base')));
   });
 }

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -51,4 +51,16 @@ void main() {
     expect(source, contains('_readyCompleter.completeError'));
     expect(source, contains('Unknown Monaco load error'));
   });
+
+  test('web Monaco vs path uses base href, not full route Uri.base', () {
+    final source = webControllerSource();
+
+    expect(source, contains('String _monacoVsAssetUrl()'));
+    expect(source, contains('final vsPath = _monacoVsAssetUrl();'));
+    expect(source, contains("querySelector('base')"));
+    expect(
+      source,
+      isNot(contains('Uri.base\n        .resolve(')),
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- Fixes **#14**: on Flutter Web with **path URL strategy**, `Uri.base` includes the SPA route, so `Uri.base.resolve('assets/...')` pointed `loader.js` at the wrong URL and Monaco failed to initialize.
- Resolve `vs/` from **`Uri.base.origin` + `<base href>`** + `assets/${MonacoAssets.assetBaseDir}/min/vs`, matching how Flutter web serves packaged assets.
- Add a small **source regression test** so the old `Uri.base` + multi-line `.resolve(` pattern does not return.

## Test plan
- [x] `flutter test test/platform/web_view_controller_web_source_test.dart`
- [x] `dart analyze lib/src/platform/web_view_controller/web.dart`

Fixes #14

Made with [Cursor](https://cursor.com)