### PR TITLE
Fix showcase Monaco iframe layout

### DIFF
--- a/example/lib/showcase/sections/playground_section.dart
+++ b/example/lib/showcase/sections/playground_section.dart
@@ -86,33 +86,28 @@ class _EditorCard extends StatelessWidget {
           ),
         ],
       ),
-      clipBehavior: Clip.antiAlias,
       child: Column(
         children: [
           _Toolbar(controller: controller),
           Divider(height: 1, color: c.border),
+          // Keep the iframe-backed HtmlElementView as a direct sized child.
+          // In the web showcase, Stack/Positioned.fill collapses its DOM rect.
           SizedBox(
             height: editorHeight,
-            child: Stack(
-              children: [
-                Positioned.fill(
-                  child: MonacoEditor(
-                    key: const ValueKey('showcase-playground-editor'),
-                    options: controller.initialEditorOptions,
-                    initialValue: controller.initialValue,
-                    customCss: kEditorCustomCss,
-                    backgroundColor: const Color(0xFF0D1117),
-                    onReady: controller.attachEditor,
-                  ),
-                ),
-                if (monaco != null)
-                  MonacoFocusGuard(
-                    controller: monaco,
-                    modalRouteObserver: routeObserver,
-                  ),
-              ],
+            child: MonacoEditor(
+              key: const ValueKey('showcase-playground-editor'),
+              options: controller.initialEditorOptions,
+              initialValue: controller.initialValue,
+              customCss: kEditorCustomCss,
+              backgroundColor: const Color(0xFF0D1117),
+              onReady: controller.attachEditor,
             ),
           ),
+          if (monaco != null)
+            MonacoFocusGuard(
+              controller: monaco,
+              modalRouteObserver: routeObserver,
+            ),
           if (controller.hint != null)
             _HintBanner(
               hint: controller.hint!,

--- a/test/showcase/playground_layout_source_test.dart
+++ b/test/showcase/playground_layout_source_test.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('showcase lays MonacoEditor out as a direct sized child', () {
+    final source = File(
+      'example/lib/showcase/sections/playground_section.dart',
+    ).readAsStringSync();
+    final editorStart = source.indexOf('child: MonacoEditor(');
+    expect(editorStart, isNonNegative);
+
+    final sizedBoxStart = source.lastIndexOf('SizedBox(', editorStart);
+    final guardStart = source.indexOf('if (monaco != null)', editorStart);
+    expect(sizedBoxStart, isNonNegative);
+    expect(guardStart, greaterThan(editorStart));
+
+    final editorLayout = source.substring(sizedBoxStart, guardStart);
+    expect(editorLayout, contains('height: editorHeight'));
+    expect(editorLayout, isNot(contains('Stack(')));
+    expect(editorLayout, isNot(contains('Positioned.fill')));
+  });
+}


### PR DESCRIPTION
## Summary
- Lay out the showcase Monaco editor as a direct sized child so Flutter Web gives the iframe a real DOM rect.
- Keep the focus guard as a zero-size sibling after the editor.
- Add a regression test that prevents wrapping the iframe-backed editor in Stack/Positioned.fill again.

## Root cause
The deployed showcase put MonacoEditor inside Stack/Positioned.fill. In the web build that left the HtmlElementView host at 0 x 0, so Monaco loaded but could not receive pointer or keyboard input.

## Validation
- dart analyze
- flutter test
- flutter build web --release --wasm -t lib/showcase/main.dart
- Local browser probe confirmed iframe 1118 x 520 and typed text reached Monaco.