### PR TITLE
Prepare 2.0.0 focus and Windows release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2026-06-20
 
+### Changed
+- Raised the minimum supported SDK to Dart 3.12 and Flutter 3.44, and moved Windows support to the maintained `webview_flutter_windows` package.
+
 ### Fixed
-- Mobile Safari on Flutter Web: touch scrolling inside the editor no longer pans the host page (#11). The generated editor document and the host iframe statically declare `touch-action: none` and `overscroll-behavior: none`, so touches Monaco does not claim can no longer chain out of the frame.
+- Windows editor focus now recovers after native-focus loss, avoids replaying focus on right-click or repeated clicks, and no longer steals the keyboard from focused Flutter text inputs.
+- Mobile Safari on Flutter Web: touch scrolling inside the editor no longer pans the host page (#11). The generated editor document and the host iframe statically declare `touch-action: none` and `overscroll-behavior: none`, so touches that Monaco does not claim can no longer chain out of the frame.
 - Mobile web soft keyboard (#11): while the keyboard constrains the browser's visual viewport, the editor now pins itself to the visible part of its frame and keeps the caret revealed.
 - iOS/macOS worker bootstrap: the WKWebView worker shim now emits escaped newline sequences inside JavaScript string literals, so Monaco language workers load instead of falling back to the main thread.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-06-20
+
+### Fixed
+- Mobile Safari on Flutter Web: touch scrolling inside the editor no longer pans the host page (#11). The generated editor document and the host iframe statically declare `touch-action: none` and `overscroll-behavior: none`, so touches Monaco does not claim can no longer chain out of the frame.
+- Mobile web soft keyboard (#11): while the keyboard constrains the browser's visual viewport, the editor now pins itself to the visible part of its frame and keeps the caret revealed.
+- iOS/macOS worker bootstrap: the WKWebView worker shim now emits escaped newline sequences inside JavaScript string literals, so Monaco language workers load instead of falling back to the main thread.
+
 ## [1.7.1] - 2026-06-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,10 +58,6 @@ Check the [live demo here](https://omar-hanafy.github.io/flutter-monaco/) to try
   </tr>
 </table>
 
-## Known Issues
-
-- **Windows window focus flicker.** When clicking inside the embedded WebView (Monaco) on Windows, the host Flutter window may momentarily lose activation, which disables global keyboard shortcuts until the next click. This is a `flutter_webview_windows`/WebView2 quirk tracked upstream in [jnschulze/flutter-webview-windows#230](https://github.com/jnschulze/flutter-webview-windows/issues/230). We are monitoring that issue and will adopt the upstream fix as soon as it lands. Other platforms are unaffected.
-
 ## Installation
 
 Add `flutter_monaco` to your `pubspec.yaml`:
@@ -824,7 +820,7 @@ The plugin uses a versioned cache system:
 - **Android**: WebView via `webview_flutter`
 - **iOS**: WKWebView with automatic blob worker shim for file:// protocol
 - **macOS**: WKWebView via `webview_flutter` with blob worker shim
-- **Windows**: WebView2 via `webview_windows` (requires WebView2 Runtime)
+- **Windows**: WebView2 via `webview_flutter_windows` (requires WebView2 Runtime)
 - **Web**: Native iframe-based integration with Monaco assets served from Flutter's asset bundle
 
 **Not Supported:**
@@ -839,6 +835,8 @@ The plugin uses a versioned cache system:
 - **Workers**: Web Workers run in separate threads for syntax highlighting
 
 ## Requirements
+
+- Flutter 3.44 / Dart 3.12 or later
 
 ### macOS
 

--- a/README.md
+++ b/README.md
@@ -910,6 +910,19 @@ This pattern works on all platforms and is the recommended approach. The `Monaco
 - Calling `create()` in `initState` (before `build`) can cause a timeout
 - Native platforms do not have this constraint because WebView initialization is different
 
+### Mobile browsers (iOS Safari, Android Chrome)
+
+No configuration is needed; the package handles both of these automatically:
+
+- **Scroll containment.** The editor document declares `touch-action: none` and
+  `overscroll-behavior: none`, so touch scrolling inside the editor moves
+  Monaco's content and never pans the surrounding Flutter page - including
+  touches that start on the line-number margin or a scrollbar.
+- **Soft keyboard fit.** While the on-screen keyboard constrains the browser's
+  visual viewport, the editor pins itself to the visible part of its frame and
+  keeps the caret revealed, so the first and last lines stay reachable. The
+  normal layout is restored when the keyboard closes.
+
 ## Example App
 
 ### Live Web Demo

--- a/example/lib/complete_example.dart
+++ b/example/lib/complete_example.dart
@@ -132,10 +132,7 @@ class _MonacoExamplePageState extends State<MonacoExamplePage> {
   Future<void> _registerCompletionSources(MonacoController controller) async {
     await controller.registerStaticCompletions(
       id: 'keywords',
-      languages: [
-        MonacoLanguage.dart.id,
-        MonacoLanguage.javascript.id,
-      ],
+      languages: [MonacoLanguage.dart.id, MonacoLanguage.javascript.id],
       triggerCharacters: const [' ', '.'],
       items: _keywordCompletions,
     );
@@ -198,7 +195,9 @@ class _MonacoExamplePageState extends State<MonacoExamplePage> {
             itemBuilder: (context) => [
               const PopupMenuItem(value: 'dart', child: Text('Dart')),
               const PopupMenuItem(
-                  value: 'javascript', child: Text('JavaScript')),
+                value: 'javascript',
+                child: Text('JavaScript'),
+              ),
               const PopupMenuItem(value: 'python', child: Text('Python')),
               const PopupMenuItem(value: 'markdown', child: Text('Markdown')),
               const PopupMenuItem(value: 'json', child: Text('JSON')),
@@ -218,7 +217,9 @@ class _MonacoExamplePageState extends State<MonacoExamplePage> {
               const PopupMenuItem(value: 'vs-dark', child: Text('Dark')),
               const PopupMenuItem(value: 'vs', child: Text('Light')),
               const PopupMenuItem(
-                  value: 'hc-black', child: Text('High Contrast')),
+                value: 'hc-black',
+                child: Text('High Contrast'),
+              ),
             ],
           ),
           // Format button
@@ -268,15 +269,13 @@ class _MonacoExamplePageState extends State<MonacoExamplePage> {
             child: _isLoading
                 ? const Center(child: CircularProgressIndicator())
                 : _controller != null
-                    ? MonacoEditor(
-                        controller: _controller!,
-                        onReady: (controller) {
-                          debugPrint('Monaco Editor is ready!');
-                        },
-                      )
-                    : const Center(
-                        child: Text('Failed to initialize editor'),
-                      ),
+                ? MonacoEditor(
+                    controller: _controller!,
+                    onReady: (controller) {
+                      debugPrint('Monaco Editor is ready!');
+                    },
+                  )
+                : const Center(child: Text('Failed to initialize editor')),
           ),
         ],
       ),
@@ -343,8 +342,12 @@ class _MonacoExamplePageState extends State<MonacoExamplePage> {
                   builder: (context) => AlertDialog(
                     title: const Text('Editor Content'),
                     content: SingleChildScrollView(
-                      child: Text(content.substring(
-                          0, content.length > 500 ? 500 : content.length)),
+                      child: Text(
+                        content.substring(
+                          0,
+                          content.length > 500 ? 500 : content.length,
+                        ),
+                      ),
                     ),
                     actions: [
                       TextButton(

--- a/example/lib/custom_font_example.dart
+++ b/example/lib/custom_font_example.dart
@@ -144,7 +144,8 @@ const features = {
           theme: MonacoTheme.vsDark,
           language: MonacoLanguage.javascript,
         ),
-        customCss: '''
+        customCss:
+            '''
           @font-face {
             font-family: 'MyCustomFont';
             src: url('data:font/woff2;base64,$mockBase64Font') format('woff2');
@@ -212,37 +213,38 @@ function secureCustomFont() {
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : _error != null
-              ? Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Icon(Icons.error, size: 48, color: Colors.red),
-                      const SizedBox(height: 16),
-                      Text('Error: $_error'),
-                      const SizedBox(height: 16),
-                      ElevatedButton(
-                        onPressed: _initializeEditor,
-                        child: const Text('Retry'),
-                      ),
-                    ],
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error, size: 48, color: Colors.red),
+                  const SizedBox(height: 16),
+                  Text('Error: $_error'),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: _initializeEditor,
+                    child: const Text('Retry'),
                   ),
-                )
-              : Column(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(8),
-                      color: Colors.blue.shade100,
-                      child: const Text(
-                        'Tip: Install Fira Code or JetBrains Mono font on your system to see ligatures!',
-                        style: TextStyle(fontSize: 12),
-                      ),
-                    ),
-                    Expanded(
-                      child: _controller?.webViewWidget ??
-                          const Center(child: Text('No editor')),
-                    ),
-                  ],
+                ],
+              ),
+            )
+          : Column(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(8),
+                  color: Colors.blue.shade100,
+                  child: const Text(
+                    'Tip: Install Fira Code or JetBrains Mono font on your system to see ligatures!',
+                    style: TextStyle(fontSize: 12),
+                  ),
                 ),
+                Expanded(
+                  child:
+                      _controller?.webViewWidget ??
+                      const Center(child: Text('No editor')),
+                ),
+              ],
+            ),
     );
   }
 }

--- a/example/lib/focus_test_example.dart
+++ b/example/lib/focus_test_example.dart
@@ -12,8 +12,9 @@ class FocusTestExample extends StatefulWidget {
 
 class _FocusTestExampleState extends State<FocusTestExample> {
   MonacoController? _controller;
-  final _textController =
-      TextEditingController(text: 'Flutter TextField content');
+  final _textController = TextEditingController(
+    text: 'Flutter TextField content',
+  );
 
   @override
   void initState() {
@@ -29,8 +30,9 @@ class _FocusTestExampleState extends State<FocusTestExample> {
         fontSize: 14,
       ),
     );
-    await _controller!
-        .setValue('// Monaco Editor\nlet message = "Hello World";');
+    await _controller!.setValue(
+      '// Monaco Editor\nlet message = "Hello World";',
+    );
     setState(() {});
   }
 
@@ -61,7 +63,8 @@ class _FocusTestExampleState extends State<FocusTestExample> {
               children: [
                 // Left: Monaco Editor
                 Expanded(
-                  child: _controller?.webViewWidget ??
+                  child:
+                      _controller?.webViewWidget ??
                       const Center(child: CircularProgressIndicator()),
                 ),
                 const VerticalDivider(width: 1),
@@ -113,8 +116,9 @@ class _FocusTestExampleState extends State<FocusTestExample> {
                       Navigator.pop(context);
                       // Send dialog text to Monaco
                       final current = await _controller?.getValue() ?? '';
-                      await _controller
-                          ?.setValue('$current\n// From dialog: $dialogText');
+                      await _controller?.setValue(
+                        '$current\n// From dialog: $dialogText',
+                      );
                     },
                     child: const Text('Send to Monaco'),
                   ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,14 +10,8 @@ void main() {
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Flutter Monaco Editor'),
-        ),
-        body: const SafeArea(
-          child: MonacoEditor(
-            showStatusBar: true,
-          ),
-        ),
+        appBar: AppBar(title: const Text('Flutter Monaco Editor')),
+        body: const SafeArea(child: MonacoEditor(showStatusBar: true)),
       ),
     ),
   );

--- a/example/lib/multi_editor_example.dart
+++ b/example/lib/multi_editor_example.dart
@@ -128,8 +128,9 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
             tooltip: 'Copy Dart → JS',
             onPressed: () async {
               final content = await _leftController!.getValue();
-              await _rightController!
-                  .setValue('// Copied from Dart editor:\n/*\n$content\n*/');
+              await _rightController!.setValue(
+                '// Copied from Dart editor:\n/*\n$content\n*/',
+              );
             },
           ),
           // Copy from right to left
@@ -138,8 +139,9 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
             tooltip: 'Copy JS → Dart',
             onPressed: () async {
               final content = await _rightController!.getValue();
-              await _leftController!
-                  .setValue('// Copied from JS editor:\n/*\n$content\n*/');
+              await _leftController!.setValue(
+                '// Copied from JS editor:\n/*\n$content\n*/',
+              );
             },
           ),
           // Sync themes
@@ -157,7 +159,9 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
               const PopupMenuItem(value: 'vs-dark', child: Text('All Dark')),
               const PopupMenuItem(value: 'vs', child: Text('All Light')),
               const PopupMenuItem(
-                  value: 'hc-black', child: Text('All High Contrast')),
+                value: 'hc-black',
+                child: Text('All High Contrast'),
+              ),
             ],
           ),
         ],
@@ -191,9 +195,7 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
                         _leftController!,
                         Colors.blue,
                       ),
-                      Expanded(
-                        child: _leftController!.webViewWidget,
-                      ),
+                      Expanded(child: _leftController!.webViewWidget),
                     ],
                   ),
                 ),
@@ -207,9 +209,7 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
                         _rightController!,
                         Colors.orange,
                       ),
-                      Expanded(
-                        child: _rightController!.webViewWidget,
-                      ),
+                      Expanded(child: _rightController!.webViewWidget),
                     ],
                   ),
                 ),
@@ -227,9 +227,7 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
                   _bottomController!,
                   Colors.green,
                 ),
-                Expanded(
-                  child: _bottomController!.webViewWidget,
-                ),
+                Expanded(child: _bottomController!.webViewWidget),
               ],
             ),
           ),
@@ -293,10 +291,7 @@ class _MultiEditorExampleState extends State<MultiEditorExample> {
           const SizedBox(width: 8),
           Text(
             title,
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-              color: color,
-            ),
+            style: TextStyle(fontWeight: FontWeight.bold, color: color),
           ),
           const Spacer(),
           // Live stats

--- a/example/lib/showcase/data/demo_snippets.dart
+++ b/example/lib/showcase/data/demo_snippets.dart
@@ -10,7 +10,10 @@ final MonacoThemeDefinition kMidnightTheme = MonacoThemeDefinition(
   base: MonacoTheme.vsDark,
   rules: const [
     MonacoThemeRule(
-        token: 'comment', foreground: '6E7681', fontStyle: 'italic'),
+      token: 'comment',
+      foreground: '6E7681',
+      fontStyle: 'italic',
+    ),
     MonacoThemeRule(token: 'keyword', foreground: '6E5BFF'),
     MonacoThemeRule(token: 'string', foreground: '00D8FF'),
     MonacoThemeRule(token: 'number', foreground: '7EE787'),

--- a/example/lib/showcase/sections/features_section.dart
+++ b/example/lib/showcase/sections/features_section.dart
@@ -27,7 +27,8 @@ class FeaturesSection extends StatelessWidget {
       FeatureCard(
         icon: Icons.translate_rounded,
         title: '100+ languages',
-        body: 'Syntax highlighting for Dart, TypeScript, Python, Rust, Go, '
+        body:
+            'Syntax highlighting for Dart, TypeScript, Python, Rust, Go, '
             'SQL and 100+ more - switch instantly.',
         snippet: 'controller.setLanguage(MonacoLanguage.rust);',
         onTry: () => _go(() => controller.setLanguage(MonacoLanguage.rust)),
@@ -35,7 +36,8 @@ class FeaturesSection extends StatelessWidget {
       FeatureCard(
         icon: Icons.palette_outlined,
         title: 'Theming',
-        body: 'Four built-in themes, or register your own token colors with '
+        body:
+            'Four built-in themes, or register your own token colors with '
             'defineTheme.',
         snippet: 'controller.defineTheme(midnightTheme);',
         onTry: () =>
@@ -51,7 +53,8 @@ class FeaturesSection extends StatelessWidget {
       FeatureCard(
         icon: Icons.fact_check_outlined,
         title: 'JSON schema validation',
-        body: 'Live diagnostics and JSON schema validation, configured in a '
+        body:
+            'Live diagnostics and JSON schema validation, configured in a '
             'single call.',
         snippet: 'controller.setJsonDiagnostics(options);',
         onTry: () => _go(controller.runJsonValidationDemo),
@@ -66,7 +69,8 @@ class FeaturesSection extends StatelessWidget {
       FeatureCard(
         icon: Icons.terminal_rounded,
         title: 'Full controller API',
-        body: 'getValue, edits, find/replace, folding, live stats and much '
+        body:
+            'getValue, edits, find/replace, folding, live stats and much '
             'more.',
         snippet: 'final code = await controller.getValue();',
         onTry: () => _go(controller.runDecorationsDemo),
@@ -78,8 +82,10 @@ class FeaturesSection extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Everything the editor can do',
-              style: ShowcaseText.h1.copyWith(color: c.textPrimary)),
+          Text(
+            'Everything the editor can do',
+            style: ShowcaseText.h1.copyWith(color: c.textPrimary),
+          ),
           const SizedBox(height: Insets.md),
           ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 620),
@@ -96,8 +102,8 @@ class FeaturesSection extends StatelessWidget {
               final columns = width >= Breakpoints.desktop
                   ? 3
                   : width >= Breakpoints.tablet
-                      ? 2
-                      : 1;
+                  ? 2
+                  : 1;
               const gap = Insets.lg;
               final itemWidth = (width - gap * (columns - 1)) / columns;
               return Wrap(

--- a/example/lib/showcase/sections/get_started_section.dart
+++ b/example/lib/showcase/sections/get_started_section.dart
@@ -35,13 +35,16 @@ class GetStartedSection extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Get started in seconds',
-              style: ShowcaseText.h1.copyWith(color: c.textPrimary)),
+          Text(
+            'Get started in seconds',
+            style: ShowcaseText.h1.copyWith(color: c.textPrimary),
+          ),
           const SizedBox(height: Insets.md),
           Text(
-              'Add the package, drop in the widget, and you have a working '
-              'editor.',
-              style: ShowcaseText.bodyLg.copyWith(color: c.textSecondary)),
+            'Add the package, drop in the widget, and you have a working '
+            'editor.',
+            style: ShowcaseText.bodyLg.copyWith(color: c.textSecondary),
+          ),
           const SizedBox(height: Insets.xl),
           const _Step(
             number: 1,
@@ -102,13 +105,13 @@ class _Step extends StatelessWidget {
                   gradient: accentGradient,
                   shape: BoxShape.circle,
                 ),
-                child: Text('$number',
-                    style: ShowcaseText.label.copyWith(color: Colors.white)),
+                child: Text(
+                  '$number',
+                  style: ShowcaseText.label.copyWith(color: Colors.white),
+                ),
               ),
               if (!isLast)
-                Expanded(
-                  child: Container(width: 2, color: c.border),
-                ),
+                Expanded(child: Container(width: 2, color: c.border)),
             ],
           ),
           const SizedBox(width: Insets.md),
@@ -120,8 +123,10 @@ class _Step extends StatelessWidget {
                 children: [
                   Padding(
                     padding: const EdgeInsets.only(top: 6, bottom: Insets.md),
-                    child: Text(title,
-                        style: ShowcaseText.h3.copyWith(color: c.textPrimary)),
+                    child: Text(
+                      title,
+                      style: ShowcaseText.h3.copyWith(color: c.textPrimary),
+                    ),
                   ),
                   child,
                 ],

--- a/example/lib/showcase/sections/hero_section.dart
+++ b/example/lib/showcase/sections/hero_section.dart
@@ -35,20 +35,22 @@ class HeroSection extends StatelessWidget {
               const SizedBox(height: Insets.lg),
               Text(
                 "VS Code's editor,",
-                style: (headlineSize != null
-                        ? headlineTop.copyWith(fontSize: headlineSize)
-                        : headlineTop)
-                    .copyWith(color: c.textPrimary),
+                style:
+                    (headlineSize != null
+                            ? headlineTop.copyWith(fontSize: headlineSize)
+                            : headlineTop)
+                        .copyWith(color: c.textPrimary),
               ),
               ShaderMask(
                 shaderCallback: (bounds) => accentGradient.createShader(bounds),
                 blendMode: BlendMode.srcIn,
                 child: Text(
                   'inside your Flutter app.',
-                  style: (headlineSize != null
-                          ? headlineTop.copyWith(fontSize: headlineSize)
-                          : headlineTop)
-                      .copyWith(color: Colors.white),
+                  style:
+                      (headlineSize != null
+                              ? headlineTop.copyWith(fontSize: headlineSize)
+                              : headlineTop)
+                          .copyWith(color: Colors.white),
                 ),
               ),
               const SizedBox(height: Insets.lg),
@@ -108,12 +110,15 @@ class _EyebrowPill extends StatelessWidget {
     final c = context.showcaseColors;
     return Container(
       padding: const EdgeInsets.symmetric(
-          horizontal: Insets.md, vertical: Insets.sm),
+        horizontal: Insets.md,
+        vertical: Insets.sm,
+      ),
       decoration: BoxDecoration(
         color: c.accentWash,
         borderRadius: BorderRadius.circular(Radii.pill),
-        border:
-            Border.all(color: ShowcaseColors.accentBlue.withValues(alpha: 0.3)),
+        border: Border.all(
+          color: ShowcaseColors.accentBlue.withValues(alpha: 0.3),
+        ),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -121,10 +126,13 @@ class _EyebrowPill extends StatelessWidget {
           const Icon(Icons.bolt, size: 14, color: ShowcaseColors.accentBlue),
           const SizedBox(width: 6),
           Flexible(
-            child: Text(text,
-                overflow: TextOverflow.ellipsis,
-                style: ShowcaseText.eyebrow
-                    .copyWith(color: ShowcaseColors.accentBlue)),
+            child: Text(
+              text,
+              overflow: TextOverflow.ellipsis,
+              style: ShowcaseText.eyebrow.copyWith(
+                color: ShowcaseColors.accentBlue,
+              ),
+            ),
           ),
         ],
       ),

--- a/example/lib/showcase/sections/playground_section.dart
+++ b/example/lib/showcase/sections/playground_section.dart
@@ -28,20 +28,23 @@ class PlaygroundSection extends StatelessWidget {
     final editorHeight = Breakpoints.isMobile(width)
         ? 380.0
         : Breakpoints.isTablet(width)
-            ? 460.0
-            : 520.0;
+        ? 460.0
+        : 520.0;
 
     return SectionContainer(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Live playground',
-              style: ShowcaseText.h1.copyWith(color: c.textPrimary)),
+          Text(
+            'Live playground',
+            style: ShowcaseText.h1.copyWith(color: c.textPrimary),
+          ),
           const SizedBox(height: Insets.md),
           Text(
-              'Real Monaco, running right here. Switch languages and themes, '
-              'toggle options, or trigger a feature - it all drives one editor.',
-              style: ShowcaseText.bodyLg.copyWith(color: c.textSecondary)),
+            'Real Monaco, running right here. Switch languages and themes, '
+            'toggle options, or trigger a feature - it all drives one editor.',
+            style: ShowcaseText.bodyLg.copyWith(color: c.textSecondary),
+          ),
           const SizedBox(height: Insets.xl),
           _EditorCard(
             controller: controller,
@@ -109,10 +112,7 @@ class _EditorCard extends StatelessWidget {
               modalRouteObserver: routeObserver,
             ),
           if (controller.hint != null)
-            _HintBanner(
-              hint: controller.hint!,
-              onClose: controller.reset,
-            ),
+            _HintBanner(hint: controller.hint!, onClose: controller.reset),
           Divider(height: 1, color: c.border),
           _LiveStatsBar(controller: controller),
         ],
@@ -147,7 +147,9 @@ class _Toolbar extends StatelessWidget {
     return Container(
       color: c.surfaceAlt,
       padding: const EdgeInsets.symmetric(
-          horizontal: Insets.md, vertical: Insets.sm),
+        horizontal: Insets.md,
+        vertical: Insets.sm,
+      ),
       child: Wrap(
         spacing: Insets.sm,
         runSpacing: Insets.sm,
@@ -156,39 +158,40 @@ class _Toolbar extends StatelessWidget {
           _ToolbarMenu<MonacoLanguage>(
             icon: Icons.translate_rounded,
             value: controller.language,
-            entries: [
-              for (final l in kPlaygroundLanguages) (l, l.label),
-            ],
+            entries: [for (final l in kPlaygroundLanguages) (l, l.label)],
             onSelected: controller.setLanguage,
           ),
           _ToolbarMenu<PlaygroundTheme>(
             icon: Icons.palette_outlined,
             value: controller.playgroundTheme,
-            entries: [
-              for (final t in PlaygroundTheme.values) (t, t.label),
-            ],
+            entries: [for (final t in PlaygroundTheme.values) (t, t.label)],
             onSelected: controller.setPlaygroundTheme,
           ),
           _ToolbarAction(
-              icon: Icons.format_align_left_rounded,
-              tooltip: 'Format',
-              onTap: controller.format),
+            icon: Icons.format_align_left_rounded,
+            tooltip: 'Format',
+            onTap: controller.format,
+          ),
           _ToolbarAction(
-              icon: Icons.search_rounded,
-              tooltip: 'Find',
-              onTap: controller.find),
+            icon: Icons.search_rounded,
+            tooltip: 'Find',
+            onTap: controller.find,
+          ),
           _ToolbarAction(
-              icon: Icons.unfold_less_rounded,
-              tooltip: 'Fold all',
-              onTap: controller.foldAll),
+            icon: Icons.unfold_less_rounded,
+            tooltip: 'Fold all',
+            onTap: controller.foldAll,
+          ),
           _ToolbarAction(
-              icon: Icons.content_copy_rounded,
-              tooltip: 'Copy',
-              onTap: () => _copy(context)),
+            icon: Icons.content_copy_rounded,
+            tooltip: 'Copy',
+            onTap: () => _copy(context),
+          ),
           _ToolbarAction(
-              icon: Icons.restart_alt_rounded,
-              tooltip: 'Reset',
-              onTap: controller.reset),
+            icon: Icons.restart_alt_rounded,
+            tooltip: 'Reset',
+            onTap: controller.reset,
+          ),
         ],
       ),
     );
@@ -230,21 +233,27 @@ class _ToolbarMenu<T> extends StatelessWidget {
             height: 40,
             child: Row(
               children: [
-                Icon(Icons.check,
-                    size: 16,
-                    color: v == value
-                        ? ShowcaseColors.accentBlue
-                        : Colors.transparent),
+                Icon(
+                  Icons.check,
+                  size: 16,
+                  color: v == value
+                      ? ShowcaseColors.accentBlue
+                      : Colors.transparent,
+                ),
                 const SizedBox(width: Insets.sm),
-                Text(label,
-                    style: ShowcaseText.small.copyWith(color: c.textPrimary)),
+                Text(
+                  label,
+                  style: ShowcaseText.small.copyWith(color: c.textPrimary),
+                ),
               ],
             ),
           ),
       ],
       child: Container(
         padding: const EdgeInsets.symmetric(
-            horizontal: Insets.md, vertical: Insets.sm),
+          horizontal: Insets.md,
+          vertical: Insets.sm,
+        ),
         decoration: BoxDecoration(
           color: c.surface,
           borderRadius: BorderRadius.circular(Radii.sm),
@@ -255,8 +264,10 @@ class _ToolbarMenu<T> extends StatelessWidget {
           children: [
             Icon(icon, size: 16, color: c.textSecondary),
             const SizedBox(width: 6),
-            Text(_currentLabel,
-                style: ShowcaseText.small.copyWith(color: c.textPrimary)),
+            Text(
+              _currentLabel,
+              style: ShowcaseText.small.copyWith(color: c.textPrimary),
+            ),
             const SizedBox(width: 2),
             Icon(Icons.arrow_drop_down, size: 18, color: c.textFaint),
           ],
@@ -309,8 +320,10 @@ class _OptionsRow extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('EDITOR OPTIONS',
-            style: ShowcaseText.label.copyWith(color: c.textFaint)),
+        Text(
+          'EDITOR OPTIONS',
+          style: ShowcaseText.label.copyWith(color: c.textFaint),
+        ),
         const SizedBox(height: Insets.md),
         Wrap(
           spacing: Insets.sm,
@@ -318,25 +331,29 @@ class _OptionsRow extends StatelessWidget {
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
             _ToggleChip(
-                icon: Icons.map_outlined,
-                label: 'Minimap',
-                value: controller.minimap,
-                onChanged: controller.setMinimap),
+              icon: Icons.map_outlined,
+              label: 'Minimap',
+              value: controller.minimap,
+              onChanged: controller.setMinimap,
+            ),
             _ToggleChip(
-                icon: Icons.wrap_text_rounded,
-                label: 'Word wrap',
-                value: controller.wordWrap,
-                onChanged: controller.setWordWrap),
+              icon: Icons.wrap_text_rounded,
+              label: 'Word wrap',
+              value: controller.wordWrap,
+              onChanged: controller.setWordWrap,
+            ),
             _ToggleChip(
-                icon: Icons.format_list_numbered_rounded,
-                label: 'Line numbers',
-                value: controller.lineNumbers,
-                onChanged: controller.setLineNumbers),
+              icon: Icons.format_list_numbered_rounded,
+              label: 'Line numbers',
+              value: controller.lineNumbers,
+              onChanged: controller.setLineNumbers,
+            ),
             _ToggleChip(
-                icon: Icons.lock_outline_rounded,
-                label: 'Read-only',
-                value: controller.readOnly,
-                onChanged: controller.setReadOnly),
+              icon: Icons.lock_outline_rounded,
+              label: 'Read-only',
+              value: controller.readOnly,
+              onChanged: controller.setReadOnly,
+            ),
             _FontSizeChip(controller: controller),
           ],
         ),
@@ -369,7 +386,9 @@ class _ToggleChip extends StatelessWidget {
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 140),
           padding: const EdgeInsets.symmetric(
-              horizontal: Insets.md, vertical: Insets.sm),
+            horizontal: Insets.md,
+            vertical: Insets.sm,
+          ),
           decoration: BoxDecoration(
             color: active ? c.accentWash : c.surface,
             borderRadius: BorderRadius.circular(Radii.pill),
@@ -382,15 +401,18 @@ class _ToggleChip extends StatelessWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(icon,
-                  size: 15,
-                  color: active ? ShowcaseColors.accentBlue : c.textSecondary),
+              Icon(
+                icon,
+                size: 15,
+                color: active ? ShowcaseColors.accentBlue : c.textSecondary,
+              ),
               const SizedBox(width: 6),
-              Text(label,
-                  style: ShowcaseText.small.copyWith(
-                      color: active
-                          ? ShowcaseColors.accentBlue
-                          : c.textSecondary)),
+              Text(
+                label,
+                style: ShowcaseText.small.copyWith(
+                  color: active ? ShowcaseColors.accentBlue : c.textSecondary,
+                ),
+              ),
             ],
           ),
         ),
@@ -418,14 +440,20 @@ class _FontSizeChip extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           _StepButton(
-              icon: Icons.remove, onTap: () => controller.changeFontSize(-1)),
+            icon: Icons.remove,
+            onTap: () => controller.changeFontSize(-1),
+          ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 6),
-            child: Text('${controller.fontSize.toInt()}px',
-                style: ShowcaseText.monoLabel.copyWith(color: c.textSecondary)),
+            child: Text(
+              '${controller.fontSize.toInt()}px',
+              style: ShowcaseText.monoLabel.copyWith(color: c.textSecondary),
+            ),
           ),
           _StepButton(
-              icon: Icons.add, onTap: () => controller.changeFontSize(1)),
+            icon: Icons.add,
+            onTap: () => controller.changeFontSize(1),
+          ),
         ],
       ),
     );
@@ -467,29 +495,35 @@ class _DemosRow extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('TRY A FEATURE',
-            style: ShowcaseText.label.copyWith(color: c.textFaint)),
+        Text(
+          'TRY A FEATURE',
+          style: ShowcaseText.label.copyWith(color: c.textFaint),
+        ),
         const SizedBox(height: Insets.md),
         Wrap(
           spacing: Insets.sm,
           runSpacing: Insets.sm,
           children: [
             _DemoButton(
-                icon: Icons.auto_awesome_outlined,
-                label: 'IntelliSense',
-                onTap: controller.runIntelliSenseDemo),
+              icon: Icons.auto_awesome_outlined,
+              label: 'IntelliSense',
+              onTap: controller.runIntelliSenseDemo,
+            ),
             _DemoButton(
-                icon: Icons.fact_check_outlined,
-                label: 'JSON validation',
-                onTap: controller.runJsonValidationDemo),
+              icon: Icons.fact_check_outlined,
+              label: 'JSON validation',
+              onTap: controller.runJsonValidationDemo,
+            ),
             _DemoButton(
-                icon: Icons.error_outline_rounded,
-                label: 'Markers',
-                onTap: controller.runMarkersDemo),
+              icon: Icons.error_outline_rounded,
+              label: 'Markers',
+              onTap: controller.runMarkersDemo,
+            ),
             _DemoButton(
-                icon: Icons.format_color_fill_outlined,
-                label: 'Decorations',
-                onTap: controller.runDecorationsDemo),
+              icon: Icons.format_color_fill_outlined,
+              label: 'Decorations',
+              onTap: controller.runDecorationsDemo,
+            ),
           ],
         ),
       ],
@@ -517,7 +551,9 @@ class _DemoButton extends StatelessWidget {
         onTap: onTap,
         child: Container(
           padding: const EdgeInsets.symmetric(
-              horizontal: Insets.md, vertical: Insets.sm),
+            horizontal: Insets.md,
+            vertical: Insets.sm,
+          ),
           decoration: BoxDecoration(
             color: c.surface,
             borderRadius: BorderRadius.circular(Radii.sm),
@@ -528,8 +564,10 @@ class _DemoButton extends StatelessWidget {
             children: [
               Icon(icon, size: 16, color: ShowcaseColors.accentBlue),
               const SizedBox(width: 6),
-              Text(label,
-                  style: ShowcaseText.small.copyWith(color: c.textPrimary)),
+              Text(
+                label,
+                style: ShowcaseText.small.copyWith(color: c.textPrimary),
+              ),
             ],
           ),
         ),
@@ -551,15 +589,22 @@ class _HintBanner extends StatelessWidget {
       width: double.infinity,
       color: ShowcaseColors.accentBlue.withValues(alpha: 0.12),
       padding: const EdgeInsets.symmetric(
-          horizontal: Insets.md, vertical: Insets.sm),
+        horizontal: Insets.md,
+        vertical: Insets.sm,
+      ),
       child: Row(
         children: [
-          const Icon(Icons.lightbulb_outline,
-              size: 16, color: ShowcaseColors.accentBlue),
+          const Icon(
+            Icons.lightbulb_outline,
+            size: 16,
+            color: ShowcaseColors.accentBlue,
+          ),
           const SizedBox(width: Insets.sm),
           Expanded(
-            child: Text(hint,
-                style: ShowcaseText.small.copyWith(color: c.textPrimary)),
+            child: Text(
+              hint,
+              style: ShowcaseText.small.copyWith(color: c.textPrimary),
+            ),
           ),
           InkWell(
             onTap: onClose,
@@ -583,21 +628,23 @@ class _LiveStatsBar extends StatelessWidget {
     final style = ShowcaseText.monoLabel.copyWith(color: c.textSecondary);
 
     Widget bar(List<String> left, String right) => Container(
-          width: double.infinity,
-          color: c.surfaceAlt,
-          padding: const EdgeInsets.symmetric(
-              horizontal: Insets.md, vertical: Insets.sm),
-          child: Row(
-            children: [
-              for (final item in left) ...[
-                Text(item, style: style),
-                const SizedBox(width: Insets.md),
-              ],
-              const Spacer(),
-              Text(right, style: style),
-            ],
-          ),
-        );
+      width: double.infinity,
+      color: c.surfaceAlt,
+      padding: const EdgeInsets.symmetric(
+        horizontal: Insets.md,
+        vertical: Insets.sm,
+      ),
+      child: Row(
+        children: [
+          for (final item in left) ...[
+            Text(item, style: style),
+            const SizedBox(width: Insets.md),
+          ],
+          const Spacer(),
+          Text(right, style: style),
+        ],
+      ),
+    );
 
     if (stats == null) {
       return bar(const ['Ready when the editor loads'], 'UTF-8');
@@ -606,15 +653,12 @@ class _LiveStatsBar extends StatelessWidget {
     return ValueListenableBuilder<LiveStats>(
       valueListenable: stats,
       builder: (context, value, _) {
-        return bar(
-          [
-            'Ln ${value.cursorPosition?.label ?? '1:1'}',
-            '${value.lineCount.value} lines',
-            if (value.selectedCharacters.value > 0)
-              '${value.selectedCharacters.value} selected',
-          ],
-          (value.language ?? controller.language.id).toUpperCase(),
-        );
+        return bar([
+          'Ln ${value.cursorPosition?.label ?? '1:1'}',
+          '${value.lineCount.value} lines',
+          if (value.selectedCharacters.value > 0)
+            '${value.selectedCharacters.value} selected',
+        ], (value.language ?? controller.language.id).toUpperCase());
       },
     );
   }

--- a/example/lib/showcase/sections/site_footer.dart
+++ b/example/lib/showcase/sections/site_footer.dart
@@ -17,20 +17,29 @@ class SiteFooter extends StatelessWidget {
 
     final brand = _Brand();
     final columns = [
-      _LinkColumn(title: 'Package', links: const [
-        ('pub.dev', Links.pubDev),
-        ('API docs', Links.apiDocs),
-        ('Changelog', Links.changelog),
-      ]),
-      _LinkColumn(title: 'Source', links: const [
-        ('GitHub', Links.github),
-        ('Issues', Links.issues),
-        ('License', Links.license),
-      ]),
-      _LinkColumn(title: 'More', links: const [
-        ('Other projects', Links.portfolio),
-        ('Buy me a coffee', Links.buyMeACoffee),
-      ]),
+      _LinkColumn(
+        title: 'Package',
+        links: const [
+          ('pub.dev', Links.pubDev),
+          ('API docs', Links.apiDocs),
+          ('Changelog', Links.changelog),
+        ],
+      ),
+      _LinkColumn(
+        title: 'Source',
+        links: const [
+          ('GitHub', Links.github),
+          ('Issues', Links.issues),
+          ('License', Links.license),
+        ],
+      ),
+      _LinkColumn(
+        title: 'More',
+        links: const [
+          ('Other projects', Links.portfolio),
+          ('Buy me a coffee', Links.buyMeACoffee),
+        ],
+      ),
     ];
 
     return SectionContainer(
@@ -61,10 +70,14 @@ class SiteFooter extends StatelessWidget {
             crossAxisAlignment: WrapCrossAlignment.center,
             runSpacing: Insets.sm,
             children: [
-              Text('Built with flutter_monaco by Omar Hanafy',
-                  style: ShowcaseText.small.copyWith(color: c.textFaint)),
-              Text('v$kPackageVersion - MIT License',
-                  style: ShowcaseText.monoLabel.copyWith(color: c.textFaint)),
+              Text(
+                'Built with flutter_monaco by Omar Hanafy',
+                style: ShowcaseText.small.copyWith(color: c.textFaint),
+              ),
+              Text(
+                'v$kPackageVersion - MIT License',
+                style: ShowcaseText.monoLabel.copyWith(color: c.textFaint),
+              ),
             ],
           ),
         ],
@@ -93,15 +106,19 @@ class _Brand extends StatelessWidget {
               child: const Icon(Icons.code, color: Colors.white, size: 17),
             ),
             const SizedBox(width: Insets.sm),
-            Text('flutter_monaco',
-                style: ShowcaseText.h3.copyWith(color: c.textPrimary)),
+            Text(
+              'flutter_monaco',
+              style: ShowcaseText.h3.copyWith(color: c.textPrimary),
+            ),
           ],
         ),
         const SizedBox(height: Insets.md),
         ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 320),
-          child: Text("VS Code's editor, inside your Flutter app.",
-              style: ShowcaseText.body.copyWith(color: c.textSecondary)),
+          child: Text(
+            "VS Code's editor, inside your Flutter app.",
+            style: ShowcaseText.body.copyWith(color: c.textSecondary),
+          ),
         ),
         const SizedBox(height: Insets.md),
         MouseRegion(
@@ -134,8 +151,10 @@ class _LinkColumn extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(title.toUpperCase(),
-            style: ShowcaseText.label.copyWith(color: c.textFaint)),
+        Text(
+          title.toUpperCase(),
+          style: ShowcaseText.label.copyWith(color: c.textFaint),
+        ),
         const SizedBox(height: Insets.md),
         for (final (label, url) in links)
           Padding(
@@ -144,8 +163,10 @@ class _LinkColumn extends StatelessWidget {
               cursor: SystemMouseCursors.click,
               child: GestureDetector(
                 onTap: () => openUrl(url),
-                child: Text(label,
-                    style: ShowcaseText.body.copyWith(color: c.textSecondary)),
+                child: Text(
+                  label,
+                  style: ShowcaseText.body.copyWith(color: c.textSecondary),
+                ),
               ),
             ),
           ),

--- a/example/lib/showcase/sections/site_nav.dart
+++ b/example/lib/showcase/sections/site_nav.dart
@@ -63,8 +63,10 @@ class SiteNav extends StatelessWidget {
                     package: 'flutter_monaco',
                     width: 20,
                     height: 20,
-                    colorFilter:
-                        ColorFilter.mode(c.textSecondary, BlendMode.srcIn),
+                    colorFilter: ColorFilter.mode(
+                      c.textSecondary,
+                      BlendMode.srcIn,
+                    ),
                   ),
                 ),
               ),
@@ -95,19 +97,25 @@ class _Logo extends StatelessWidget {
           child: const Icon(Icons.code, color: Colors.white, size: 18),
         ),
         const SizedBox(width: Insets.sm),
-        Text('flutter_monaco',
-            style: ShowcaseText.h3.copyWith(color: c.textPrimary)),
+        Text(
+          'flutter_monaco',
+          style: ShowcaseText.h3.copyWith(color: c.textPrimary),
+        ),
         const SizedBox(width: Insets.sm),
         Container(
-          padding:
-              const EdgeInsets.symmetric(horizontal: Insets.sm, vertical: 2),
+          padding: const EdgeInsets.symmetric(
+            horizontal: Insets.sm,
+            vertical: 2,
+          ),
           decoration: BoxDecoration(
             color: c.surface,
             borderRadius: BorderRadius.circular(Radii.pill),
             border: Border.all(color: c.border),
           ),
-          child: Text('v$kPackageVersion',
-              style: ShowcaseText.monoLabel.copyWith(color: c.textFaint)),
+          child: Text(
+            'v$kPackageVersion',
+            style: ShowcaseText.monoLabel.copyWith(color: c.textFaint),
+          ),
         ),
       ],
     );
@@ -127,8 +135,10 @@ class _NavLink extends StatelessWidget {
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
         onTap: onTap,
-        child: Text(label,
-            style: ShowcaseText.small.copyWith(color: c.textSecondary)),
+        child: Text(
+          label,
+          style: ShowcaseText.small.copyWith(color: c.textSecondary),
+        ),
       ),
     );
   }
@@ -147,13 +157,17 @@ class _PubButton extends StatelessWidget {
         onTap: () => openUrl(Links.pubDev),
         child: Container(
           padding: EdgeInsets.symmetric(
-              horizontal: compact ? Insets.md : Insets.lg, vertical: 9),
+            horizontal: compact ? Insets.md : Insets.lg,
+            vertical: 9,
+          ),
           decoration: BoxDecoration(
             gradient: accentGradient,
             borderRadius: BorderRadius.circular(Radii.sm),
           ),
-          child: Text(compact ? 'pub.dev' : 'Get it on pub.dev',
-              style: ShowcaseText.small.copyWith(color: Colors.white)),
+          child: Text(
+            compact ? 'pub.dev' : 'Get it on pub.dev',
+            style: ShowcaseText.small.copyWith(color: Colors.white),
+          ),
         ),
       ),
     );

--- a/example/lib/showcase/showcase_app.dart
+++ b/example/lib/showcase/showcase_app.dart
@@ -77,14 +77,17 @@ class _ShowcaseAppState extends State<ShowcaseApp> {
                     child: Column(
                       children: [
                         HeroSection(
-                            onTryPlayground: () => _scrollTo(_playgroundKey)),
+                          onTryPlayground: () => _scrollTo(_playgroundKey),
+                        ),
                         PlaygroundSection(
                           key: _playgroundKey,
                           controller: _controller,
                           routeObserver: _routeObserver,
                         ),
                         FeaturesSection(
-                            key: _featuresKey, controller: _controller),
+                          key: _featuresKey,
+                          controller: _controller,
+                        ),
                         const GetStartedSection(),
                         const SiteFooter(),
                       ],

--- a/example/lib/showcase/state/showcase_controller.dart
+++ b/example/lib/showcase/state/showcase_controller.dart
@@ -14,21 +14,21 @@ enum PlaygroundTheme {
   midnight;
 
   String get label => switch (this) {
-        PlaygroundTheme.dark => 'Dark',
-        PlaygroundTheme.light => 'Light',
-        PlaygroundTheme.hcDark => 'High Contrast Dark',
-        PlaygroundTheme.hcLight => 'High Contrast Light',
-        PlaygroundTheme.midnight => 'Midnight (custom)',
-      };
+    PlaygroundTheme.dark => 'Dark',
+    PlaygroundTheme.light => 'Light',
+    PlaygroundTheme.hcDark => 'High Contrast Dark',
+    PlaygroundTheme.hcLight => 'High Contrast Light',
+    PlaygroundTheme.midnight => 'Midnight (custom)',
+  };
 
   /// The Monaco theme id to apply via [MonacoController.setThemeById].
   String get monacoId => switch (this) {
-        PlaygroundTheme.dark => MonacoTheme.vsDark.id,
-        PlaygroundTheme.light => MonacoTheme.vs.id,
-        PlaygroundTheme.hcDark => MonacoTheme.hcBlack.id,
-        PlaygroundTheme.hcLight => MonacoTheme.hcLight.id,
-        PlaygroundTheme.midnight => kMidnightThemeId,
-      };
+    PlaygroundTheme.dark => MonacoTheme.vsDark.id,
+    PlaygroundTheme.light => MonacoTheme.vs.id,
+    PlaygroundTheme.hcDark => MonacoTheme.hcBlack.id,
+    PlaygroundTheme.hcLight => MonacoTheme.hcLight.id,
+    PlaygroundTheme.midnight => kMidnightThemeId,
+  };
 
   bool get isDark =>
       this == PlaygroundTheme.dark ||
@@ -93,17 +93,17 @@ class ShowcaseController extends ChangeNotifier {
   String get initialValue => sampleFor(MonacoLanguage.dart);
 
   EditorOptions _buildOptions() => EditorOptions(
-        language: _language,
-        theme: _playgroundTheme.isDark ? MonacoTheme.vsDark : MonacoTheme.vs,
-        fontSize: _fontSize,
-        wordWrap: _wordWrap,
-        minimap: _minimap,
-        lineNumbers: _lineNumbers,
-        readOnly: _readOnly,
-        automaticLayout: true,
-        scrollBeyondLastLine: false,
-        padding: const {'top': 16, 'bottom': 16},
-      );
+    language: _language,
+    theme: _playgroundTheme.isDark ? MonacoTheme.vsDark : MonacoTheme.vs,
+    fontSize: _fontSize,
+    wordWrap: _wordWrap,
+    minimap: _minimap,
+    lineNumbers: _lineNumbers,
+    readOnly: _readOnly,
+    automaticLayout: true,
+    scrollBeyondLastLine: false,
+    padding: const {'top': 16, 'bottom': 16},
+  );
 
   /// Called from [MonacoEditor.onReady]: registers the custom theme and
   /// completion snippets, then syncs the current theme.
@@ -129,8 +129,9 @@ class ShowcaseController extends ChangeNotifier {
   /// Flips the page brightness and keeps the editor theme in sync (the nav
   /// toggle controls both, per the design).
   void toggleBrightness() {
-    _brightness =
-        _brightness == Brightness.dark ? Brightness.light : Brightness.dark;
+    _brightness = _brightness == Brightness.dark
+        ? Brightness.light
+        : Brightness.dark;
     _playgroundTheme = _brightness == Brightness.dark
         ? PlaygroundTheme.dark
         : PlaygroundTheme.light;
@@ -231,7 +232,8 @@ class ShowcaseController extends ChangeNotifier {
   Future<void> runIntelliSenseDemo() async {
     await setLanguage(MonacoLanguage.dart);
     _setHint(
-        'Type "pr" then press Ctrl/Cmd + Space to see custom completions.');
+      'Type "pr" then press Ctrl/Cmd + Space to see custom completions.',
+    );
   }
 
   Future<void> runJsonValidationDemo() async {
@@ -243,8 +245,10 @@ class ShowcaseController extends ChangeNotifier {
     await editor.setLanguage(MonacoLanguage.json);
     await editor.setValue(kInvalidJsonSample);
     await editor.setJsonDiagnostics(kJsonDiagnostics);
-    _setHint('Invalid fields are underlined - hover a squiggle for the schema '
-        'error.');
+    _setHint(
+      'Invalid fields are underlined - hover a squiggle for the schema '
+      'error.',
+    );
   }
 
   Future<void> runMarkersDemo() async {
@@ -257,8 +261,10 @@ class ShowcaseController extends ChangeNotifier {
     await editor.setValue(kMarkersDemoCode);
     await editor.setErrorMarkers(kDemoErrorMarkers);
     await editor.setWarningMarkers(kDemoWarningMarkers);
-    _setHint('Error + warning squiggles with overview-ruler ticks - hover to '
-        'read each message.');
+    _setHint(
+      'Error + warning squiggles with overview-ruler ticks - hover to '
+      'read each message.',
+    );
   }
 
   Future<void> runDecorationsDemo() async {

--- a/example/lib/showcase/widgets/code_block.dart
+++ b/example/lib/showcase/widgets/code_block.dart
@@ -7,11 +7,7 @@ import '../theme/showcase_tokens.dart';
 /// A styled, static code snippet (not a Monaco instance) with an optional
 /// filename header and a copy button. Keeps the page to a single live editor.
 class CodeBlock extends StatelessWidget {
-  const CodeBlock({
-    super.key,
-    required this.code,
-    this.filename,
-  });
+  const CodeBlock({super.key, required this.code, this.filename});
 
   final String code;
   final String? filename;
@@ -34,7 +30,11 @@ class CodeBlock extends StatelessWidget {
         children: [
           Container(
             padding: const EdgeInsets.fromLTRB(
-                Insets.md, Insets.sm, Insets.sm, Insets.sm),
+              Insets.md,
+              Insets.sm,
+              Insets.sm,
+              Insets.sm,
+            ),
             decoration: BoxDecoration(
               border: Border(bottom: BorderSide(color: c.border)),
             ),
@@ -47,9 +47,10 @@ class CodeBlock extends StatelessWidget {
                 _dot(const Color(0xFF27C93F)),
                 const SizedBox(width: Insets.md),
                 if (filename != null)
-                  Text(filename!,
-                      style:
-                          ShowcaseText.monoLabel.copyWith(color: c.textFaint)),
+                  Text(
+                    filename!,
+                    style: ShowcaseText.monoLabel.copyWith(color: c.textFaint),
+                  ),
                 const Spacer(),
                 Tooltip(
                   message: 'Copy',
@@ -71,8 +72,11 @@ class CodeBlock extends StatelessWidget {
                       },
                       child: Padding(
                         padding: const EdgeInsets.all(6),
-                        child: Icon(Icons.copy_rounded,
-                            size: 15, color: c.textSecondary),
+                        child: Icon(
+                          Icons.copy_rounded,
+                          size: 15,
+                          color: c.textSecondary,
+                        ),
                       ),
                     ),
                   ),
@@ -94,8 +98,8 @@ class CodeBlock extends StatelessWidget {
   }
 
   Widget _dot(Color color) => Container(
-        width: 11,
-        height: 11,
-        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-      );
+    width: 11,
+    height: 11,
+    decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+  );
 }

--- a/example/lib/showcase/widgets/copy_field.dart
+++ b/example/lib/showcase/widgets/copy_field.dart
@@ -8,11 +8,7 @@ import '../theme/showcase_tokens.dart';
 ///
 /// Used for the hero install line (`flutter pub add flutter_monaco`).
 class CopyField extends StatelessWidget {
-  const CopyField({
-    super.key,
-    required this.text,
-    this.prefix = r'$',
-  });
+  const CopyField({super.key, required this.text, this.prefix = r'$'});
 
   /// The text copied to the clipboard and displayed after [prefix].
   final String text;
@@ -38,8 +34,10 @@ class CopyField extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text('$prefix ',
-              style: ShowcaseText.monoSm.copyWith(color: c.textFaint)),
+          Text(
+            '$prefix ',
+            style: ShowcaseText.monoSm.copyWith(color: c.textFaint),
+          ),
           Flexible(
             child: Text(
               text,
@@ -68,8 +66,11 @@ class CopyField extends StatelessWidget {
                 },
                 child: Padding(
                   padding: const EdgeInsets.all(Insets.sm),
-                  child: Icon(Icons.copy_rounded,
-                      size: 16, color: c.textSecondary),
+                  child: Icon(
+                    Icons.copy_rounded,
+                    size: 16,
+                    color: c.textSecondary,
+                  ),
                 ),
               ),
             ),

--- a/example/lib/showcase/widgets/feature_card.dart
+++ b/example/lib/showcase/widgets/feature_card.dart
@@ -69,25 +69,32 @@ class _FeatureCardState extends State<FeatureCard> {
               child: Icon(widget.icon, color: Colors.white, size: 22),
             ),
             const SizedBox(height: Insets.md),
-            Text(widget.title,
-                style: ShowcaseText.h3.copyWith(color: c.textPrimary)),
+            Text(
+              widget.title,
+              style: ShowcaseText.h3.copyWith(color: c.textPrimary),
+            ),
             const SizedBox(height: Insets.sm),
-            Text(widget.body,
-                style: ShowcaseText.body.copyWith(color: c.textSecondary)),
+            Text(
+              widget.body,
+              style: ShowcaseText.body.copyWith(color: c.textSecondary),
+            ),
             if (widget.snippet != null) ...[
               const SizedBox(height: Insets.md),
               Container(
                 width: double.infinity,
                 padding: const EdgeInsets.symmetric(
-                    horizontal: Insets.md, vertical: Insets.sm),
+                  horizontal: Insets.md,
+                  vertical: Insets.sm,
+                ),
                 decoration: BoxDecoration(
                   color: c.page,
                   borderRadius: BorderRadius.circular(Radii.sm),
                   border: Border.all(color: c.border),
                 ),
-                child: Text(widget.snippet!,
-                    style:
-                        ShowcaseText.monoSm.copyWith(color: c.textSecondary)),
+                child: Text(
+                  widget.snippet!,
+                  style: ShowcaseText.monoSm.copyWith(color: c.textSecondary),
+                ),
               ),
             ],
             if (widget.onTry != null) ...[
@@ -115,12 +122,18 @@ class _TryLink extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text('Try it',
-                style: ShowcaseText.small
-                    .copyWith(color: ShowcaseColors.accentBlue)),
+            Text(
+              'Try it',
+              style: ShowcaseText.small.copyWith(
+                color: ShowcaseColors.accentBlue,
+              ),
+            ),
             const SizedBox(width: 4),
-            const Icon(Icons.arrow_forward,
-                size: 15, color: ShowcaseColors.accentBlue),
+            const Icon(
+              Icons.arrow_forward,
+              size: 15,
+              color: ShowcaseColors.accentBlue,
+            ),
           ],
         ),
       ),

--- a/example/lib/showcase/widgets/gradient_button.dart
+++ b/example/lib/showcase/widgets/gradient_button.dart
@@ -40,8 +40,8 @@ class _GradientButtonState extends State<GradientButton> {
     final Color fg = filled
         ? Colors.white
         : outline
-            ? c.textPrimary
-            : c.textSecondary;
+        ? c.textPrimary
+        : c.textSecondary;
 
     final content = Row(
       mainAxisSize: MainAxisSize.min,
@@ -64,15 +64,17 @@ class _GradientButtonState extends State<GradientButton> {
           duration: const Duration(milliseconds: 160),
           curve: Curves.easeOut,
           transform: Matrix4.translationValues(0, _hovered ? -2 : 0, 0),
-          padding:
-              const EdgeInsets.symmetric(horizontal: Insets.lg, vertical: 14),
+          padding: const EdgeInsets.symmetric(
+            horizontal: Insets.lg,
+            vertical: 14,
+          ),
           decoration: BoxDecoration(
             gradient: filled ? accentGradient : null,
             color: filled
                 ? null
                 : outline
-                    ? Colors.transparent
-                    : (_hovered ? c.surface : Colors.transparent),
+                ? Colors.transparent
+                : (_hovered ? c.surface : Colors.transparent),
             borderRadius: BorderRadius.circular(Radii.md),
             border: outline ? Border.all(color: c.border) : null,
             boxShadow: filled && _hovered

--- a/example/lib/showcase/widgets/platform_badges.dart
+++ b/example/lib/showcase/widgets/platform_badges.dart
@@ -25,7 +25,9 @@ class PlatformBadges extends StatelessWidget {
         for (final (icon, label) in _items)
           Container(
             padding: const EdgeInsets.symmetric(
-                horizontal: Insets.md, vertical: Insets.sm),
+              horizontal: Insets.md,
+              vertical: Insets.sm,
+            ),
             decoration: BoxDecoration(
               color: c.surface,
               borderRadius: BorderRadius.circular(Radii.pill),
@@ -36,8 +38,10 @@ class PlatformBadges extends StatelessWidget {
               children: [
                 Icon(icon, size: 15, color: c.textSecondary),
                 const SizedBox(width: 6),
-                Text(label,
-                    style: ShowcaseText.small.copyWith(color: c.textSecondary)),
+                Text(
+                  label,
+                  style: ShowcaseText.small.copyWith(color: c.textSecondary),
+                ),
               ],
             ),
           ),

--- a/example/lib/showcase/widgets/section_container.dart
+++ b/example/lib/showcase/widgets/section_container.dart
@@ -26,10 +26,11 @@ class SectionContainer extends StatelessWidget {
     final horizontal = Breakpoints.isMobile(width)
         ? Insets.lg
         : Breakpoints.isTablet(width)
-            ? Insets.xl
-            : Insets.xxl;
-    final vertical =
-        Breakpoints.isMobile(width) ? verticalPadding * 0.55 : verticalPadding;
+        ? Insets.xl
+        : Insets.xxl;
+    final vertical = Breakpoints.isMobile(width)
+        ? verticalPadding * 0.55
+        : verticalPadding;
 
     return Container(
       width: double.infinity,

--- a/example/lib/web_demo.dart
+++ b/example/lib/web_demo.dart
@@ -303,10 +303,13 @@ MonacoEditor(
     String? appVersion;
 
     try {
-      final pubspec =
-          await rootBundle.loadString('packages/flutter_monaco/pubspec.yaml');
-      final match =
-          RegExp(r'^version:\s*([^\s]+)', multiLine: true).firstMatch(pubspec);
+      final pubspec = await rootBundle.loadString(
+        'packages/flutter_monaco/pubspec.yaml',
+      );
+      final match = RegExp(
+        r'^version:\s*([^\s]+)',
+        multiLine: true,
+      ).firstMatch(pubspec);
       packageVersion = match?.group(1);
     } catch (_) {
       packageVersion = null;
@@ -332,15 +335,16 @@ MonacoEditor(
   }
 
   Future<void> _registerJsonDiagnostics(MonacoController controller) async {
-    await controller.setJsonDiagnostics(JsonDiagnosticsOptions(
+    await controller.setJsonDiagnostics(
+      JsonDiagnosticsOptions(
         allowComments: true,
         trailingCommas: DiagnosticsSeverity.warning,
         schemaValidation: DiagnosticsSeverity.error,
         schemas: [
           JsonDiagnosticsSchema(
-              uri: Uri.parse("https://example.com/schema.json"),
-              fileMatch: ["*"],
-              schema: jsonDecode("""
+            uri: Uri.parse("https://example.com/schema.json"),
+            fileMatch: ["*"],
+            schema: jsonDecode("""
 {
   "\$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Example Schema",
@@ -424,8 +428,11 @@ MonacoEditor(
       "required": ["defaultTheme", "features"]
     }
     }
-} """))
-        ]));
+} """),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _registerCompletions(MonacoController controller) async {
@@ -485,8 +492,10 @@ MonacoEditor(
       output += 'Valid JSON document (${code.length} characters)\n';
     } else if (file.language == MonacoLanguage.markdown) {
       final lineCount = code.split('\n').length;
-      final wordCount =
-          code.split(RegExp(r'\s+')).where((w) => w.isNotEmpty).length;
+      final wordCount = code
+          .split(RegExp(r'\s+'))
+          .where((w) => w.isNotEmpty)
+          .length;
       output += 'Markdown Preview\n';
       output += 'Lines: $lineCount | Words: $wordCount\n';
     } else {
@@ -522,10 +531,7 @@ MonacoEditor(
 
   Future<void> _openUrl(String url) async {
     final uri = Uri.parse(url);
-    final launched = await launchUrl(
-      uri,
-      mode: LaunchMode.externalApplication,
-    );
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
     if (!launched && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -591,12 +597,12 @@ MonacoEditor(
             color: Colors.transparent,
             child: InkWell(
               borderRadius: BorderRadius.circular(4),
-              onTap: () => _openUrl(
-                'https://pub.dev/packages/flutter_monaco',
-              ),
+              onTap: () => _openUrl('https://pub.dev/packages/flutter_monaco'),
               child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
                 decoration: BoxDecoration(
                   color: const Color(0xFF0098FF).withValues(alpha: 0.15),
                   borderRadius: BorderRadius.circular(4),
@@ -617,8 +623,10 @@ MonacoEditor(
                     const SizedBox(width: 8),
                     Text(
                       _appVersion,
-                      style:
-                          const TextStyle(color: Colors.white54, fontSize: 12),
+                      style: const TextStyle(
+                        color: Colors.white54,
+                        fontSize: 12,
+                      ),
                     ),
                   ],
                 ),
@@ -632,8 +640,8 @@ MonacoEditor(
             icon: _currentTheme == MonacoTheme.vsDark
                 ? Icons.dark_mode
                 : _currentTheme == MonacoTheme.vs
-                    ? Icons.light_mode
-                    : Icons.contrast,
+                ? Icons.light_mode
+                : Icons.contrast,
             label: _currentTheme.id,
             onPressed: () => _showThemeMenu(context),
           ),
@@ -699,16 +707,17 @@ MonacoEditor(
           const SizedBox(width: 8),
           IconButton(
             tooltip: 'GitHub',
-            onPressed: () => _openUrl(
-              'https://github.com/omar-hanafy/flutter_monaco',
-            ),
+            onPressed: () =>
+                _openUrl('https://github.com/omar-hanafy/flutter_monaco'),
             icon: SvgPicture.asset(
               'assets/github.svg',
               package: 'flutter_monaco',
               width: 20,
               height: 20,
-              colorFilter:
-                  const ColorFilter.mode(Colors.white70, BlendMode.srcIn),
+              colorFilter: const ColorFilter.mode(
+                Colors.white70,
+                BlendMode.srcIn,
+              ),
             ),
           ),
         ],
@@ -726,7 +735,10 @@ MonacoEditor(
         _buildThemeMenuItem(MonacoTheme.vsDark, 'Dark', Icons.dark_mode),
         _buildThemeMenuItem(MonacoTheme.vs, 'Light', Icons.light_mode),
         _buildThemeMenuItem(
-            MonacoTheme.hcBlack, 'High Contrast', Icons.contrast),
+          MonacoTheme.hcBlack,
+          'High Contrast',
+          Icons.contrast,
+        ),
       ],
     );
     if (!mounted || theme == null) return;
@@ -735,16 +747,21 @@ MonacoEditor(
   }
 
   PopupMenuItem<MonacoTheme> _buildThemeMenuItem(
-      MonacoTheme theme, String label, IconData icon) {
+    MonacoTheme theme,
+    String label,
+    IconData icon,
+  ) {
     return PopupMenuItem(
       value: theme,
       child: Row(
         children: [
-          Icon(icon,
-              size: 18,
-              color: _currentTheme == theme
-                  ? const Color(0xFF0098FF)
-                  : Colors.white70),
+          Icon(
+            icon,
+            size: 18,
+            color: _currentTheme == theme
+                ? const Color(0xFF0098FF)
+                : Colors.white70,
+          ),
           const SizedBox(width: 12),
           Text(label),
           if (_currentTheme == theme) ...[
@@ -766,8 +783,10 @@ MonacoEditor(
           builder: (context, setDialogState) => Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text('${_fontSize.toInt()}px',
-                  style: const TextStyle(fontSize: 24)),
+              Text(
+                '${_fontSize.toInt()}px',
+                style: const TextStyle(fontSize: 24),
+              ),
               Slider(
                 value: _fontSize,
                 min: 10,
@@ -825,8 +844,10 @@ MonacoEditor(
                 return InkWell(
                   onTap: () => _switchFile(index),
                   child: Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
                     decoration: BoxDecoration(
                       color: isActive
                           ? const Color(0xFF37373D)
@@ -834,7 +855,9 @@ MonacoEditor(
                       border: isActive
                           ? const Border(
                               left: BorderSide(
-                                  color: Color(0xFF0098FF), width: 2),
+                                color: Color(0xFF0098FF),
+                                width: 2,
+                              ),
                             )
                           : null,
                     ),
@@ -913,9 +936,7 @@ MonacoEditor(
       padding: const EdgeInsets.symmetric(horizontal: 12),
       decoration: const BoxDecoration(
         color: Color(0xFF1E1E1E),
-        border: Border(
-          top: BorderSide(color: Color(0xFF0098FF), width: 2),
-        ),
+        border: Border(top: BorderSide(color: Color(0xFF0098FF), width: 2)),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -981,14 +1002,20 @@ MonacoEditor(
                 const Spacer(),
                 InkWell(
                   onTap: () => setState(() => _output = ''),
-                  child: const Icon(Icons.delete_outline,
-                      size: 16, color: Colors.white54),
+                  child: const Icon(
+                    Icons.delete_outline,
+                    size: 16,
+                    color: Colors.white54,
+                  ),
                 ),
                 const SizedBox(width: 8),
                 InkWell(
                   onTap: () => setState(() => _showOutput = false),
-                  child:
-                      const Icon(Icons.close, size: 16, color: Colors.white54),
+                  child: const Icon(
+                    Icons.close,
+                    size: 16,
+                    color: Colors.white54,
+                  ),
                 ),
               ],
             ),
@@ -1055,8 +1082,10 @@ MonacoEditor(
                 children: [
                   Icon(Icons.terminal, size: 14, color: Colors.white),
                   SizedBox(width: 4),
-                  Text('Output',
-                      style: TextStyle(color: Colors.white, fontSize: 12)),
+                  Text(
+                    'Output',
+                    style: TextStyle(color: Colors.white, fontSize: 12),
+                  ),
                 ],
               ),
             ),
@@ -1109,8 +1138,10 @@ class _HeaderButton extends StatelessWidget {
           children: [
             Icon(icon, size: 16, color: Colors.white70),
             const SizedBox(width: 6),
-            Text(label,
-                style: const TextStyle(color: Colors.white70, fontSize: 12)),
+            Text(
+              label,
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
             const SizedBox(width: 4),
             const Icon(Icons.arrow_drop_down, size: 16, color: Colors.white54),
           ],
@@ -1147,15 +1178,18 @@ class _HeaderToggle extends StatelessWidget {
           borderRadius: BorderRadius.circular(4),
           border: value
               ? Border.all(
-                  color: const Color(0xFF0098FF).withValues(alpha: 0.5))
+                  color: const Color(0xFF0098FF).withValues(alpha: 0.5),
+                )
               : null,
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon,
-                size: 16,
-                color: value ? const Color(0xFF0098FF) : Colors.white54),
+            Icon(
+              icon,
+              size: 16,
+              color: value ? const Color(0xFF0098FF) : Colors.white54,
+            ),
             const SizedBox(width: 6),
             Text(
               label,
@@ -1186,10 +1220,7 @@ class _FeatureChip extends StatelessWidget {
           Container(
             width: 8,
             height: 8,
-            decoration: BoxDecoration(
-              color: color,
-              shape: BoxShape.circle,
-            ),
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
           ),
           const SizedBox(width: 8),
           Text(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 1.0.0
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/example/test/showcase/layout_test.dart
+++ b/example/test/showcase/layout_test.dart
@@ -41,13 +41,14 @@ void main() {
   }
 
   Map<String, Widget> sections(ShowcaseController controller) => {
-        'hero': HeroSection(onTryPlayground: () {}),
-        'features': FeaturesSection(controller: controller),
-        'getStarted': const GetStartedSection(),
-      };
+    'hero': HeroSection(onTryPlayground: () {}),
+    'features': FeaturesSection(controller: controller),
+    'getStarted': const GetStartedSection(),
+  };
 
-  testWidgets('sections render without overflow at tablet and desktop',
-      (tester) async {
+  testWidgets('sections render without overflow at tablet and desktop', (
+    tester,
+  ) async {
     final controller = ShowcaseController();
     addTearDown(controller.dispose);
 
@@ -56,7 +57,8 @@ void main() {
       for (final entry in sections(controller).entries) {
         final errors = await errorsFor(tester, entry.value, size);
         all.addAll(
-            errors.map((e) => '${entry.key} @${size.width.toInt()}: $e'));
+          errors.map((e) => '${entry.key} @${size.width.toInt()}: $e'),
+        );
       }
     }
     expect(all, isEmpty, reason: all.join('\n---\n'));
@@ -73,7 +75,10 @@ void main() {
     }
 
     await errorsFor(
-        tester, FeaturesSection(controller: controller), const Size(390, 3600));
+      tester,
+      FeaturesSection(controller: controller),
+      const Size(390, 3600),
+    );
     expect(find.text('Everything the editor can do'), findsOneWidget);
   });
 }

--- a/example/test/showcase/samples_test.dart
+++ b/example/test/showcase/samples_test.dart
@@ -10,8 +10,11 @@ void main() {
     test('every curated language has a non-empty sample', () {
       for (final language in kPlaygroundLanguages) {
         final sample = sampleFor(language);
-        expect(sample.trim(), isNotEmpty,
-            reason: 'missing sample for ${language.id}');
+        expect(
+          sample.trim(),
+          isNotEmpty,
+          reason: 'missing sample for ${language.id}',
+        );
       }
     });
 

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <url_launcher_windows/url_launcher_windows.h>
-#include <webview_windows/webview_windows_plugin.h>
+#include <webview_flutter_windows/webview_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   url_launcher_windows
-  webview_windows
+  webview_flutter_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/lib/src/core/monaco_actions.dart
+++ b/lib/src/core/monaco_actions.dart
@@ -487,7 +487,7 @@ class MonacoAction {
   static const String unicodeHighlightDisableHighlightingOfInvisibleCharacters =
       'editor.action.unicodeHighlight.disableHighlightingOfInvisibleCharacters';
   static const String
-      unicodeHighlightDisableHighlightingOfNonBasicAsciiCharacters =
+  unicodeHighlightDisableHighlightingOfNonBasicAsciiCharacters =
       'editor.action.unicodeHighlight.disableHighlightingOfNonBasicAsciiCharacters';
   static const String unicodeHighlightShowExcludeOptions =
       'editor.action.unicodeHighlight.showExcludeOptions';

--- a/lib/src/core/monaco_assets.dart
+++ b/lib/src/core/monaco_assets.dart
@@ -67,7 +67,7 @@ class MonacoAssets {
   ///
   /// Bump this whenever [generateIndexHtml] output or the JS bridge changes
   /// in a way Dart depends on.
-  static const int htmlGenerationVersion = 2;
+  static const int htmlGenerationVersion = 3;
 
   static Completer<void>? _initCompleter;
 
@@ -533,11 +533,15 @@ class MonacoAssets {
     self.MonacoEnvironment = {
       baseUrl: baseUrl,
       getWorkerUrl: function (moduleId, label) {
-        // Include the label for better worker resolution and debugging
+        // Include the label for better worker resolution and debugging.
+        // This template is a cooked Dart string: the newline escapes must be
+        // written as \\n so JavaScript receives "\\n" and not a raw newline,
+        // which is a SyntaxError inside a JS string literal and would kill
+        // this whole script block (workers then fall back to the main thread).
         const src =
-          "self.MonacoEnvironment = { baseUrl: '" + baseUrl + "' };\n" +
-          "self.monacoLabel = '" + label + "';\n" +
-          "importScripts('" + absVs + "/base/worker/workerMain.js');\n";
+          "self.MonacoEnvironment = { baseUrl: '" + baseUrl + "' };\\n" +
+          "self.monacoLabel = '" + label + "';\\n" +
+          "importScripts('" + absVs + "/base/worker/workerMain.js');\\n";
         return URL.createObjectURL(new Blob([src], { type: 'application/javascript' }));
       }
     };
@@ -576,6 +580,19 @@ class MonacoAssets {
       html, body, #editor-container {
         width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden;
       }
+      ${isWeb ? '''
+      /* Scroll containment for the iframe embed (issue #11). Monaco only
+         preventDefault()s touches that start on its text surface or
+         scrollbar sliders; touches that start on the margin, a scrollbar
+         track, or before Monaco loads fall through to the browser's native
+         pan. Nothing in this document can scroll, so mobile Safari chains
+         that pan to the host Flutter page. Declaring the policy here removes
+         the native pan for every touch in this document; Monaco's own touch
+         scrolling is JS-driven and unaffected by touch-action. */
+      html, body, #editor-container {
+        touch-action: none;
+        overscroll-behavior: none;
+      }''' : ''}
     </style>
     ${customCss != null ? '<style id="flutter-monaco-custom">\n$customCss\n</style>' : ''}
     $platformScript
@@ -1454,7 +1471,118 @@ class MonacoAssets {
                     }
                   } catch (_) {}
                 }
+                ${isWeb ? '''
 
+                // Mobile web keyboard fit (issue #11): the soft keyboard
+                // shrinks only the host page's *visual* viewport. This iframe
+                // keeps its layout size, so Monaco keeps rendering lines under
+                // the keyboard while Safari pans the host page to chase the
+                // hidden caret textarea - the editor's top band leaves the
+                // screen and cannot be scrolled back while the keyboard is up.
+                // While the parent's visual viewport is constrained, pin
+                // #editor-container to the visible intersection of this frame
+                // (automaticLayout relayouts Monaco via its ResizeObserver);
+                // restore the stylesheet layout once it is unconstrained.
+                if (isMobileInputPlatform() && !window.__flutterMonacoViewportFitBound) {
+                  try {
+                    const fitWindow = window;
+                    const fitContainer = document.getElementById('editor-container');
+                    const fitFrame = fitWindow.frameElement;
+                    const fitParent = fitWindow.parent;
+                    if (fitContainer && fitFrame && fitParent && fitParent !== fitWindow) {
+                      fitWindow.__flutterMonacoViewportFitBound = true;
+                      const fitViewport = fitParent.visualViewport || null;
+                      let fitRaf = 0;
+                      let fitApplied = false;
+                      let fitLast = '';
+                      const clearViewportFit = () => {
+                        fitLast = '';
+                        if (!fitApplied) return;
+                        fitApplied = false;
+                        fitContainer.style.position = '';
+                        fitContainer.style.top = '';
+                        fitContainer.style.left = '';
+                        fitContainer.style.width = '';
+                        fitContainer.style.height = '';
+                      };
+                      const scheduleViewportFit = () => {
+                        if (fitRaf) return;
+                        try {
+                          fitRaf = fitWindow.requestAnimationFrame(applyViewportFit);
+                        } catch (_) {
+                          fitRaf = 0;
+                        }
+                      };
+                      const applyViewportFit = () => {
+                        fitRaf = 0;
+                        let rect = null;
+                        try { rect = fitFrame.getBoundingClientRect(); } catch (_) {}
+                        if (!rect || rect.width <= 0 || rect.height <= 0) {
+                          clearViewportFit();
+                          return;
+                        }
+                        const viewLeft = fitViewport ? fitViewport.offsetLeft : 0;
+                        const viewTop = fitViewport ? fitViewport.offsetTop : 0;
+                        const viewWidth =
+                          (fitViewport && fitViewport.width) || fitParent.innerWidth || rect.width;
+                        const viewHeight =
+                          (fitViewport && fitViewport.height) || fitParent.innerHeight || rect.height;
+                        const left = Math.max(rect.left, viewLeft);
+                        const top = Math.max(rect.top, viewTop);
+                        const width = Math.min(rect.right, viewLeft + viewWidth) - left;
+                        const height = Math.min(rect.bottom, viewTop + viewHeight) - top;
+                        if (width >= rect.width - 1 && height >= rect.height - 1) {
+                          clearViewportFit();
+                          return;
+                        }
+                        // Keep tracking while constrained: Flutter can move the
+                        // frame (scrolling, route animations) without firing
+                        // any parent viewport event.
+                        scheduleViewportFit();
+                        // Sub-48px intersections are mid-transition slivers;
+                        // keep the previous geometry instead of collapsing.
+                        if (width < 48 || height < 48) return;
+                        const next =
+                          Math.round(left - rect.left) + ':' + Math.round(top - rect.top) +
+                          ':' + Math.round(width) + ':' + Math.round(height);
+                        if (next === fitLast) return;
+                        fitLast = next;
+                        fitApplied = true;
+                        fitContainer.style.position = 'absolute';
+                        fitContainer.style.left = Math.round(left - rect.left) + 'px';
+                        fitContainer.style.top = Math.round(top - rect.top) + 'px';
+                        fitContainer.style.width = Math.round(width) + 'px';
+                        fitContainer.style.height = Math.round(height) + 'px';
+                        try {
+                          const ed = E();
+                          if (ed && ed.hasTextFocus && ed.hasTextFocus()) {
+                            const pos = ed.getPosition && ed.getPosition();
+                            if (pos && ed.revealPosition) ed.revealPosition(pos);
+                          }
+                        } catch (_) {}
+                      };
+                      const detachViewportFit = () => {
+                        try {
+                          if (fitViewport) {
+                            fitViewport.removeEventListener('resize', scheduleViewportFit);
+                            fitViewport.removeEventListener('scroll', scheduleViewportFit);
+                          }
+                          fitParent.removeEventListener('resize', scheduleViewportFit);
+                        } catch (_) {}
+                      };
+                      if (fitViewport) {
+                        fitViewport.addEventListener('resize', scheduleViewportFit, { passive: true });
+                        fitViewport.addEventListener('scroll', scheduleViewportFit, { passive: true });
+                      }
+                      fitParent.addEventListener('resize', scheduleViewportFit, { passive: true });
+                      // The parent-side listeners outlive this document unless
+                      // removed; without this, every editor (re)load leaks one.
+                      fitWindow.addEventListener('pagehide', detachViewportFit, { once: true });
+                      scheduleViewportFit();
+                    }
+                  } catch (_) {}
+                }
+''' : ''}
                 // Completion bridge: JS stays dumb, Flutter drives the data
                 (function () {
                   const completion = {

--- a/lib/src/core/monaco_assets.dart
+++ b/lib/src/core/monaco_assets.dart
@@ -117,7 +117,8 @@ class MonacoAssets {
         final loader = File(p.join(targetDir, 'min', 'vs', 'loader.js'));
         final sentinel = File(p.join(targetDir, '.monaco_complete'));
 
-        final ok = loader.existsSync() &&
+        final ok =
+            loader.existsSync() &&
             sentinel.existsSync() &&
             (await sentinel.readAsString()).trim() == monacoVersion;
 
@@ -458,7 +459,8 @@ class MonacoAssets {
     String platformScript = '';
 
     if (isWeb) {
-      platformScript = '''
+      platformScript =
+          '''
 <script>
   console.log('[Web Init] Setting up for iframe mode');
   self.MonacoEnvironment = {
@@ -516,7 +518,8 @@ class MonacoAssets {
 ''';
     } else if (isIosOrMacOS) {
       // iOS and macOS need blob worker shim for WKWebView + file:// protocol
-      platformScript = '''
+      platformScript =
+          '''
 <script>
   (function () {
     console.log('[Init] Setting up worker shim for WKWebView');
@@ -552,7 +555,8 @@ class MonacoAssets {
     } else {
       // Linux and other platforms: just set baseUrl
       final baseUrl = vsPath.replaceAll('/vs', '/');
-      platformScript = '''
+      platformScript =
+          '''
 <script>
   // Linux/Other: Set base URL for worker resolution
   console.log('[Init] Setting Monaco base URL');

--- a/lib/src/core/monaco_assets.dart
+++ b/lib/src/core/monaco_assets.dart
@@ -821,6 +821,17 @@ class MonacoAssets {
                         if (!rect.width || !rect.height) {
                           return requestAnimationFrame(attempt);
                         }
+                        // Idempotency guard: if the editor's input already owns
+                        // focus, return WITHOUT the document.body.focus() handoff
+                        // below. That handoff blurs then refocuses, which flickers
+                        // the caret and tears down an open context menu. Refocusing
+                        // an already-focused editor must be a no-op - this removes
+                        // the flicker for EVERY caller, not just guarded pointers.
+                        const input = node.querySelector(
+                          'textarea.inputarea, .native-edit-context');
+                        if (input && document.activeElement === input) {
+                          return;
+                        }
                         try { window.focus && window.focus(); } catch (_) {}
                         try {
                           if (document.body && !document.body.hasAttribute('tabindex')) {

--- a/lib/src/core/monaco_bridge.dart
+++ b/lib/src/core/monaco_bridge.dart
@@ -67,8 +67,9 @@ class MonacoBridge extends ChangeNotifier {
   /// Use this to display status bar information like line count, selection
   /// length, and cursor position. Starts with [LiveStats.defaults] until
   /// Monaco sends actual values.
-  final ValueNotifier<LiveStats> liveStats =
-      ValueNotifier(LiveStats.defaults());
+  final ValueNotifier<LiveStats> liveStats = ValueNotifier(
+    LiveStats.defaults(),
+  );
 
   final List<void Function(Map<String, dynamic>)> _rawListeners = [];
   bool _disposed = false;
@@ -240,8 +241,9 @@ class MonacoBridge extends ChangeNotifier {
     if (_disposed) return;
 
     // Create a copy to avoid concurrent modification
-    final listeners =
-        List<void Function(Map<String, dynamic>)>.of(_rawListeners);
+    final listeners = List<void Function(Map<String, dynamic>)>.of(
+      _rawListeners,
+    );
     for (final listener in listeners) {
       try {
         listener(json);

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -549,14 +549,42 @@ class MonacoController {
     await _invokeMonacoCommand('executeAction', [actionId, args]);
   }
 
+  /// Whether a Flutter text input (TextField, CupertinoTextField,
+  /// SelectableText, ...) currently owns Flutter's primary focus.
+  ///
+  /// Focus nudges must never steal the keyboard from one: on Windows,
+  /// [PlatformWebViewController.requestNativeFocus] moves real Win32
+  /// keyboard focus to the WebView, which would make typing land in the
+  /// editor instead of, say, a dialog's TextField.
+  static bool _flutterTextInputHasFocus() {
+    final BuildContext? context;
+    try {
+      context = FocusManager.instance.primaryFocus?.context;
+    } catch (_) {
+      // MonacoController also runs headless (no widget binding, e.g. plain
+      // Dart tests); without a binding there is no Flutter focus to steal.
+      return false;
+    }
+    if (context == null) return false;
+    // Every Flutter text input attaches its focus node inside an
+    // EditableText, so it is found as an ancestor state.
+    return context.findAncestorStateOfType<EditableTextState>() != null;
+  }
+
   /// Requests focus for the editor widget.
   ///
   /// Uses a robust method that waits for visibility and layout before attempting focus.
   /// On Android and iOS, the OS soft keyboard may only appear after a user tap
   /// inside the editor.
+  ///
+  /// This is cooperative: it does nothing while a Flutter text input owns
+  /// the primary focus, so background refocus calls cannot steal the
+  /// keyboard from a focused TextField (e.g. in a dialog). For an
+  /// intentional handoff, unfocus the field first.
   Future<void> focus() async {
     if (!_interactionEnabled) return;
     await _ensureReady();
+    if (_flutterTextInputHasFocus()) return;
     // On Windows, WebView2 must hold real Win32 keyboard focus before the
     // in-page focus below has any effect. No-op on other platforms.
     await _webViewController.requestNativeFocus();
@@ -569,6 +597,11 @@ class MonacoController {
   /// Attempts to focus the editor multiple times to handle race conditions during layout transitions.
   ///
   /// [attempts] defaults to 3, with [interval] of 24ms.
+  ///
+  /// Like [focus], this is cooperative: attempts made while a Flutter text
+  /// input owns the primary focus are skipped, so refocus nudges (after
+  /// content updates, route pops, app resume) cannot steal the keyboard
+  /// from a focused TextField.
   Future<void> ensureEditorFocus({
     int attempts = 3,
     Duration interval = const Duration(milliseconds: 24),
@@ -576,9 +609,7 @@ class MonacoController {
     if (!_interactionEnabled) return;
     await _ensureReady();
 
-    // On Windows, hand real Win32 keyboard focus to WebView2 first; the JS
-    // focus attempts below cannot take effect without it.
-    await _webViewController.requestNativeFocus();
+    var nativeFocusRequested = false;
 
     // On mobile, multiple async focus() calls interrupt the IME lifecycle.
     final isMobileNative = !kIsWeb &&
@@ -587,11 +618,21 @@ class MonacoController {
     final effectiveAttempts = isMobileNative ? 1 : attempts;
 
     for (var i = 0; i < effectiveAttempts; i++) {
-      try {
-        await _webViewController.runJavaScript(
-          'window.flutterMonaco && window.flutterMonaco.forceFocus && window.flutterMonaco.forceFocus()',
-        );
-      } catch (_) {}
+      // Re-evaluated per attempt: a text input losing focus mid-loop (e.g.
+      // a closing dialog) lets the remaining attempts proceed.
+      if (!_flutterTextInputHasFocus()) {
+        if (!nativeFocusRequested) {
+          // On Windows, hand real Win32 keyboard focus to WebView2 first;
+          // the JS focus below cannot take effect without it.
+          await _webViewController.requestNativeFocus();
+          nativeFocusRequested = true;
+        }
+        try {
+          await _webViewController.runJavaScript(
+            'window.flutterMonaco && window.flutterMonaco.forceFocus && window.flutterMonaco.forceFocus()',
+          );
+        } catch (_) {}
+      }
       if (i + 1 < effectiveAttempts) {
         await Future<void>.delayed(interval);
       }

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -11,8 +11,8 @@ import 'package:flutter_monaco/src/platform/platform_webview.dart';
 /// A callback function that provides completion items for a given
 /// [CompletionRequest]. It should return a [Future] that resolves to a
 /// [CompletionList].
-typedef CompletionProvider = Future<CompletionList> Function(
-    CompletionRequest request);
+typedef CompletionProvider =
+    Future<CompletionList> Function(CompletionRequest request);
 
 /// Manages the lifecycle and interaction with a Monaco Editor instance.
 ///
@@ -183,7 +183,7 @@ class MonacoController {
       })();
 
       if (kIsWeb) {
-        unawaited(readyFuture.catchError((Object _, StackTrace __) {}));
+        unawaited(readyFuture.catchError((Object _, StackTrace _) {}));
       } else {
         await readyFuture;
       }
@@ -274,10 +274,9 @@ class MonacoController {
   ///
   /// See [JsonDiagnosticsOptions] for available settings and defaults.
   Future<void> setJsonDiagnostics(JsonDiagnosticsOptions diagnostics) async {
-    await _invokeMonacoCommand(
-      'setJsonDiagnosticsOptions',
-      [diagnostics.toJson()],
-    );
+    await _invokeMonacoCommand('setJsonDiagnosticsOptions', [
+      diagnostics.toJson(),
+    ]);
   }
 
   /// Changes the editor's color theme.
@@ -339,10 +338,7 @@ class MonacoController {
   /// an [ArgumentError] when [id] is empty.
   ///
   /// [data] must follow Monaco's `IStandaloneThemeData` shape.
-  Future<void> defineThemeFromJson(
-    String id,
-    Map<String, Object?> data,
-  ) async {
+  Future<void> defineThemeFromJson(String id, Map<String, Object?> data) async {
     if (id.trim().isEmpty) {
       throw ArgumentError.value(
         id,
@@ -469,7 +465,8 @@ class MonacoController {
       throw ArgumentError.value(id, 'id', 'Completion source already exists');
     }
 
-    final providerId = id ??
+    final providerId =
+        id ??
         'flutter_${DateTime.now().millisecondsSinceEpoch}_${_completionSources.length}';
     final entry = _RegisteredCompletion(
       id: providerId,
@@ -612,7 +609,8 @@ class MonacoController {
     var nativeFocusRequested = false;
 
     // On mobile, multiple async focus() calls interrupt the IME lifecycle.
-    final isMobileNative = !kIsWeb &&
+    final isMobileNative =
+        !kIsWeb &&
         (defaultTargetPlatform == TargetPlatform.android ||
             defaultTargetPlatform == TargetPlatform.iOS);
     final effectiveAttempts = isMobileNative ? 1 : attempts;
@@ -748,8 +746,9 @@ class MonacoController {
             'selection',
             alternativeKeys: ['sel', 'range'],
           );
-          final selection =
-              selectionMap != null ? Range.fromJson(selectionMap) : null;
+          final selection = selectionMap != null
+              ? Range.fromJson(selectionMap)
+              : null;
           _onSelectionChanged.add(selection);
           break;
         case 'focus':
@@ -815,7 +814,8 @@ class MonacoController {
 
       // Windows WebView2 might auto-decode JSON, handle both cases
       // Only decode if jsonAware is true (for API calls that return JSON)
-      final result = (jsonAware &&
+      final result =
+          (jsonAware &&
               raw is String &&
               (raw.startsWith('{') || raw.startsWith('[')))
           ? (raw.tryDecode() ?? raw)
@@ -1132,10 +1132,9 @@ class MonacoController {
   /// This is the most efficient way to make multiple changes at once.
   Future<void> applyEdits(List<EditOperation> edits) async {
     if (edits.isEmpty) return;
-    await _invokeMonacoCommand(
-      'applyEdits',
-      [edits.map((e) => e.toJson()).toList()],
-    );
+    await _invokeMonacoCommand('applyEdits', [
+      edits.map((e) => e.toJson()).toList(),
+    ]);
   }
 
   /// Inserts [text] at the specified [position].
@@ -1171,10 +1170,10 @@ class MonacoController {
   Future<List<String>> setDecorations(
     List<DecorationOptions> decorations,
   ) async {
-    final raw = await _invokeMonacoCommand(
-      'deltaDecorations',
-      [_decorationIds, decorations.map((d) => d.toJson()).toList()],
-    );
+    final raw = await _invokeMonacoCommand('deltaDecorations', [
+      _decorationIds,
+      decorations.map((d) => d.toJson()).toList(),
+    ]);
     if (raw is! List) {
       throw MonacoJavaScriptException(
         operation: 'deltaDecorations',
@@ -1183,8 +1182,10 @@ class MonacoController {
       );
     }
 
-    return _decorationIds =
-        raw.map((e) => e.toString()).where((s) => s.isNotEmpty).toList();
+    return _decorationIds = raw
+        .map((e) => e.toString())
+        .where((s) => s.isNotEmpty)
+        .toList();
   }
 
   /// Adds inline style decorations (e.g., text color, background) to specific [ranges].
@@ -1239,10 +1240,10 @@ class MonacoController {
     List<MarkerData> markers, {
     String owner = 'flutter',
   }) async {
-    await _invokeMonacoCommand(
-      'setModelMarkers',
-      [owner, markers.map((m) => m.toJson()).toList()],
-    );
+    await _invokeMonacoCommand('setModelMarkers', [
+      owner,
+      markers.map((m) => m.toJson()).toList(),
+    ]);
   }
 
   /// Convenience method to set error markers.
@@ -1341,7 +1342,8 @@ class MonacoController {
     Uri? uri,
     Uri? defaultUri,
   }) async {
-    final script = '''
+    final script =
+        '''
       flutterMonaco.createModel(
         ${jsonEncode(value)}, 
         ${jsonEncode(language)}, 
@@ -1429,10 +1431,10 @@ class MonacoController {
 
   /// Set cursor position
   Future<void> setCursorPosition(Position position) async {
-    await _invokeMonacoCommand(
-      'setCursorPosition',
-      [position.line, position.column],
-    );
+    await _invokeMonacoCommand('setCursorPosition', [
+      position.line,
+      position.column,
+    ]);
   }
 
   /// Set cursor position from zero-based coordinates

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -557,6 +557,9 @@ class MonacoController {
   Future<void> focus() async {
     if (!_interactionEnabled) return;
     await _ensureReady();
+    // On Windows, WebView2 must hold real Win32 keyboard focus before the
+    // in-page focus below has any effect. No-op on other platforms.
+    await _webViewController.requestNativeFocus();
     // Use robust in-page helper (waits for visibility, layouts, focuses textarea)
     await _webViewController.runJavaScript(
       'window.flutterMonaco && window.flutterMonaco.forceFocus && window.flutterMonaco.forceFocus()',
@@ -572,6 +575,10 @@ class MonacoController {
   }) async {
     if (!_interactionEnabled) return;
     await _ensureReady();
+
+    // On Windows, hand real Win32 keyboard focus to WebView2 first; the JS
+    // focus attempts below cannot take effect without it.
+    await _webViewController.requestNativeFocus();
 
     // On mobile, multiple async focus() calls interrupt the IME lifecycle.
     final isMobileNative = !kIsWeb &&

--- a/lib/src/models/editor_options.dart
+++ b/lib/src/models/editor_options.dart
@@ -172,17 +172,20 @@ sealed class EditorOptions with _$EditorOptions {
     final rawThemeId = json.tryGetString('themeId');
     final legacyCustomThemeId =
         rawThemeId == null && !builtInIds.contains(rawBuiltInTheme)
-            ? rawBuiltInTheme
-            : null;
+        ? rawBuiltInTheme
+        : null;
 
     return EditorOptions(
       language: MonacoLanguage.fromId(
-          json.getString('language', defaultValue: 'markdown')),
+        json.getString('language', defaultValue: 'markdown'),
+      ),
       theme: MonacoTheme.fromId(rawBuiltInTheme, orElse: MonacoTheme.vsDark),
       themeId: rawThemeId ?? legacyCustomThemeId,
       fontSize: json.getDouble('fontSize', defaultValue: 14),
-      fontFamily: json.getString('fontFamily',
-          defaultValue: 'Consolas, "Courier New", monospace'),
+      fontFamily: json.getString(
+        'fontFamily',
+        defaultValue: 'Consolas, "Courier New", monospace',
+      ),
       lineHeight: json.getDouble('lineHeight', defaultValue: 1.4),
       wordWrap: json.getBool('wordWrap', defaultValue: true),
       minimap: json.getBool('minimap', defaultValue: false),
@@ -193,21 +196,30 @@ sealed class EditorOptions with _$EditorOptions {
       readOnly: json.getBool('readOnly', defaultValue: false),
       automaticLayout: json.getBool('automaticLayout', defaultValue: true),
       padding: json.tryGetMap<String, int>('padding'),
-      scrollBeyondLastLine:
-          json.getBool('scrollBeyondLastLine', defaultValue: true),
+      scrollBeyondLastLine: json.getBool(
+        'scrollBeyondLastLine',
+        defaultValue: true,
+      ),
       smoothScrolling: json.getBool('smoothScrolling', defaultValue: false),
       cursorBlinking: CursorBlinking.fromId(
-          json.getString('cursorBlinking', defaultValue: 'blink')),
+        json.getString('cursorBlinking', defaultValue: 'blink'),
+      ),
       cursorStyle: CursorStyle.fromId(
-          json.getString('cursorStyle', defaultValue: 'line')),
+        json.getString('cursorStyle', defaultValue: 'line'),
+      ),
       renderWhitespace: RenderWhitespace.fromId(
-          json.getString('renderWhitespace', defaultValue: 'selection')),
-      bracketPairColorization:
-          json.getBool('bracketPairColorization', defaultValue: true),
-      autoClosingBrackets: AutoClosingBehavior.fromId(json
-          .getString('autoClosingBrackets', defaultValue: 'languageDefined')),
+        json.getString('renderWhitespace', defaultValue: 'selection'),
+      ),
+      bracketPairColorization: json.getBool(
+        'bracketPairColorization',
+        defaultValue: true,
+      ),
+      autoClosingBrackets: AutoClosingBehavior.fromId(
+        json.getString('autoClosingBrackets', defaultValue: 'languageDefined'),
+      ),
       autoClosingQuotes: AutoClosingBehavior.fromId(
-          json.getString('autoClosingQuotes', defaultValue: 'languageDefined')),
+        json.getString('autoClosingQuotes', defaultValue: 'languageDefined'),
+      ),
       formatOnPaste: json.getBool('formatOnPaste', defaultValue: false),
       formatOnType: json.getBool('formatOnType', defaultValue: false),
       quickSuggestions: json.getBool('quickSuggestions', defaultValue: true),
@@ -217,16 +229,26 @@ sealed class EditorOptions with _$EditorOptions {
       contextMenu: json.getBool('contextMenu', defaultValue: true),
       mouseWheelZoom: json.getBool('mouseWheelZoom', defaultValue: false),
       roundedSelection: json.getBool('roundedSelection', defaultValue: true),
-      selectionHighlight:
-          json.getBool('selectionHighlight', defaultValue: true),
-      overviewRulerBorder:
-          json.getBool('overviewRulerBorder', defaultValue: true),
-      renderControlCharacters:
-          json.getBool('renderControlCharacters', defaultValue: false),
-      disableLayerHinting:
-          json.getBool('disableLayerHinting', defaultValue: false),
-      disableMonospaceOptimizations:
-          json.getBool('disableMonospaceOptimizations', defaultValue: false),
+      selectionHighlight: json.getBool(
+        'selectionHighlight',
+        defaultValue: true,
+      ),
+      overviewRulerBorder: json.getBool(
+        'overviewRulerBorder',
+        defaultValue: true,
+      ),
+      renderControlCharacters: json.getBool(
+        'renderControlCharacters',
+        defaultValue: false,
+      ),
+      disableLayerHinting: json.getBool(
+        'disableLayerHinting',
+        defaultValue: false,
+      ),
+      disableMonospaceOptimizations: json.getBool(
+        'disableMonospaceOptimizations',
+        defaultValue: false,
+      ),
     );
   }
 
@@ -235,13 +257,13 @@ sealed class EditorOptions with _$EditorOptions {
     final int? lineHeightPx = lineHeight <= 0
         ? null
         : (lineHeight < 8
-            ? (fontSize * lineHeight).round()
-            : lineHeight.round());
+              ? (fontSize * lineHeight).round()
+              : lineHeight.round());
 
     return {
       'fontSize': fontSize,
       'fontFamily': fontFamily,
-      if (lineHeightPx != null) 'lineHeight': lineHeightPx,
+      'lineHeight': ?lineHeightPx,
       'wordWrap': wordWrap ? 'on' : 'off',
       'minimap': {'enabled': minimap},
       'lineNumbers': lineNumbers ? 'on' : 'off',

--- a/lib/src/models/monaco_theme_definition.dart
+++ b/lib/src/models/monaco_theme_definition.dart
@@ -57,9 +57,7 @@ sealed class MonacoThemeDefinition with _$MonacoThemeDefinition {
     final rawRules = json['rules'];
     final rules = rawRules is List
         ? rawRules.whereType<Map>().map((entry) {
-            return MonacoThemeRule.fromJson(
-              Map<String, dynamic>.from(entry),
-            );
+            return MonacoThemeRule.fromJson(Map<String, dynamic>.from(entry));
           }).toList()
         : const <MonacoThemeRule>[];
 
@@ -100,10 +98,7 @@ sealed class MonacoThemeDefinition with _$MonacoThemeDefinition {
     String id,
     Map<String, dynamic> data,
   ) {
-    return MonacoThemeDefinition.fromJson({
-      'id': id,
-      ...data,
-    });
+    return MonacoThemeDefinition.fromJson({'id': id, ...data});
   }
 
   /// Serializes this theme for app persistence.
@@ -111,10 +106,7 @@ sealed class MonacoThemeDefinition with _$MonacoThemeDefinition {
   /// The shape includes [id] so [fromJson] can rebuild a complete
   /// definition. Use [toMonacoThemeData] when forwarding to the JS bridge.
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      ...toMonacoThemeData(),
-    };
+    return {'id': id, ...toMonacoThemeData()};
   }
 
   /// Serializes this theme to Monaco's `IStandaloneThemeData` shape.

--- a/lib/src/models/monaco_types.dart
+++ b/lib/src/models/monaco_types.dart
@@ -47,10 +47,7 @@ sealed class Position with _$Position {
   int get columnZeroBased => column - 1;
 
   /// Converts the position to a JSON-compatible map.
-  Map<String, dynamic> toJson() => {
-        'lineNumber': line,
-        'column': column,
-      };
+  Map<String, dynamic> toJson() => {'lineNumber': line, 'column': column};
 }
 
 /// Represents a range in the editor, defined by a start and end [Position].
@@ -137,11 +134,11 @@ sealed class Range with _$Range {
 
   /// Converts the range to a JSON-compatible map.
   Map<String, dynamic> toJson() => {
-        'startLineNumber': startLine,
-        'startColumn': startColumn,
-        'endLineNumber': endLine,
-        'endColumn': endColumn,
-      };
+    'startLineNumber': startLine,
+    'startColumn': startColumn,
+    'endLineNumber': endLine,
+    'endColumn': endColumn,
+  };
 
   /// The starting position of the range.
   Position get startPosition => Position(line: startLine, column: startColumn);
@@ -298,8 +295,9 @@ sealed class MarkerData with _$MarkerData {
     if (source != null) json['source'] = source;
     if (tags != null && tags!.isNotEmpty) json['tags'] = tags;
     if (relatedInformation != null && relatedInformation!.isNotEmpty) {
-      json['relatedInformation'] =
-          relatedInformation!.map((info) => info.toJson()).toList();
+      json['relatedInformation'] = relatedInformation!
+          .map((info) => info.toJson())
+          .toList();
     }
 
     return json;
@@ -339,10 +337,10 @@ sealed class RelatedInformation with _$RelatedInformation {
 
   /// Converts the related information to a JSON-compatible map.
   Map<String, dynamic> toJson() => {
-        'resource': resource.toString(),
-        ...range.toJson(),
-        'message': message,
-      };
+    'resource': resource.toString(),
+    ...range.toJson(),
+    'message': message,
+  };
 }
 
 /// Defines options for applying decorations to text in the editor.
@@ -368,7 +366,7 @@ sealed class DecorationOptions with _$DecorationOptions {
       range: range,
       options: {
         'inlineClassName': className,
-        if (hoverMessage != null) 'hoverMessage': hoverMessage,
+        'hoverMessage': ?hoverMessage,
         ...?additionalOptions,
       },
     );
@@ -385,7 +383,7 @@ sealed class DecorationOptions with _$DecorationOptions {
       range: range,
       options: {
         'glyphMarginClassName': className,
-        if (hoverMessage != null) 'glyphMarginHoverMessage': hoverMessage,
+        'glyphMarginHoverMessage': ?hoverMessage,
         ...?additionalOptions,
       },
     );
@@ -414,18 +412,15 @@ sealed class DecorationOptions with _$DecorationOptions {
   factory DecorationOptions.fromJson(Map<String, dynamic> json) {
     return DecorationOptions(
       range: json.parse('range', Range.fromJson),
-      options: json.getMap<String, dynamic>(
-        'options',
-        defaultValue: {},
-      ),
+      options: json.getMap<String, dynamic>('options', defaultValue: {}),
     );
   }
 
   /// Converts the decoration options to a JSON-compatible map.
   Map<String, dynamic> toJson() => {
-        'range': range.toJson(),
-        'options': options,
-      };
+    'range': range.toJson(),
+    'options': options,
+  };
 }
 
 /// Represents a single text edit operation to be applied to the editor.
@@ -459,10 +454,7 @@ sealed class EditOperation with _$EditOperation {
   }
 
   /// A convenience factory for creating a deletion operation over a [range].
-  factory EditOperation.delete({
-    required Range range,
-    bool? forceMoveMarkers,
-  }) {
+  factory EditOperation.delete({required Range range, bool? forceMoveMarkers}) {
     return EditOperation(
       range: range,
       text: '',
@@ -485,10 +477,7 @@ sealed class EditOperation with _$EditOperation {
 
   /// Converts the edit operation to a JSON-compatible map.
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{
-      'range': range.toJson(),
-      'text': text,
-    };
+    final json = <String, dynamic>{'range': range.toJson(), 'text': text};
     if (forceMoveMarkers != null) {
       json['forceMoveMarkers'] = forceMoveMarkers;
     }
@@ -536,38 +525,37 @@ sealed class CompletionItem with _$CompletionItem {
 
   /// Creates a [CompletionItem] from a JSON map.
   factory CompletionItem.fromJson(Map<String, dynamic> json) => CompletionItem(
-        label: json.getString('label', defaultValue: ''),
-        insertText: json.tryGetString('insertText'),
-        kind: CompletionItemKind.maybeFromJsonValue(
-          json.tryGetString('kind'),
-        ),
-        detail: json.tryGetString('detail'),
-        documentation: json.tryGetString('documentation'),
-        sortText: json.tryGetString('sortText'),
-        filterText: json.tryGetString('filterText'),
-        range: json.tryParse('range', Range.fromJson),
-        commitCharacters: json.tryGetList<String>('commitCharacters'),
-        insertTextRules: json
-            .tryGetList<String>('insertTextRules')
-            ?.map(InsertTextRule.fromJsonValue)
-            .toSet(),
-      );
+    label: json.getString('label', defaultValue: ''),
+    insertText: json.tryGetString('insertText'),
+    kind: CompletionItemKind.maybeFromJsonValue(json.tryGetString('kind')),
+    detail: json.tryGetString('detail'),
+    documentation: json.tryGetString('documentation'),
+    sortText: json.tryGetString('sortText'),
+    filterText: json.tryGetString('filterText'),
+    range: json.tryParse('range', Range.fromJson),
+    commitCharacters: json.tryGetList<String>('commitCharacters'),
+    insertTextRules: json
+        .tryGetList<String>('insertTextRules')
+        ?.map(InsertTextRule.fromJsonValue)
+        .toSet(),
+  );
 
   /// Converts the completion item to a JSON-compatible map.
   Map<String, dynamic> toJson() => {
-        'label': label,
-        if (insertText != null) 'insertText': insertText,
-        if (kind != null) 'kind': kind!.jsonValue,
-        if (detail != null) 'detail': detail,
-        if (documentation != null) 'documentation': documentation,
-        if (sortText != null) 'sortText': sortText,
-        if (filterText != null) 'filterText': filterText,
-        if (range != null) 'range': range!.toJson(),
-        if (commitCharacters != null) 'commitCharacters': commitCharacters,
-        if (insertTextRules != null && insertTextRules!.isNotEmpty)
-          'insertTextRules':
-              insertTextRules!.map((rule) => rule.jsonValue).toList(),
-      };
+    'label': label,
+    if (insertText != null) 'insertText': insertText,
+    if (kind != null) 'kind': kind!.jsonValue,
+    if (detail != null) 'detail': detail,
+    if (documentation != null) 'documentation': documentation,
+    if (sortText != null) 'sortText': sortText,
+    if (filterText != null) 'filterText': filterText,
+    if (range != null) 'range': range!.toJson(),
+    if (commitCharacters != null) 'commitCharacters': commitCharacters,
+    if (insertTextRules != null && insertTextRules!.isNotEmpty)
+      'insertTextRules': insertTextRules!
+          .map((rule) => rule.jsonValue)
+          .toList(),
+  };
 }
 
 /// A list of completion items to be returned to the editor.
@@ -586,18 +574,18 @@ sealed class CompletionList with _$CompletionList {
 
   /// Creates a [CompletionList] from a JSON map.
   factory CompletionList.fromJson(Map<String, dynamic> json) => CompletionList(
-        suggestions: json
-            .getList<Map<String, dynamic>>('suggestions', defaultValue: [])
-            .map(CompletionItem.fromJson)
-            .toList(),
-        isIncomplete: json.getBool('isIncomplete', defaultValue: false),
-      );
+    suggestions: json
+        .getList<Map<String, dynamic>>('suggestions', defaultValue: [])
+        .map(CompletionItem.fromJson)
+        .toList(),
+    isIncomplete: json.getBool('isIncomplete', defaultValue: false),
+  );
 
   /// Converts the completion list to a JSON-compatible map.
   Map<String, dynamic> toJson() => {
-        'suggestions': suggestions.map((item) => item.toJson()).toList(),
-        'isIncomplete': isIncomplete,
-      };
+    'suggestions': suggestions.map((item) => item.toJson()).toList(),
+    'isIncomplete': isIncomplete,
+  };
 }
 
 /// Represents a request for completion items from the editor.
@@ -655,16 +643,16 @@ sealed class CompletionRequest with _$CompletionRequest {
 
   /// Converts the completion request to a JSON-compatible map.
   Map<String, dynamic> toJson() => {
-        'providerId': providerId,
-        'requestId': requestId,
-        'language': language,
-        if (uri != null) 'uri': uri.toString(),
-        'position': position.toJson(),
-        'defaultRange': defaultRange.toJson(),
-        if (lineText != null) 'lineText': lineText,
-        if (triggerKind != null) 'triggerKind': triggerKind,
-        if (triggerCharacter != null) 'triggerCharacter': triggerCharacter,
-      };
+    'providerId': providerId,
+    'requestId': requestId,
+    'language': language,
+    if (uri != null) 'uri': uri.toString(),
+    'position': position.toJson(),
+    'defaultRange': defaultRange.toJson(),
+    if (lineText != null) 'lineText': lineText,
+    if (triggerKind != null) 'triggerKind': triggerKind,
+    if (triggerCharacter != null) 'triggerCharacter': triggerCharacter,
+  };
 }
 
 /// Defines the kind of a [CompletionItem] for icon and sorting purposes.
@@ -814,22 +802,12 @@ sealed class FindOptions with _$FindOptions {
     bool isRegex = false,
     bool wholeWord = false,
   }) {
-    return FindOptions(
-      isRegex: isRegex,
-      matchCase: true,
-      wholeWord: wholeWord,
-    );
+    return FindOptions(isRegex: isRegex, matchCase: true, wholeWord: wholeWord);
   }
 
   /// A convenience factory for creating regular expression find options.
-  factory FindOptions.regex({
-    bool matchCase = false,
-  }) {
-    return FindOptions(
-      isRegex: true,
-      matchCase: matchCase,
-      wholeWord: false,
-    );
+  factory FindOptions.regex({bool matchCase = false}) {
+    return FindOptions(isRegex: true, matchCase: matchCase, wholeWord: false);
   }
 
   const FindOptions._();
@@ -950,7 +928,7 @@ sealed class LiveStats with _$LiveStats {
           alternativeKeys: [
             'selectedChars',
             'selectionLength',
-            'selectedCharacters'
+            'selectedCharacters',
           ],
           defaultValue: 0,
         ),
@@ -973,7 +951,8 @@ sealed class LiveStats with _$LiveStats {
   }
 
   static ({int value, String label})? _extractCursorPosition(
-      Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+  ) {
     final line = json.tryGetInt(
       'cursorLine',
       alternativeKeys: ['line', 'currentLine'],
@@ -997,24 +976,24 @@ sealed class LiveStats with _$LiveStats {
 
   /// Returns all statistics as a list of labeled values, suitable for UI iteration.
   List<({int value, String label})> get allStats => [
-        lineCount,
-        charCount,
-        selectedLines,
-        selectedCharacters,
-        caretCount,
-        if (cursorPosition != null) cursorPosition!,
-      ];
+    lineCount,
+    charCount,
+    selectedLines,
+    selectedCharacters,
+    caretCount,
+    ?cursorPosition,
+  ];
 
   /// Converts the live stats to a JSON-compatible map.
   Map<String, dynamic> toJson() => {
-        'lineCount': lineCount.value,
-        'charCount': charCount.value,
-        'selLines': selectedLines.value,
-        'selChars': selectedCharacters.value,
-        'caretCount': caretCount.value,
-        if (cursorPosition != null) 'cursorPosition': cursorPosition!.label,
-        if (language != null) 'language': language,
-      };
+    'lineCount': lineCount.value,
+    'charCount': charCount.value,
+    'selLines': selectedLines.value,
+    'selChars': selectedCharacters.value,
+    'caretCount': caretCount.value,
+    if (cursorPosition != null) 'cursorPosition': cursorPosition!.label,
+    if (language != null) 'language': language,
+  };
 }
 
 /// A snapshot of the editor's complete state.
@@ -1080,15 +1059,15 @@ sealed class EditorState with _$EditorState {
 
   /// Converts the editor state to a JSON-compatible map.
   Map<String, dynamic> toJson() => {
-        'content': content,
-        if (selection != null) 'selection': selection!.toJson(),
-        if (cursorPosition != null) 'cursorPosition': cursorPosition!.toJson(),
-        'lineCount': lineCount,
-        'hasUnsavedChanges': hasUnsavedChanges,
-        if (language != null) 'language': language,
-        if (theme != null) 'theme': theme,
-        if (stats != null) 'stats': stats!.toJson(),
-      };
+    'content': content,
+    if (selection != null) 'selection': selection!.toJson(),
+    if (cursorPosition != null) 'cursorPosition': cursorPosition!.toJson(),
+    'lineCount': lineCount,
+    'hasUnsavedChanges': hasUnsavedChanges,
+    if (language != null) 'language': language,
+    if (theme != null) 'theme': theme,
+    if (stats != null) 'stats': stats!.toJson(),
+  };
 
   /// Returns `true` if the editor content is empty.
   bool get isEmpty => content.isEmpty;
@@ -1122,9 +1101,9 @@ sealed class FindMatch with _$FindMatch {
 
   /// Converts the find match to a JSON-compatible map.
   Map<String, dynamic> toJson() => {
-        'range': range.toJson(),
-        if (match != null) 'match': match,
-      };
+    'range': range.toJson(),
+    if (match != null) 'match': match,
+  };
 }
 
 /// Configures Monaco's JSON language diagnostics and schema validation.
@@ -1213,14 +1192,16 @@ sealed class JsonDiagnosticsOptions with _$JsonDiagnosticsOptions {
       allowComments: json.tryGetBool('allowComments'),
       validate: json.tryGetBool('validate'),
       enableSchemaRequest: json.tryGetBool('enableSchemaRequest'),
-      schemaRequest:
-          json.tryGetString('schemaRequest')?.let(DiagnosticsSeverity.fromId),
+      schemaRequest: json
+          .tryGetString('schemaRequest')
+          ?.let(DiagnosticsSeverity.fromId),
       comments: json.tryGetString('comments')?.let(DiagnosticsSeverity.fromId),
       schemaValidation: json
           .tryGetString('schemaValidation')
           ?.let(DiagnosticsSeverity.fromId),
-      trailingCommas:
-          json.tryGetString('trailingCommas')?.let(DiagnosticsSeverity.fromId),
+      trailingCommas: json
+          .tryGetString('trailingCommas')
+          ?.let(DiagnosticsSeverity.fromId),
       schemas: json
           .tryGetList<Map<String, dynamic>>('schemas')
           ?.map(JsonDiagnosticsSchema.fromJson)
@@ -1233,17 +1214,16 @@ sealed class JsonDiagnosticsOptions with _$JsonDiagnosticsOptions {
   /// `null` fields are omitted so Monaco keeps its own defaults for those
   /// settings. Severity values are serialized as their string [DiagnosticsSeverity.id].
   Map<String, dynamic> toJson() => {
-        if (validate != null) 'validate': validate,
-        if (allowComments != null) 'allowComments': allowComments,
-        if (enableSchemaRequest != null)
-          'enableSchemaRequest': enableSchemaRequest,
-        if (schemas != null && schemas!.isNotEmpty)
-          'schemas': schemas!.map((schema) => schema.toJson()).toList(),
-        if (schemaRequest != null) 'schemaRequest': schemaRequest!.id,
-        if (schemaValidation != null) 'schemaValidation': schemaValidation!.id,
-        if (comments != null) 'comments': comments!.id,
-        if (trailingCommas != null) 'trailingCommas': trailingCommas!.id,
-      };
+    if (validate != null) 'validate': validate,
+    if (allowComments != null) 'allowComments': allowComments,
+    if (enableSchemaRequest != null) 'enableSchemaRequest': enableSchemaRequest,
+    if (schemas != null && schemas!.isNotEmpty)
+      'schemas': schemas!.map((schema) => schema.toJson()).toList(),
+    if (schemaRequest != null) 'schemaRequest': schemaRequest!.id,
+    if (schemaValidation != null) 'schemaValidation': schemaValidation!.id,
+    if (comments != null) 'comments': comments!.id,
+    if (trailingCommas != null) 'trailingCommas': trailingCommas!.id,
+  };
 }
 
 /// Associates a JSON Schema with a set of Monaco model-URI patterns.
@@ -1283,12 +1263,7 @@ sealed class JsonDiagnosticsSchema with _$JsonDiagnosticsSchema {
   /// Throws a `ConversionException` if neither key is present.
   factory JsonDiagnosticsSchema.fromJson(Map<String, dynamic> json) {
     return JsonDiagnosticsSchema(
-      uri: Uri.parse(
-        json.getString(
-          'uri',
-          alternativeKeys: ['schemaUri'],
-        ),
-      ),
+      uri: Uri.parse(json.getString('uri', alternativeKeys: ['schemaUri'])),
       fileMatch: json.tryGetList<String>('fileMatch'),
       schema: json.tryGetMap<String, dynamic>('schema'),
     );
@@ -1298,8 +1273,8 @@ sealed class JsonDiagnosticsSchema with _$JsonDiagnosticsSchema {
   /// which key was used during deserialization. `null` optional fields are
   /// omitted.
   Map<String, dynamic> toJson() => {
-        'uri': uri.toString(),
-        if (fileMatch != null) 'fileMatch': fileMatch,
-        if (schema != null) 'schema': schema,
-      };
+    'uri': uri.toString(),
+    if (fileMatch != null) 'fileMatch': fileMatch,
+    if (schema != null) 'schema': schema,
+  };
 }

--- a/lib/src/platform/overlay_shield/overlay_shield_stub.dart
+++ b/lib/src/platform/overlay_shield/overlay_shield_stub.dart
@@ -11,10 +11,7 @@ class MonacoOverlayDomShield {
 
   /// No-op constructor. Construction is permitted so callers can share the
   /// same code path on web and native, but no DOM work happens.
-  MonacoOverlayDomShield({
-    required int flutterViewId,
-    required bool debug,
-  });
+  MonacoOverlayDomShield({required int flutterViewId, required bool debug});
 
   /// Update the shield's tracked rect. No-op on native.
   void update(Rect rect) {}

--- a/lib/src/platform/overlay_shield/overlay_shield_web.dart
+++ b/lib/src/platform/overlay_shield/overlay_shield_web.dart
@@ -26,13 +26,10 @@ class MonacoOverlayDomShield {
 
   /// Create a shield attached to the Flutter view with the given [flutterViewId].
   ///
-  /// Set [debug] to render the shield as a translucent green rectangle while
+  /// Set [_debug] to render the shield as a translucent green rectangle while
   /// developing.
-  MonacoOverlayDomShield({
-    required int flutterViewId,
-    required bool debug,
-  })  : _debug = debug,
-        _lockId = 'flutter-monaco-overlay-${_nextLockId()}' {
+  MonacoOverlayDomShield({required int flutterViewId, required this._debug})
+    : _lockId = 'flutter-monaco-overlay-${_nextLockId()}' {
     _host = ui_web.views.getHostElement(flutterViewId) as web.Element?;
     _createElement();
   }
@@ -128,8 +125,9 @@ class MonacoOverlayDomShield {
     element.style.padding = '0';
     element.style.border = '0';
     element.style.pointerEvents = 'none';
-    element.style.backgroundColor =
-        _debug ? 'rgba(0, 255, 0, 0.18)' : 'transparent';
+    element.style.backgroundColor = _debug
+        ? 'rgba(0, 255, 0, 0.18)'
+        : 'transparent';
     element.style.outline = _debug ? '1px solid rgba(0, 128, 0, 0.7)' : 'none';
 
     // Max z-index so the shield beats platform-view wrappers in DOM stacking.

--- a/lib/src/platform/platform_webview.dart
+++ b/lib/src/platform/platform_webview.dart
@@ -131,6 +131,9 @@ class WebViewController implements PlatformWebViewController {
   @override
   Future<void> setInteractionEnabled(bool enabled) =>
       _controller.setInteractionEnabled(enabled);
+
+  @override
+  Future<void> requestNativeFocus() => _controller.requestNativeFocus();
 }
 
 /// Normalizes WebView2 `ExecuteScript` results to Dart-friendly types.

--- a/lib/src/platform/platform_webview.dart
+++ b/lib/src/platform/platform_webview.dart
@@ -44,7 +44,7 @@ class PlatformWebViewFactory {
   /// Creates a new [PlatformWebViewController] for the current platform.
   ///
   /// On native platforms, this returns a controller backed by `webview_flutter`
-  /// (Android/iOS/macOS) or `webview_windows` (Windows). On web, it returns
+  /// (Android/iOS/macOS) or `webview_flutter_windows` (Windows). On web, it returns
   /// an iframe-based controller.
   ///
   /// If [debugCreateOverride] is set, returns the result of that function
@@ -87,10 +87,7 @@ class WebViewController implements PlatformWebViewController {
 
   @override
   Future<void> load({String? customCss, bool allowCdnFonts = false}) {
-    return _controller.load(
-      customCss: customCss,
-      allowCdnFonts: allowCdnFonts,
-    );
+    return _controller.load(customCss: customCss, allowCdnFonts: allowCdnFonts);
   }
 
   @override

--- a/lib/src/platform/platform_webview_interface.dart
+++ b/lib/src/platform/platform_webview_interface.dart
@@ -138,4 +138,12 @@ abstract class PlatformWebViewController {
   /// On native platforms, this may be a no-op or implemented via
   /// platform-specific pointer transparency APIs.
   Future<void> setInteractionEnabled(bool enabled);
+
+  /// Requests native keyboard focus for the WebView host.
+  ///
+  /// On Windows, WebView2 must hold real Win32 keyboard focus before any
+  /// in-page (JavaScript) focus call has an effect, so this moves native
+  /// focus to the WebView2 control. On all other platforms this is a no-op;
+  /// their WebViews participate in the regular platform focus system.
+  Future<void> requestNativeFocus();
 }

--- a/lib/src/platform/platform_webview_interface.dart
+++ b/lib/src/platform/platform_webview_interface.dart
@@ -13,7 +13,7 @@ import 'package:flutter/widgets.dart';
 /// ### Platform Implementations
 ///
 /// - **Android/iOS/macOS:** Uses `webview_flutter` via [FlutterWebViewController]
-/// - **Windows:** Uses `webview_windows` (WebView2) via [WindowsWebViewController]
+/// - **Windows:** Uses `webview_flutter_windows` (WebView2) via [WindowsWebViewController]
 /// - **Web:** Uses an iframe with `dart:js_interop` via web-specific controller
 ///
 /// ### Lifecycle
@@ -117,10 +117,7 @@ abstract class PlatformWebViewController {
   /// - [allowCdnFonts]: If `true`, relaxes Content-Security-Policy to allow
   ///   loading fonts from remote URLs. **Security note:** This enables
   ///   network requests from the WebView.
-  Future<void> load({
-    String? customCss,
-    bool allowCdnFonts = false,
-  });
+  Future<void> load({String? customCss, bool allowCdnFonts = false});
 
   /// Sets the background color of the WebView container.
   ///

--- a/lib/src/platform/web_interaction_coordinator.dart
+++ b/lib/src/platform/web_interaction_coordinator.dart
@@ -136,17 +136,13 @@ class MonacoWebInteractionCoordinator {
 
   Rect _rectForElement(web.Element element) {
     final rect = element.getBoundingClientRect();
-    return Rect.fromLTWH(
-      rect.left,
-      rect.top,
-      rect.width,
-      rect.height,
-    );
+    return Rect.fromLTWH(rect.left, rect.top, rect.width, rect.height);
   }
 
   void _apply(_EditorEntry entry) {
-    entry.iframe.style.pointerEvents =
-        entry.baseEnabled && entry.locks.isEmpty ? 'auto' : 'none';
+    entry.iframe.style.pointerEvents = entry.baseEnabled && entry.locks.isEmpty
+        ? 'auto'
+        : 'none';
   }
 }
 

--- a/lib/src/platform/web_view_controller/native.dart
+++ b/lib/src/platform/web_view_controller/native.dart
@@ -8,7 +8,7 @@ import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/platform/platform_webview.dart';
 import 'package:path/path.dart' as p;
 import 'package:webview_flutter/webview_flutter.dart' as wf;
-import 'package:webview_windows/webview_windows.dart' as ww;
+import 'package:webview_flutter_windows/webview_flutter_windows.dart' as ww;
 
 /// Base class for native platform WebView implementations.
 ///
@@ -18,7 +18,7 @@ import 'package:webview_windows/webview_windows.dart' as ww;
 ///
 /// ### Platform Selection
 ///
-/// - **Windows:** Returns [WindowsWebViewController] using `webview_windows`
+/// - **Windows:** Returns [WindowsWebViewController] using `webview_flutter_windows`
 ///   (Microsoft Edge WebView2 runtime).
 /// - **Android/iOS/macOS:** Returns [FlutterWebViewController] using
 ///   `webview_flutter` with platform-specific WebView implementations.
@@ -272,7 +272,7 @@ class FlutterWebViewController extends WebViewController {
 
 /// WebView implementation for Windows using Microsoft Edge WebView2.
 ///
-/// This controller wraps the `webview_windows` package to provide Monaco editor
+/// This controller wraps the `webview_flutter_windows` package to provide Monaco editor
 /// hosting on Windows. It requires the WebView2 runtime, which is pre-installed
 /// on Windows 11 and available as a separate download for Windows 10.
 ///
@@ -300,7 +300,7 @@ class FlutterWebViewController extends WebViewController {
 /// - [ww.WebviewController] for the underlying Windows WebView controller.
 /// - [parseWindowsScriptResult] for result normalization.
 class WindowsWebViewController extends WebViewController {
-  /// Creates a new controller backed by `webview_windows` (WebView2).
+  /// Creates a new controller backed by `webview_flutter_windows` (WebView2).
   WindowsWebViewController() : super._() {
     _controller = ww.WebviewController();
   }
@@ -314,7 +314,7 @@ class WindowsWebViewController extends WebViewController {
   bool _isInitialized = false;
   bool _disposed = false;
 
-  /// Provides direct access to the underlying `webview_windows` controller.
+  /// Provides direct access to the underlying `webview_flutter_windows` controller.
   ///
   /// Use this for advanced operations not exposed by [PlatformWebViewController],
   /// such as custom popup policies or DevTools access.
@@ -442,7 +442,8 @@ class WindowsWebViewController extends WebViewController {
     void Function(String) onMessage,
   ) async {
     debugPrint(
-        '[WindowsWebViewController] Registering handler for channel: $name');
+      '[WindowsWebViewController] Registering handler for channel: $name',
+    );
 
     // Store the handler - HTML already defines window.flutterChannel
     _channels[name] = onMessage;

--- a/lib/src/platform/web_view_controller/native.dart
+++ b/lib/src/platform/web_view_controller/native.dart
@@ -48,6 +48,12 @@ abstract class WebViewController implements PlatformWebViewController {
 
   const WebViewController._();
 
+  @override
+  Future<void> requestNativeFocus() async {
+    // No-op by default. webview_flutter platforms participate in the regular
+    // platform focus system; only Windows needs an explicit handoff.
+  }
+
   /// Generates and caches the Monaco editor HTML file for native platforms.
   ///
   /// This method:
@@ -396,6 +402,14 @@ class WindowsWebViewController extends WebViewController {
   @override
   Future<void> setInteractionEnabled(bool enabled) async {
     // No-op on Windows as WebView2 respects Flutter's overlay stacking.
+  }
+
+  @override
+  Future<void> requestNativeFocus() async {
+    if (!_isInitialized || _disposed) return;
+    // Moves real Win32 keyboard focus to the WebView2 control so that
+    // subsequent in-page focus calls (and typing) actually work.
+    await _controller.focus();
   }
 
   @override

--- a/lib/src/platform/web_view_controller/stub.dart
+++ b/lib/src/platform/web_view_controller/stub.dart
@@ -13,7 +13,7 @@ import 'package:flutter_monaco/src/platform/platform_webview.dart';
 ///
 /// If you encounter errors from this stub, verify that:
 /// 1. You're running on a supported platform (Android, iOS, macOS, Windows, Web)
-/// 2. The `webview_flutter` or `webview_windows` dependencies are properly configured
+/// 2. The `webview_flutter` or `webview_flutter_windows` dependencies are properly configured
 ///
 /// See also:
 /// - [web_view_controller.dart] for the conditional export logic.

--- a/lib/src/platform/web_view_controller/stub.dart
+++ b/lib/src/platform/web_view_controller/stub.dart
@@ -68,6 +68,11 @@ class WebViewController implements PlatformWebViewController {
   }
 
   @override
+  Future<void> requestNativeFocus() {
+    throw UnsupportedError('WebView not supported on this platform');
+  }
+
+  @override
   void dispose() {
     throw UnsupportedError('WebView not supported on this platform');
   }

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -23,8 +23,9 @@ import 'package:web/web.dart' as web;
 /// URL strategy, so the path stays correct and still resolves inside the
 /// blob-URL iframe that hosts Monaco (see issue #14).
 String _monacoVsAssetUrl() {
-  final assetUrl =
-      ui_web.assetManager.getAssetUrl('${MonacoAssets.assetBaseDir}/min/vs');
+  final assetUrl = ui_web.assetManager.getAssetUrl(
+    '${MonacoAssets.assetBaseDir}/min/vs',
+  );
   return resolveWebAssetUrl(web.document.baseURI, assetUrl);
 }
 
@@ -105,10 +106,7 @@ class WebViewController implements PlatformWebViewController {
       ..style.overscrollBehavior = 'none'
       ..allow = 'clipboard-read; clipboard-write';
 
-    MonacoWebInteractionCoordinator.instance.registerEditor(
-      _viewId!,
-      _iframe!,
-    );
+    MonacoWebInteractionCoordinator.instance.registerEditor(_viewId!, _iframe!);
     _applyInteractionEnabled();
 
     // Register the view factory.
@@ -159,7 +157,8 @@ class WebViewController implements PlatformWebViewController {
     }
 
     // Only log non-stats messages to reduce noise (stats fire on every keystroke/selection)
-    final isStatsMessage = message.contains('"event":"stats"') ||
+    final isStatsMessage =
+        message.contains('"event":"stats"') ||
         message.contains('"event": "stats"');
     if (!isStatsMessage) {
       debugPrint('[WebViewController] Received iframe message: $message');
@@ -292,8 +291,10 @@ class WebViewController implements PlatformWebViewController {
     if (_disposed) return null;
 
     try {
-      final result =
-          _iframe?.contentWindow?.callMethod('eval'.toJS, script.toJS);
+      final result = _iframe?.contentWindow?.callMethod(
+        'eval'.toJS,
+        script.toJS,
+      );
       return result?.dartify();
     } catch (e) {
       debugPrint('[WebViewController] JS result error: $e');
@@ -340,10 +341,9 @@ class WebViewController implements PlatformWebViewController {
         allowCdnFonts: allowCdnFonts,
       );
 
-      final blobUrl = web.URL.createObjectURL(web.Blob(
-        [html.toJS].toJS,
-        web.BlobPropertyBag(type: 'text/html'),
-      ));
+      final blobUrl = web.URL.createObjectURL(
+        web.Blob([html.toJS].toJS, web.BlobPropertyBag(type: 'text/html')),
+      );
 
       try {
         _iframe!.src = blobUrl;

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -95,6 +95,14 @@ class WebViewController implements PlatformWebViewController {
       ..style.width = '100%'
       ..style.height = '100%'
       ..style.border = 'none'
+      // Iframes are inline by default; the baseline gap can overflow the
+      // host page by a few pixels, giving mobile Safari something to pan.
+      ..style.display = 'block'
+      // Touch pans and overscroll that start over the editor must never
+      // chain into the host page (issue #11). The embedded document declares
+      // the same policy; this covers the frame boundary itself.
+      ..style.touchAction = 'none'
+      ..style.overscrollBehavior = 'none'
       ..allow = 'clipboard-read; clipboard-write';
 
     MonacoWebInteractionCoordinator.instance.registerEditor(
@@ -256,6 +264,11 @@ class WebViewController implements PlatformWebViewController {
         );
       } catch (_) {}
     }
+  }
+
+  @override
+  Future<void> requestNativeFocus() async {
+    // No-op on web; iframe focus is handled by the in-page focus helpers.
   }
 
   @override

--- a/lib/src/platform/web_view_controller/web_view_controller.dart
+++ b/lib/src/platform/web_view_controller/web_view_controller.dart
@@ -6,7 +6,7 @@
 /// - **`dart.library.js_interop`** (Web): Uses [web.dart] with iframe-based
 ///   Monaco hosting and `postMessage` communication.
 /// - **`dart.library.io`** (Native): Uses [native.dart] which further
-///   dispatches to `webview_flutter` or `webview_windows` based on OS.
+///   dispatches to `webview_flutter` or `webview_flutter_windows` based on OS.
 /// - **Fallback** (Unsupported): Uses [stub.dart] which throws
 ///   [UnsupportedError] for all operations.
 ///

--- a/lib/src/widgets/monaco_editor_theme.dart
+++ b/lib/src/widgets/monaco_editor_theme.dart
@@ -28,17 +28,12 @@ class MonacoEditorTheme extends InheritedTheme {
   /// `child` is a runtime parameter. Call sites incur a normal allocation,
   /// not a const lookup - acceptable for a theme widget that sits at the
   /// top of a subtree rather than rebuilding frequently.
-  MonacoEditorTheme({
-    super.key,
-    required this.data,
-    required Widget child,
-  })  : _isResolved = false,
-        super(child: _MonacoEditorThemeResolver(child: child));
+  MonacoEditorTheme({super.key, required this.data, required Widget child})
+    : _isResolved = false,
+      super(child: _MonacoEditorThemeResolver(child: child));
 
-  const MonacoEditorTheme._resolved({
-    required this.data,
-    required super.child,
-  }) : _isResolved = true;
+  const MonacoEditorTheme._resolved({required this.data, required super.child})
+    : _isResolved = true;
 
   /// The chrome theme applied to descendants.
   final MonacoEditorThemeData data;
@@ -245,8 +240,9 @@ class MonacoEditorThemeData {
         backgroundColor: theme.colorScheme.primary,
         foregroundColor: theme.colorScheme.onPrimary,
       ),
-      statusBarBackgroundColor:
-          theme.colorScheme.surface.withValues(alpha: 0.95),
+      statusBarBackgroundColor: theme.colorScheme.surface.withValues(
+        alpha: 0.95,
+      ),
       statusBarBorderColor: theme.dividerColor,
       statusBarTextStyle:
           theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12),

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -179,14 +179,14 @@ class MonacoEditor extends StatefulWidget {
   ///
   /// Defaults to an error icon and retry button.
   final Widget Function(BuildContext context, Object error, StackTrace? st)?
-      errorBuilder;
+  errorBuilder;
 
   /// If `true`, displays a status bar with line/column info at the bottom.
   final bool showStatusBar;
 
   /// Builder for a custom status bar widget.
   final Widget Function(BuildContext context, LiveStats stats)?
-      statusBarBuilder;
+  statusBarBuilder;
 
   /// The background color of the WebView container.
   ///
@@ -265,7 +265,8 @@ class _MonacoEditorState extends State<MonacoEditor> {
     }
 
     // If we OWN the controller and HTML-affecting knobs changed, rebuild.
-    final htmlKnobsChanged = (oldWidget.customCss != widget.customCss) ||
+    final htmlKnobsChanged =
+        (oldWidget.customCss != widget.customCss) ||
         (oldWidget.allowCdnFonts != widget.allowCdnFonts);
     if (_ownsController && htmlKnobsChanged) {
       _teardown(disposeOldController: true);
@@ -276,7 +277,8 @@ class _MonacoEditorState extends State<MonacoEditor> {
     if (widget.interactionEnabled != oldWidget.interactionEnabled &&
         _controller != null) {
       _ignoreAsync(
-          _controller!.setInteractionEnabled(widget.interactionEnabled));
+        _controller!.setInteractionEnabled(widget.interactionEnabled),
+      );
     }
 
     if (_connectionState != _ConnectionState.ready || _controller == null) {
@@ -287,9 +289,7 @@ class _MonacoEditorState extends State<MonacoEditor> {
     if (widget.options != oldWidget.options) {
       _ignoreAsync(_controller!.updateOptions(widget.options));
       // Explicitly update theme and language as they require separate bridge calls.
-      _ignoreAsync(
-        _controller!.setThemeById(widget.options.effectiveThemeId),
-      );
+      _ignoreAsync(_controller!.setThemeById(widget.options.effectiveThemeId));
       _ignoreAsync(_controller!.setLanguage(widget.options.language));
     }
 
@@ -319,7 +319,8 @@ class _MonacoEditorState extends State<MonacoEditor> {
     try {
       final ownsController = widget.controller == null;
       _ownsController = ownsController;
-      final controller = widget.controller ??
+      final controller =
+          widget.controller ??
           await (widget.controllerFactory?.call() ??
               MonacoController.create(
                 options: widget.options,
@@ -361,8 +362,9 @@ class _MonacoEditorState extends State<MonacoEditor> {
           debugPrint('[MonacoEditor] setBackgroundColor failed: $e');
         }
         try {
-          await _controller!
-              .setHostPageBackgroundColor(widget.backgroundColor!);
+          await _controller!.setHostPageBackgroundColor(
+            widget.backgroundColor!,
+          );
         } catch (e) {
           debugPrint('[MonacoEditor] setHostPageBackgroundColor failed: $e');
         }
@@ -431,8 +433,9 @@ class _MonacoEditorState extends State<MonacoEditor> {
 
     _wireContentListener();
     if (widget.onSelectionChanged != null) {
-      final selectionSub = _controller!.onSelectionChanged
-          .listen((r) => widget.onSelectionChanged?.call(r));
+      final selectionSub = _controller!.onSelectionChanged.listen(
+        (r) => widget.onSelectionChanged?.call(r),
+      );
       _streamSubscriptions.add(selectionSub);
     }
     final focusSub = _controller!.onFocus.listen((_) {
@@ -446,15 +449,17 @@ class _MonacoEditorState extends State<MonacoEditor> {
     });
     _streamSubscriptions.add(blurSub);
 
-    _statsListener =
-        () => widget.onLiveStats?.call(_controller!.liveStats.value);
+    _statsListener = () =>
+        widget.onLiveStats?.call(_controller!.liveStats.value);
     _controller!.liveStats.addListener(_statsListener!);
   }
 
   void _ignoreAsync(Future<void> future) {
-    unawaited(future.catchError((e, st) {
-      debugPrint('[MonacoEditor] Async update error: $e');
-    }));
+    unawaited(
+      future.catchError((e, st) {
+        debugPrint('[MonacoEditor] Async update error: $e');
+      }),
+    );
   }
 
   /// Wires only the content changed listener, allowing it to be updated separately.
@@ -486,8 +491,10 @@ class _MonacoEditorState extends State<MonacoEditor> {
       }
 
       _contentDebounceTimer?.cancel();
-      _contentDebounceTimer =
-          Timer(widget.contentDebounce, () => _ignoreAsync(pullAndEmit()));
+      _contentDebounceTimer = Timer(
+        widget.contentDebounce,
+        () => _ignoreAsync(pullAndEmit()),
+      );
     });
   }
 
@@ -522,7 +529,8 @@ class _MonacoEditorState extends State<MonacoEditor> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final bg = widget.backgroundColor ??
+    final bg =
+        widget.backgroundColor ??
         (theme.brightness == Brightness.dark
             ? const Color(0xFF1E1E1E)
             : Colors.white);
@@ -609,7 +617,8 @@ class _MonacoEditorState extends State<MonacoEditor> {
         children: [
           webView,
           Positioned.fill(
-            child: widget.errorBuilder?.call(context, _error!, _stack) ??
+            child:
+                widget.errorBuilder?.call(context, _error!, _stack) ??
                 _DefaultError(
                   error: _error!,
                   onRetry: _ownsController ? _bootstrap : null,
@@ -663,7 +672,8 @@ class _MonacoStatusBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = MonacoEditorTheme.of(context);
-    final style = theme.statusBarTextStyle ??
+    final style =
+        theme.statusBarTextStyle ??
         Theme.of(context).textTheme.bodySmall ??
         const TextStyle(fontSize: 12);
 
@@ -681,13 +691,15 @@ class _MonacoStatusBar extends StatelessWidget {
         ].where((s) => s.isNotEmpty).toList();
 
         return Container(
-          padding: theme.statusBarPadding ??
+          padding:
+              theme.statusBarPadding ??
               const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           decoration: BoxDecoration(
             color: theme.statusBarBackgroundColor,
             border: Border(
               top: BorderSide(
-                color: theme.statusBarBorderColor ??
+                color:
+                    theme.statusBarBorderColor ??
                     Theme.of(context).dividerColor,
                 width: 0.5,
               ),
@@ -697,9 +709,7 @@ class _MonacoStatusBar extends StatelessWidget {
             alignment: WrapAlignment.end,
             spacing: theme.statusBarSpacing ?? 16,
             runSpacing: 4,
-            children: [
-              for (final entry in entries) Text(entry, style: style),
-            ],
+            children: [for (final entry in entries) Text(entry, style: style)],
           ),
         );
       },
@@ -730,10 +740,7 @@ class _DefaultLoading extends StatelessWidget {
 }
 
 class _DefaultError extends StatelessWidget {
-  const _DefaultError({
-    required this.error,
-    this.onRetry,
-  });
+  const _DefaultError({required this.error, this.onRetry});
 
   final Object error;
   final VoidCallback? onRetry;

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
@@ -15,6 +16,19 @@ enum _ConnectionState {
 
   /// An error occurred during the initialization of the editor.
   error,
+}
+
+bool _pointerMayClaimKeyboard(PointerDownEvent event) {
+  if (event.kind == PointerDeviceKind.mouse ||
+      event.kind == PointerDeviceKind.trackpad) {
+    return event.buttons == kPrimaryMouseButton;
+  }
+  return true;
+}
+
+bool _pointerShouldNudgeFocus(PointerDownEvent event,
+    {required bool hasFocus}) {
+  return !hasFocus && _pointerMayClaimKeyboard(event);
 }
 
 /// A widget that renders a Monaco Editor instance.
@@ -535,11 +549,15 @@ class _MonacoEditorState extends State<MonacoEditor> {
           },
           child: Listener(
             behavior: HitTestBehavior.translucent,
-            onPointerDown: (_) {
+            onPointerDown: (event) {
               if (!widget.interactionEnabled) return;
-              if (!_webFocusNode.hasFocus) {
-                _webFocusNode.requestFocus();
+              if (!_pointerShouldNudgeFocus(
+                event,
+                hasFocus: _webFocusNode.hasFocus,
+              )) {
+                return;
               }
+              _webFocusNode.requestFocus();
               unawaited(_controller!.ensureEditorFocus(attempts: 1));
             },
             child: _controller!.webViewWidget,

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -26,9 +26,19 @@ bool _pointerMayClaimKeyboard(PointerDownEvent event) {
   return true;
 }
 
-bool _pointerShouldNudgeFocus(PointerDownEvent event,
-    {required bool hasFocus}) {
-  return !hasFocus && _pointerMayClaimKeyboard(event);
+bool _pointerShouldNudgeFocus(
+  PointerDownEvent event, {
+  required bool hasFlutterFocus,
+  required bool editorReportsFocused,
+}) {
+  // Re-assert focus only when the editor is not already fully focused: it
+  // lacks Flutter focus (key routing) OR Monaco itself reports unfocused (its
+  // input cannot receive keystrokes). Reading Monaco's own focus signal - not
+  // just the Flutter-focus proxy - lets a click recover typing after the
+  // editor silently lost native focus (alt-tab, a dialog, a tab switch),
+  // while an already-focused editor is still left alone (no replay).
+  if (!_pointerMayClaimKeyboard(event)) return false;
+  return !hasFlutterFocus || !editorReportsFocused;
 }
 
 /// A widget that renders a Monaco Editor instance.
@@ -231,6 +241,12 @@ class _MonacoEditorState extends State<MonacoEditor> {
   /// FocusNode to explicitly request platform view focus for the WebView.
   final FocusNode _webFocusNode = FocusNode(debugLabel: 'MonacoWebViewFocus');
 
+  /// Whether Monaco itself reports the editor focused (its input can receive
+  /// keystrokes), driven by the controller's focus/blur stream. Lets a
+  /// pointer-down tell "already focused, leave it alone" apart from "Flutter
+  /// thinks it's focused but Monaco lost it" (the alt-tab/dialog desync).
+  bool _editorReportsFocused = false;
+
   @override
   void initState() {
     super.initState();
@@ -419,9 +435,15 @@ class _MonacoEditorState extends State<MonacoEditor> {
           .listen((r) => widget.onSelectionChanged?.call(r));
       _streamSubscriptions.add(selectionSub);
     }
-    final focusSub = _controller!.onFocus.listen((_) => widget.onFocus?.call());
+    final focusSub = _controller!.onFocus.listen((_) {
+      _editorReportsFocused = true;
+      widget.onFocus?.call();
+    });
     _streamSubscriptions.add(focusSub);
-    final blurSub = _controller!.onBlur.listen((_) => widget.onBlur?.call());
+    final blurSub = _controller!.onBlur.listen((_) {
+      _editorReportsFocused = false;
+      widget.onBlur?.call();
+    });
     _streamSubscriptions.add(blurSub);
 
     _statsListener =
@@ -553,7 +575,8 @@ class _MonacoEditorState extends State<MonacoEditor> {
               if (!widget.interactionEnabled) return;
               if (!_pointerShouldNudgeFocus(
                 event,
-                hasFocus: _webFocusNode.hasFocus,
+                hasFlutterFocus: _webFocusNode.hasFocus,
+                editorReportsFocused: _editorReportsFocused,
               )) {
                 return;
               }

--- a/lib/src/widgets/monaco_scaffold.dart
+++ b/lib/src/widgets/monaco_scaffold.dart
@@ -135,8 +135,9 @@ class MonacoScaffold extends StatelessWidget {
       floatingActionButton: _shield(floatingActionButton),
       floatingActionButtonLocation: floatingActionButtonLocation,
       floatingActionButtonAnimator: floatingActionButtonAnimator,
-      persistentFooterButtons:
-          persistentFooterButtons?.map((button) => _shield(button)!).toList(),
+      persistentFooterButtons: persistentFooterButtons
+          ?.map((button) => _shield(button)!)
+          .toList(),
       persistentFooterAlignment: persistentFooterAlignment,
       drawer: _shield(drawer),
       onDrawerChanged: onDrawerChanged,
@@ -160,20 +161,14 @@ class MonacoScaffold extends StatelessWidget {
     if (child == null) return null;
     if (!shieldStaticOverlays) return child;
 
-    return MonacoOverlayBoundary(
-      debug: overlayDebug,
-      child: child,
-    );
+    return MonacoOverlayBoundary(debug: overlayDebug, child: child);
   }
 
   PreferredSizeWidget? _shieldPreferredSize(PreferredSizeWidget? child) {
     if (child == null) return null;
     if (!shieldStaticOverlays) return child;
 
-    return _PreferredMonacoOverlayBoundary(
-      debug: overlayDebug,
-      child: child,
-    );
+    return _PreferredMonacoOverlayBoundary(debug: overlayDebug, child: child);
   }
 }
 
@@ -192,9 +187,6 @@ class _PreferredMonacoOverlayBoundary extends StatelessWidget
 
   @override
   Widget build(BuildContext context) {
-    return MonacoOverlayBoundary(
-      debug: debug,
-      child: child,
-    );
+    return MonacoOverlayBoundary(debug: debug, child: child);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 1.7.1
+version: 2.0.0
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues
@@ -22,8 +22,8 @@ platforms:
   # linux: # Not yet supported (no webview support yet)
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.29.0"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   convert_object: ^1.0.4
@@ -34,11 +34,7 @@ dependencies:
   path_provider: ^2.1.5
   web: ^1.1.1
   webview_flutter: ^4.13.1
-  webview_windows:
-    git:
-      url: https://github.com/omar-hanafy/packages.git
-      ref: webview-windows-2026-focus-fix
-      path: packages/webview_windows
+  webview_flutter_windows: ^1.0.0
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,11 @@ dependencies:
   path_provider: ^2.1.5
   web: ^1.1.1
   webview_flutter: ^4.13.1
-  webview_windows: ^0.4.0
+  webview_windows:
+    git:
+      url: https://github.com/omar-hanafy/packages.git
+      ref: webview-windows-2026-focus-fix
+      path: packages/webview_windows
 
 dev_dependencies:
   build_runner: ^2.10.5

--- a/test/core/monaco_actions_test.dart
+++ b/test/core/monaco_actions_test.dart
@@ -53,9 +53,13 @@ void main() {
       expect(MonacoAction.undo, 'undo');
       expect(MonacoAction.redo, 'redo');
       expect(
-          MonacoAction.clipboardCutAction, 'editor.action.clipboardCutAction');
-      expect(MonacoAction.clipboardCopyAction,
-          'editor.action.clipboardCopyAction');
+        MonacoAction.clipboardCutAction,
+        'editor.action.clipboardCutAction',
+      );
+      expect(
+        MonacoAction.clipboardCopyAction,
+        'editor.action.clipboardCopyAction',
+      );
       expect(
         MonacoAction.clipboardPasteAction,
         'editor.action.clipboardPasteAction',

--- a/test/core/monaco_assets_test.dart
+++ b/test/core/monaco_assets_test.dart
@@ -179,5 +179,67 @@ void main() {
       expect(html, contains('focusEditorTextAreaNow();'));
       expect(html, contains('ta.focus({ preventScroll: true });'));
     });
+
+    test('web html statically contains touch pans inside the editor document',
+        () {
+      final html = MonacoAssets.generateIndexHtml(
+        'https://example.com/assets/monaco/min/vs',
+        isWeb: true,
+        messageToken: 'token',
+      );
+
+      expect(html, contains('touch-action: none;'));
+      expect(html, contains('overscroll-behavior: none;'));
+    });
+
+    test('web html includes the visual viewport keyboard fit module', () {
+      final html = MonacoAssets.generateIndexHtml(
+        'https://example.com/assets/monaco/min/vs',
+        isWeb: true,
+        messageToken: 'token',
+      );
+
+      expect(html, contains('__flutterMonacoViewportFitBound'));
+      expect(html, contains('const applyViewportFit = () =>'));
+      expect(html, contains('const scheduleViewportFit = () =>'));
+      expect(html, contains('const clearViewportFit = () =>'));
+      expect(html, contains('fitFrame.getBoundingClientRect()'));
+      expect(html, contains('fitParent.visualViewport'));
+      expect(html, contains("fitViewport.addEventListener('resize'"));
+      expect(html, contains("fitViewport.addEventListener('scroll'"));
+      expect(html, contains('ed.revealPosition(pos)'));
+      expect(
+        html,
+        contains("fitWindow.addEventListener('pagehide', detachViewportFit"),
+      );
+    });
+
+    test('apple worker shim emits escaped newlines inside JS string literals',
+        () {
+      final html = MonacoAssets.generateIndexHtml('min/vs', isIosOrMacOS: true);
+
+      // The escape must reach JavaScript as the two characters backslash-n.
+      expect(html, contains(r'''};\n" +'''));
+      expect(html, contains(r"""';\n" +"""));
+      // A raw newline inside the JS string literal is a SyntaxError that
+      // silently disables MonacoEnvironment (workers fall back to the main
+      // thread), which is exactly what shipped between 1.0.0 and 1.7.0.
+      expect(html, isNot(contains('\' };\n" +')));
+      expect(html, isNot(contains('\';\n" +')));
+    });
+
+    test('native html does not opt into web scroll containment', () {
+      for (final html in [
+        MonacoAssets.generateIndexHtml('min/vs'),
+        MonacoAssets.generateIndexHtml('min/vs', isIosOrMacOS: true),
+        MonacoAssets.generateIndexHtml(r'file:///C:/monaco/min/vs',
+            isWindows: true),
+      ]) {
+        expect(html, isNot(contains('touch-action: none')));
+        expect(html, isNot(contains('overscroll-behavior')));
+        expect(html, isNot(contains('applyViewportFit')));
+        expect(html, isNot(contains('__flutterMonacoViewportFitBound')));
+      }
+    });
   });
 }

--- a/test/core/monaco_assets_test.dart
+++ b/test/core/monaco_assets_test.dart
@@ -118,10 +118,7 @@ void main() {
       expect(html, contains('ed.getScrollTop'));
       expect(html, contains('ed.getScrollLeft'));
       expect(html, contains('const hasMovedFromStart = (event) =>'));
-      expect(
-        html,
-        contains('const hasTouchScrollMovedFromStart = (event) =>'),
-      );
+      expect(html, contains('const hasTouchScrollMovedFromStart = (event) =>'));
       expect(html, contains('const blockEvent = (event) =>'));
       expect(html, contains('const suppressAndBlock = (event) =>'));
       expect(html, contains('const editorInputSelector ='));
@@ -180,17 +177,19 @@ void main() {
       expect(html, contains('ta.focus({ preventScroll: true });'));
     });
 
-    test('web html statically contains touch pans inside the editor document',
-        () {
-      final html = MonacoAssets.generateIndexHtml(
-        'https://example.com/assets/monaco/min/vs',
-        isWeb: true,
-        messageToken: 'token',
-      );
+    test(
+      'web html statically contains touch pans inside the editor document',
+      () {
+        final html = MonacoAssets.generateIndexHtml(
+          'https://example.com/assets/monaco/min/vs',
+          isWeb: true,
+          messageToken: 'token',
+        );
 
-      expect(html, contains('touch-action: none;'));
-      expect(html, contains('overscroll-behavior: none;'));
-    });
+        expect(html, contains('touch-action: none;'));
+        expect(html, contains('overscroll-behavior: none;'));
+      },
+    );
 
     test('web html includes the visual viewport keyboard fit module', () {
       final html = MonacoAssets.generateIndexHtml(
@@ -214,26 +213,33 @@ void main() {
       );
     });
 
-    test('apple worker shim emits escaped newlines inside JS string literals',
-        () {
-      final html = MonacoAssets.generateIndexHtml('min/vs', isIosOrMacOS: true);
+    test(
+      'apple worker shim emits escaped newlines inside JS string literals',
+      () {
+        final html = MonacoAssets.generateIndexHtml(
+          'min/vs',
+          isIosOrMacOS: true,
+        );
 
-      // The escape must reach JavaScript as the two characters backslash-n.
-      expect(html, contains(r'''};\n" +'''));
-      expect(html, contains(r"""';\n" +"""));
-      // A raw newline inside the JS string literal is a SyntaxError that
-      // silently disables MonacoEnvironment (workers fall back to the main
-      // thread), which is exactly what shipped between 1.0.0 and 1.7.0.
-      expect(html, isNot(contains('\' };\n" +')));
-      expect(html, isNot(contains('\';\n" +')));
-    });
+        // The escape must reach JavaScript as the two characters backslash-n.
+        expect(html, contains(r'''};\n" +'''));
+        expect(html, contains(r"""';\n" +"""));
+        // A raw newline inside the JS string literal is a SyntaxError that
+        // silently disables MonacoEnvironment (workers fall back to the main
+        // thread), which is exactly what shipped between 1.0.0 and 1.7.0.
+        expect(html, isNot(contains('\' };\n" +')));
+        expect(html, isNot(contains('\';\n" +')));
+      },
+    );
 
     test('native html does not opt into web scroll containment', () {
       for (final html in [
         MonacoAssets.generateIndexHtml('min/vs'),
         MonacoAssets.generateIndexHtml('min/vs', isIosOrMacOS: true),
-        MonacoAssets.generateIndexHtml(r'file:///C:/monaco/min/vs',
-            isWindows: true),
+        MonacoAssets.generateIndexHtml(
+          r'file:///C:/monaco/min/vs',
+          isWindows: true,
+        ),
       ]) {
         expect(html, isNot(contains('touch-action: none')));
         expect(html, isNot(contains('overscroll-behavior')));

--- a/test/core/monaco_bridge_test.dart
+++ b/test/core/monaco_bridge_test.dart
@@ -46,7 +46,7 @@ void main() {
         final bridge = MonacoBridge();
         // Lists should not crash, just not be processed as events
         bridge.handleJavaScriptMessage([
-          {'event': 'stats'}
+          {'event': 'stats'},
         ]);
         expect(bridge.liveStats.value.lineCount.value, 0); // Default
       });
@@ -155,8 +155,12 @@ void main() {
         bridge.handleJavaScriptMessage('{"event":"focus"}');
         bridge.handleJavaScriptMessage('{"event":"blur"}');
 
-        expect(
-            received, ['contentChanged', 'selectionChanged', 'focus', 'blur']);
+        expect(received, [
+          'contentChanged',
+          'selectionChanged',
+          'focus',
+          'blur',
+        ]);
       });
 
       test('isolates exceptions between listeners', () {

--- a/test/core/monaco_controller_completion_test.dart
+++ b/test/core/monaco_controller_completion_test.dart
@@ -6,7 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import '../fakes/fake_platform_webview_controller.dart';
 
 Future<MonacoController> _createController(
-    FakePlatformWebViewController webview) async {
+  FakePlatformWebViewController webview,
+) async {
   return MonacoController.createForTesting(
     webViewController: webview,
     markReady: true,
@@ -102,8 +103,9 @@ void main() {
           provider: (_) async => const CompletionList(suggestions: []),
         );
 
-        final call =
-            webview.scriptsContaining('registerCompletionSource').first;
+        final call = webview
+            .scriptsContaining('registerCompletionSource')
+            .first;
         expect(call, contains('"myProvider"'));
         expect(call, contains('"dart"'));
         expect(call, contains('"typescript"'));
@@ -171,8 +173,9 @@ void main() {
         expect(request.position.line, 1);
         expect(request.position.column, 2);
 
-        final completeCall =
-            webview.scriptsContaining('flutterMonaco.complete').first;
+        final completeCall = webview
+            .scriptsContaining('flutterMonaco.complete')
+            .first;
         expect(completeCall, contains('"req-1"'));
         expect(completeCall, contains('"print"'));
         expect(completeCall, contains('"println"'));
@@ -194,9 +197,7 @@ void main() {
           },
         );
 
-        webview.emitToChannel(
-          'flutterChannel',
-          '''
+        webview.emitToChannel('flutterChannel', '''
           {
             "event":"completionRequest",
             "providerId":"p1",
@@ -208,8 +209,7 @@ void main() {
             "triggerKind":2,
             "triggerCharacter":"."
           }
-          ''',
-        );
+          ''');
         await pumpEventQueue();
 
         expect(receivedRequest, isNotNull);
@@ -237,8 +237,9 @@ void main() {
         );
         await pumpEventQueue();
 
-        final completeCall =
-            webview.scriptsContaining('flutterMonaco.complete').first;
+        final completeCall = webview
+            .scriptsContaining('flutterMonaco.complete')
+            .first;
         expect(completeCall, contains('"suggestions":[]'));
         expect(completeCall, isNot(contains('"should not appear"')));
       });
@@ -261,8 +262,9 @@ void main() {
         );
         await pumpEventQueue();
 
-        final completeCall =
-            webview.scriptsContaining('flutterMonaco.complete').first;
+        final completeCall = webview
+            .scriptsContaining('flutterMonaco.complete')
+            .first;
         expect(completeCall, contains('"suggestions":[]'));
       });
 
@@ -563,9 +565,7 @@ void main() {
           id: 'p1',
           languages: const ['dart'],
           provider: (_) async => const CompletionList(
-            suggestions: [
-              CompletionItem(label: 'minimal'),
-            ],
+            suggestions: [CompletionItem(label: 'minimal')],
           ),
         );
 

--- a/test/core/monaco_controller_create_test.dart
+++ b/test/core/monaco_controller_create_test.dart
@@ -71,6 +71,9 @@ class _ThrowingWebViewController implements PlatformWebViewController {
   }
 
   @override
+  Future<void> requestNativeFocus() async {}
+
+  @override
   Widget get widget => const SizedBox.shrink();
 
   @override

--- a/test/core/monaco_controller_source_test.dart
+++ b/test/core/monaco_controller_source_test.dart
@@ -4,8 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('web queued setters return before editor readiness', () {
-    final source =
-        File('lib/src/core/monaco_controller.dart').readAsStringSync();
+    final source = File(
+      'lib/src/core/monaco_controller.dart',
+    ).readAsStringSync();
 
     expect(source, contains('_queuedLanguage = language;'));
     expect(source, contains('_queuedValue = value;'));

--- a/test/core/monaco_controller_test.dart
+++ b/test/core/monaco_controller_test.dart
@@ -27,10 +27,7 @@ Future<_TestBundle> _createBundle({bool ready = true}) async {
   return _TestBundle(controller, webview, bridge);
 }
 
-String _evaluationEnvelope({
-  Object? value,
-  bool isUndefined = false,
-}) {
+String _evaluationEnvelope({Object? value, bool isUndefined = false}) {
   return jsonEncode({
     '__flutterMonacoEval': true,
     'isUndefined': isUndefined,
@@ -104,8 +101,9 @@ void main() {
         bundle.controller.completeReadyForTesting();
         await future;
         expect(
-          bundle.webview.executed
-              .any((script) => script.contains('findMatches')),
+          bundle.webview.executed.any(
+            (script) => script.contains('findMatches'),
+          ),
           true,
         );
       });
@@ -128,42 +126,48 @@ void main() {
         expect(joined.contains('forceFocus'), true);
       });
 
-      test('executeAction routes toolbar commands to monaco action ids',
-          () async {
-        final bundle = await _createBundle();
+      test(
+        'executeAction routes toolbar commands to monaco action ids',
+        () async {
+          final bundle = await _createBundle();
 
-        const ids = [
-          MonacoAction.foldAll,
-          MonacoAction.unfoldAll,
-          MonacoAction.commentLine,
-          MonacoAction.indentLines,
-          MonacoAction.outdentLines,
-        ];
-        for (final id in ids) {
-          await bundle.controller.executeAction(id);
-        }
+          const ids = [
+            MonacoAction.foldAll,
+            MonacoAction.unfoldAll,
+            MonacoAction.commentLine,
+            MonacoAction.indentLines,
+            MonacoAction.outdentLines,
+          ];
+          for (final id in ids) {
+            await bundle.controller.executeAction(id);
+          }
 
-        final joined = bundle.webview.executed.join('\n');
-        for (final id in ids) {
-          expect(joined.contains(id), true, reason: 'missing $id');
-        }
-      });
+          final joined = bundle.webview.executed.join('\n');
+          for (final id in ids) {
+            expect(joined.contains(id), true, reason: 'missing $id');
+          }
+        },
+      );
 
-      test('command failure envelope throws MonacoJavaScriptException',
-          () async {
-        final bundle = await _createBundle();
-        bundle.webview
-            .injectCommandFailure('executeAction', message: 'broken action');
+      test(
+        'command failure envelope throws MonacoJavaScriptException',
+        () async {
+          final bundle = await _createBundle();
+          bundle.webview.injectCommandFailure(
+            'executeAction',
+            message: 'broken action',
+          );
 
-        await expectLater(
-          () => bundle.controller.executeAction('whatever'),
-          throwsA(
-            isA<MonacoJavaScriptException>()
-                .having((e) => e.operation, 'operation', 'executeAction')
-                .having((e) => e.message, 'message', 'broken action'),
-          ),
-        );
-      });
+          await expectLater(
+            () => bundle.controller.executeAction('whatever'),
+            throwsA(
+              isA<MonacoJavaScriptException>()
+                  .having((e) => e.operation, 'operation', 'executeAction')
+                  .having((e) => e.message, 'message', 'broken action'),
+            ),
+          );
+        },
+      );
     });
 
     group('theme registration', () {
@@ -172,16 +176,15 @@ void main() {
         const theme = MonacoThemeDefinition(
           id: 'app-dark',
           base: MonacoTheme.vsDark,
-          rules: [
-            MonacoThemeRule(token: 'comment', foreground: '6A9955'),
-          ],
+          rules: [MonacoThemeRule(token: 'comment', foreground: '6A9955')],
           colors: {'editor.background': '#101010'},
         );
 
         await bundle.controller.defineTheme(theme);
 
-        final invocation =
-            bundle.webview.scriptsContaining('"defineTheme"').single;
+        final invocation = bundle.webview
+            .scriptsContaining('"defineTheme"')
+            .single;
         expect(invocation, contains('"app-dark"'));
         expect(invocation, contains('"vs-dark"'));
         expect(invocation, contains('"6A9955"'));
@@ -197,8 +200,9 @@ void main() {
           'colors': {'editor.background': '#FFFFFF'},
         });
 
-        final invocation =
-            bundle.webview.scriptsContaining('"defineTheme"').single;
+        final invocation = bundle.webview
+            .scriptsContaining('"defineTheme"')
+            .single;
         expect(invocation, contains('"raw-id"'));
         expect(invocation, contains('"editor.background"'));
         expect(invocation, contains('"#FFFFFF"'));
@@ -235,48 +239,54 @@ void main() {
         expect(await bundle.controller.getThemeId(), isNull);
       });
 
-      test('getThemeId returns null when bridge reports empty string',
-          () async {
-        final bundle = await _createBundle();
-        bundle.webview.injectCommandSuccess('getTheme', value: '');
-        expect(await bundle.controller.getThemeId(), isNull);
-      });
+      test(
+        'getThemeId returns null when bridge reports empty string',
+        () async {
+          final bundle = await _createBundle();
+          bundle.webview.injectCommandSuccess('getTheme', value: '');
+          expect(await bundle.controller.getThemeId(), isNull);
+        },
+      );
 
-      test('MonacoThemeDefinition JSON round-trip preserves rules and colors',
-          () {
-        const original = MonacoThemeDefinition(
-          id: 'roundtrip',
-          base: MonacoTheme.hcBlack,
-          inherit: false,
-          rules: [
-            MonacoThemeRule(
-              token: 'keyword',
-              foreground: '569CD6',
-              fontStyle: 'italic',
-            ),
-            MonacoThemeRule(token: 'string', foreground: 'CE9178'),
-          ],
-          colors: {
-            'editor.background': '#1E1E1E',
-            'editor.foreground': '#D4D4D4',
-          },
-        );
+      test(
+        'MonacoThemeDefinition JSON round-trip preserves rules and colors',
+        () {
+          const original = MonacoThemeDefinition(
+            id: 'roundtrip',
+            base: MonacoTheme.hcBlack,
+            inherit: false,
+            rules: [
+              MonacoThemeRule(
+                token: 'keyword',
+                foreground: '569CD6',
+                fontStyle: 'italic',
+              ),
+              MonacoThemeRule(token: 'string', foreground: 'CE9178'),
+            ],
+            colors: {
+              'editor.background': '#1E1E1E',
+              'editor.foreground': '#D4D4D4',
+            },
+          );
 
-        final json = original.toJson();
-        final restored = MonacoThemeDefinition.fromJson(json);
+          final json = original.toJson();
+          final restored = MonacoThemeDefinition.fromJson(json);
 
-        expect(restored, equals(original));
-      });
+          expect(restored, equals(original));
+        },
+      );
 
-      test('MonacoThemeRule.fromJson accepts empty token as default selector',
-          () {
-        final rule = MonacoThemeRule.fromJson(const {
-          'token': '',
-          'foreground': 'D4D4D4',
-        });
-        expect(rule.token, isEmpty);
-        expect(rule.foreground, 'D4D4D4');
-      });
+      test(
+        'MonacoThemeRule.fromJson accepts empty token as default selector',
+        () {
+          final rule = MonacoThemeRule.fromJson(const {
+            'token': '',
+            'foreground': 'D4D4D4',
+          });
+          expect(rule.token, isEmpty);
+          expect(rule.foreground, 'D4D4D4');
+        },
+      );
 
       test('MonacoThemeDefinition.fromMonacoThemeData attaches the id', () {
         final restored = MonacoThemeDefinition.fromMonacoThemeData(
@@ -298,8 +308,10 @@ void main() {
       });
 
       test('EditorOptions.effectiveThemeId prefers themeId override', () {
-        const builtIn =
-            EditorOptions(theme: MonacoTheme.vs, themeId: 'custom-dark');
+        const builtIn = EditorOptions(
+          theme: MonacoTheme.vs,
+          themeId: 'custom-dark',
+        );
         expect(builtIn.effectiveThemeId, 'custom-dark');
 
         const fallback = EditorOptions(theme: MonacoTheme.hcLight);
@@ -318,17 +330,19 @@ void main() {
         expect(builtIn.theme, MonacoTheme.vs);
       });
 
-      test('EditorOptions.fromJson preserves built-in fallback with themeId',
-          () {
-        final options = EditorOptions.fromJson(const {
-          'theme': 'hc-light',
-          'themeId': 'app-dark',
-        });
+      test(
+        'EditorOptions.fromJson preserves built-in fallback with themeId',
+        () {
+          final options = EditorOptions.fromJson(const {
+            'theme': 'hc-light',
+            'themeId': 'app-dark',
+          });
 
-        expect(options.theme, MonacoTheme.hcLight);
-        expect(options.themeId, 'app-dark');
-        expect(options.effectiveThemeId, 'app-dark');
-      });
+          expect(options.theme, MonacoTheme.hcLight);
+          expect(options.themeId, 'app-dark');
+          expect(options.effectiveThemeId, 'app-dark');
+        },
+      );
     });
 
     group('interaction', () {
@@ -337,19 +351,21 @@ void main() {
         expect(bundle.controller.isInteractionEnabled, true);
       });
 
-      test('setInteractionEnabled updates state and webview immediately',
-          () async {
-        final bundle = await _createBundle(ready: false);
+      test(
+        'setInteractionEnabled updates state and webview immediately',
+        () async {
+          final bundle = await _createBundle(ready: false);
 
-        await bundle.controller.setInteractionEnabled(false);
+          await bundle.controller.setInteractionEnabled(false);
 
-        expect(bundle.controller.isInteractionEnabled, false);
-        expect(bundle.webview.interactionEnabled, false);
-        expect(
-          bundle.webview.executed.any((s) => s == 'SET_INTERACTION:false'),
-          true,
-        );
-      });
+          expect(bundle.controller.isInteractionEnabled, false);
+          expect(bundle.webview.interactionEnabled, false);
+          expect(
+            bundle.webview.executed.any((s) => s == 'SET_INTERACTION:false'),
+            true,
+          );
+        },
+      );
     });
 
     group('content queuing', () {
@@ -399,8 +415,9 @@ void main() {
       test('returns defaultValue on error', () async {
         final bundle = await _createBundle();
         bundle.webview.injectCommandFailure('getValue', message: 'boom');
-        final value =
-            await bundle.controller.getValue(defaultValue: 'fallback');
+        final value = await bundle.controller.getValue(
+          defaultValue: 'fallback',
+        );
         expect(value, 'fallback');
       });
 
@@ -546,8 +563,10 @@ void main() {
       test('getLineContent validates bounds - below', () async {
         final bundle = await _createBundle();
         bundle.webview.injectCommandSuccess('getLineCount', value: 3);
-        final value =
-            await bundle.controller.getLineContent(0, defaultValue: 'x');
+        final value = await bundle.controller.getLineContent(
+          0,
+          defaultValue: 'x',
+        );
         expect(value, 'x');
         expect(
           bundle.webview.executed.any((s) => s.contains('"getLineContent"')),
@@ -558,8 +577,10 @@ void main() {
       test('getLineContent validates bounds - above', () async {
         final bundle = await _createBundle();
         bundle.webview.injectCommandSuccess('getLineCount', value: 3);
-        final value =
-            await bundle.controller.getLineContent(10, defaultValue: 'y');
+        final value = await bundle.controller.getLineContent(
+          10,
+          defaultValue: 'y',
+        );
         expect(value, 'y');
       });
 
@@ -632,12 +653,7 @@ void main() {
       test('deleteRange creates delete operation', () async {
         final bundle = await _createBundle();
         await bundle.controller.deleteRange(
-          const Range(
-            startLine: 1,
-            startColumn: 1,
-            endLine: 1,
-            endColumn: 5,
-          ),
+          const Range(startLine: 1, startColumn: 1, endLine: 1, endColumn: 5),
         );
         final joined = bundle.webview.executed.join('\n');
         expect(joined, contains('applyEdits'));
@@ -647,12 +663,7 @@ void main() {
       test('replaceRange creates replace operation', () async {
         final bundle = await _createBundle();
         await bundle.controller.replaceRange(
-          const Range(
-            startLine: 1,
-            startColumn: 1,
-            endLine: 1,
-            endColumn: 5,
-          ),
+          const Range(startLine: 1, startColumn: 1, endLine: 1, endColumn: 5),
           'replacement',
         );
         final joined = bundle.webview.executed.join('\n');
@@ -672,8 +683,10 @@ void main() {
     group('decorations', () {
       test('setDecorations tracks ids across calls', () async {
         final bundle = await _createBundle();
-        bundle.webview
-            .injectCommandSuccess('deltaDecorations', value: ['a', 'b']);
+        bundle.webview.injectCommandSuccess(
+          'deltaDecorations',
+          value: ['a', 'b'],
+        );
         bundle.webview.injectCommandSuccess('deltaDecorations', value: ['c']);
 
         final first = await bundle.controller.setDecorations([
@@ -699,8 +712,10 @@ void main() {
       test('setDecorations throws on malformed bridge result', () async {
         final bundle = await _createBundle();
         bundle.webview.injectCommandSuccess('deltaDecorations', value: ['a']);
-        bundle.webview
-            .injectCommandSuccess('deltaDecorations', value: 'not-a-list');
+        bundle.webview.injectCommandSuccess(
+          'deltaDecorations',
+          value: 'not-a-list',
+        );
         bundle.webview.injectCommandSuccess('deltaDecorations', value: ['b']);
 
         final first = await bundle.controller.setDecorations([
@@ -719,16 +734,16 @@ void main() {
         await expectLater(
           () => bundle.controller.setDecorations(const []),
           throwsA(
-            isA<MonacoJavaScriptException>()
-                .having((e) => e.operation, 'operation', 'deltaDecorations'),
+            isA<MonacoJavaScriptException>().having(
+              (e) => e.operation,
+              'operation',
+              'deltaDecorations',
+            ),
           ),
         );
 
         await bundle.controller.setDecorations(const []);
-        expect(
-          bundle.webview.executed.join('\n'),
-          contains('["a"]'),
-        );
+        expect(bundle.webview.executed.join('\n'), contains('["a"]'));
       });
 
       test('addInlineDecorations creates correct options', () async {
@@ -746,21 +761,25 @@ void main() {
 
       test('addLineDecorations creates whole line decorations', () async {
         final bundle = await _createBundle();
-        bundle.webview
-            .injectCommandSuccess('deltaDecorations', value: ['l1', 'l2']);
-
-        final ids = await bundle.controller.addLineDecorations(
-          [1, 2],
-          'line-highlight',
+        bundle.webview.injectCommandSuccess(
+          'deltaDecorations',
+          value: ['l1', 'l2'],
         );
+
+        final ids = await bundle.controller.addLineDecorations([
+          1,
+          2,
+        ], 'line-highlight');
         expect(ids, ['l1', 'l2']);
         expect(bundle.webview.executed.join('\n'), contains('isWholeLine'));
       });
 
       test('clearDecorations passes empty array', () async {
         final bundle = await _createBundle();
-        bundle.webview
-            .injectCommandSuccess('deltaDecorations', value: <String>[]);
+        bundle.webview.injectCommandSuccess(
+          'deltaDecorations',
+          value: <String>[],
+        );
 
         await bundle.controller.clearDecorations();
         expect(
@@ -773,20 +792,17 @@ void main() {
     group('markers', () {
       test('setMarkers uses owner and severity values', () async {
         final bundle = await _createBundle();
-        await bundle.controller.setMarkers(
-          [
-            MarkerData.error(
-              range: const Range(
-                startLine: 1,
-                startColumn: 1,
-                endLine: 1,
-                endColumn: 10,
-              ),
-              message: 'Error message',
+        await bundle.controller.setMarkers([
+          MarkerData.error(
+            range: const Range(
+              startLine: 1,
+              startColumn: 1,
+              endLine: 1,
+              endColumn: 10,
             ),
-          ],
-          owner: 'flutter-errors',
-        );
+            message: 'Error message',
+          ),
+        ], owner: 'flutter-errors');
 
         final joined = bundle.webview.executed.join('\n');
         expect(joined, contains('setModelMarkers'));
@@ -824,7 +840,9 @@ void main() {
           ),
         ]);
         expect(
-            bundle.webview.executed.join('\n'), contains('flutter-warnings'));
+          bundle.webview.executed.join('\n'),
+          contains('flutter-warnings'),
+        );
       });
 
       test('clearAllMarkers clears all known owners', () async {
@@ -1043,16 +1061,18 @@ void main() {
         await bundle.controller.setCursorPosition(
           const Position(line: 3, column: 7),
         );
-        final invocation =
-            bundle.webview.scriptsContaining('"setCursorPosition"').single;
+        final invocation = bundle.webview
+            .scriptsContaining('"setCursorPosition"')
+            .single;
         expect(invocation, contains('[3,7]'));
       });
 
       test('setCursorPositionZeroBased converts to 1-based', () async {
         final bundle = await _createBundle();
         await bundle.controller.setCursorPositionZeroBased(0, 0);
-        final invocation =
-            bundle.webview.scriptsContaining('"setCursorPosition"').single;
+        final invocation = bundle.webview
+            .scriptsContaining('"setCursorPosition"')
+            .single;
         expect(invocation, contains('[1,1]'));
       });
 
@@ -1073,10 +1093,7 @@ void main() {
       test('format calls formatDocument action', () async {
         final bundle = await _createBundle();
         await bundle.controller.format();
-        expect(
-          bundle.webview.executed.join('\n'),
-          contains('formatDocument'),
-        );
+        expect(bundle.webview.executed.join('\n'), contains('formatDocument'));
       });
 
       test('find calls find action', () async {
@@ -1097,10 +1114,7 @@ void main() {
       test('toggleWordWrap calls action', () async {
         final bundle = await _createBundle();
         await bundle.controller.toggleWordWrap();
-        expect(
-          bundle.webview.executed.join('\n'),
-          contains('toggleWordWrap'),
-        );
+        expect(bundle.webview.executed.join('\n'), contains('toggleWordWrap'));
       });
 
       test('undo/redo call correct actions', () async {
@@ -1166,51 +1180,50 @@ void main() {
       });
 
       testWidgets(
-          'focus and ensureEditorFocus do not steal the keyboard from a '
-          'focused Flutter text input', (tester) async {
-        final bundle = await _createBundle();
-        final focusNode = FocusNode();
-        addTearDown(focusNode.dispose);
+        'focus and ensureEditorFocus do not steal the keyboard from a '
+        'focused Flutter text input',
+        (tester) async {
+          final bundle = await _createBundle();
+          final focusNode = FocusNode();
+          addTearDown(focusNode.dispose);
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: TextField(focusNode: focusNode, autofocus: true),
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: TextField(focusNode: focusNode, autofocus: true),
+              ),
             ),
-          ),
-        );
-        await tester.pump();
-        expect(focusNode.hasPrimaryFocus, isTrue);
+          );
+          await tester.pump();
+          expect(focusNode.hasPrimaryFocus, isTrue);
 
-        // While the TextField owns the keyboard, both helpers must no-op:
-        // on Windows requestNativeFocus would move real Win32 focus to the
-        // WebView and typing would land in the editor instead of the field.
-        await tester.runAsync(() => bundle.controller.focus());
-        await tester.runAsync(
-          () => bundle.controller.ensureEditorFocus(
-            attempts: 2,
-            interval: Duration.zero,
-          ),
-        );
-        expect(
-          bundle.webview.executed.where((s) => s.contains('forceFocus')),
-          isEmpty,
-        );
-        expect(
-          bundle.webview.executed,
-          isNot(contains('REQUEST_NATIVE_FOCUS')),
-        );
+          // While the TextField owns the keyboard, both helpers must no-op:
+          // on Windows requestNativeFocus would move real Win32 focus to the
+          // WebView and typing would land in the editor instead of the field.
+          await tester.runAsync(() => bundle.controller.focus());
+          await tester.runAsync(
+            () => bundle.controller.ensureEditorFocus(
+              attempts: 2,
+              interval: Duration.zero,
+            ),
+          );
+          expect(
+            bundle.webview.executed.where((s) => s.contains('forceFocus')),
+            isEmpty,
+          );
+          expect(
+            bundle.webview.executed,
+            isNot(contains('REQUEST_NATIVE_FOCUS')),
+          );
 
-        // Once the text input releases the keyboard, focusing works again.
-        focusNode.unfocus();
-        await tester.pump();
-        await tester.runAsync(() => bundle.controller.focus());
-        expect(bundle.webview.executed, contains('REQUEST_NATIVE_FOCUS'));
-        expect(
-          bundle.webview.executed.join('\n'),
-          contains('forceFocus'),
-        );
-      });
+          // Once the text input releases the keyboard, focusing works again.
+          focusNode.unfocus();
+          await tester.pump();
+          await tester.runAsync(() => bundle.controller.focus());
+          expect(bundle.webview.executed, contains('REQUEST_NATIVE_FOCUS'));
+          expect(bundle.webview.executed.join('\n'), contains('forceFocus'));
+        },
+      );
 
       test('layout calls layout', () async {
         final bundle = await _createBundle();
@@ -1269,8 +1282,10 @@ void main() {
           'JSON.stringify(flutterMonaco.getCursorPosition())',
           '{"lineNumber":1,"column":3}',
         );
-        bundle.webview
-            .enqueueResult('flutterMonaco.hasUnsavedChanges()', false);
+        bundle.webview.enqueueResult(
+          'flutterMonaco.hasUnsavedChanges()',
+          false,
+        );
 
         final state = await bundle.controller.getEditorState();
 
@@ -1365,10 +1380,7 @@ void main() {
         expect(bundle.webview.executed, isEmpty);
         bundle.controller.completeReadyForTesting();
         await future;
-        expect(
-          bundle.webview.hasExecuted('setJsonDiagnosticsOptions'),
-          true,
-        );
+        expect(bundle.webview.hasExecuted('setJsonDiagnosticsOptions'), true);
       });
 
       test('generates correct JS payload', () async {
@@ -1416,11 +1428,7 @@ void main() {
                   'operation',
                   'setJsonDiagnosticsOptions',
                 )
-                .having(
-                  (e) => e.message,
-                  'message',
-                  'json diagnostics failed',
-                ),
+                .having((e) => e.message, 'message', 'json diagnostics failed'),
           ),
         );
       });
@@ -1546,23 +1554,25 @@ void main() {
         expect(result, 'hello');
       });
 
-      test('preserves numeric-looking string result when T is String',
-          () async {
-        final bundle = await _createBundle();
-        bundle.webview.resultResolver = (script) {
-          if (script.contains('__flutterMonacoEval')) {
-            return _evaluationEnvelope(value: '42');
-          }
-          return null;
-        };
+      test(
+        'preserves numeric-looking string result when T is String',
+        () async {
+          final bundle = await _createBundle();
+          bundle.webview.resultResolver = (script) {
+            if (script.contains('__flutterMonacoEval')) {
+              return _evaluationEnvelope(value: '42');
+            }
+            return null;
+          };
 
-        final result = await bundle.controller.evaluateJavaScript<String>(
-          '"42"',
-        );
+          final result = await bundle.controller.evaluateJavaScript<String>(
+            '"42"',
+          );
 
-        expect(result, '42');
-        expect(result, isA<String>());
-      });
+          expect(result, '42');
+          expect(result, isA<String>());
+        },
+      );
 
       test('returns maps', () async {
         final bundle = await _createBundle();
@@ -1677,16 +1687,18 @@ void main() {
         final bundle = await _createBundle();
         bundle.webview.enqueueResult('myQuery()', '42');
 
-        final result = await bundle.controller
-            .runJavaScriptReturningResultRaw('myQuery()');
+        final result = await bundle.controller.runJavaScriptReturningResultRaw(
+          'myQuery()',
+        );
 
         expect(result, '42');
       });
 
       test('waits for ready before executing', () async {
         final bundle = await _createBundle(ready: false);
-        final future =
-            bundle.controller.runJavaScriptReturningResultRaw('myQuery()');
+        final future = bundle.controller.runJavaScriptReturningResultRaw(
+          'myQuery()',
+        );
         expect(bundle.webview.executed, isEmpty);
 
         bundle.webview.enqueueResult('myQuery()', 42);

--- a/test/core/monaco_controller_test.dart
+++ b/test/core/monaco_controller_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/core/monaco_bridge.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1162,6 +1163,53 @@ void main() {
         } finally {
           debugDefaultTargetPlatformOverride = null;
         }
+      });
+
+      testWidgets(
+          'focus and ensureEditorFocus do not steal the keyboard from a '
+          'focused Flutter text input', (tester) async {
+        final bundle = await _createBundle();
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TextField(focusNode: focusNode, autofocus: true),
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(focusNode.hasPrimaryFocus, isTrue);
+
+        // While the TextField owns the keyboard, both helpers must no-op:
+        // on Windows requestNativeFocus would move real Win32 focus to the
+        // WebView and typing would land in the editor instead of the field.
+        await tester.runAsync(() => bundle.controller.focus());
+        await tester.runAsync(
+          () => bundle.controller.ensureEditorFocus(
+            attempts: 2,
+            interval: Duration.zero,
+          ),
+        );
+        expect(
+          bundle.webview.executed.where((s) => s.contains('forceFocus')),
+          isEmpty,
+        );
+        expect(
+          bundle.webview.executed,
+          isNot(contains('REQUEST_NATIVE_FOCUS')),
+        );
+
+        // Once the text input releases the keyboard, focusing works again.
+        focusNode.unfocus();
+        await tester.pump();
+        await tester.runAsync(() => bundle.controller.focus());
+        expect(bundle.webview.executed, contains('REQUEST_NATIVE_FOCUS'));
+        expect(
+          bundle.webview.executed.join('\n'),
+          contains('forceFocus'),
+        );
       });
 
       test('layout calls layout', () async {

--- a/test/fakes/fake_platform_webview_controller.dart
+++ b/test/fakes/fake_platform_webview_controller.dart
@@ -23,7 +23,7 @@ class FakePlatformWebViewController implements PlatformWebViewController {
   ///
   /// [widget] - Optional widget to return from [widget] getter.
   FakePlatformWebViewController({Widget? widget})
-      : _widget = widget ?? const SizedBox.shrink();
+    : _widget = widget ?? const SizedBox.shrink();
 
   /// All executed JavaScript scripts in order.
   final List<String> executed = [];

--- a/test/fakes/fake_platform_webview_controller.dart
+++ b/test/fakes/fake_platform_webview_controller.dart
@@ -127,6 +127,11 @@ class FakePlatformWebViewController implements PlatformWebViewController {
   }
 
   @override
+  Future<void> requestNativeFocus() async {
+    executed.add('REQUEST_NATIVE_FOCUS');
+  }
+
+  @override
   Future<void> runJavaScript(String script) async {
     if (disposed) {
       throw StateError('Cannot run JS on disposed controller');

--- a/test/models/monaco_enums_test.dart
+++ b/test/models/monaco_enums_test.dart
@@ -14,7 +14,9 @@ void main() {
         AutoClosingBehavior.languageDefined,
       );
       expect(
-          DiagnosticsSeverity.fromId('unknown'), DiagnosticsSeverity.warning);
+        DiagnosticsSeverity.fromId('unknown'),
+        DiagnosticsSeverity.warning,
+      );
     });
 
     test('ids match expected values', () {

--- a/test/models/monaco_types_test.dart
+++ b/test/models/monaco_types_test.dart
@@ -5,10 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Position', () {
     test('fromJson with standard keys', () {
-      final pos = Position.fromJson({
-        'lineNumber': 5,
-        'column': 10,
-      });
+      final pos = Position.fromJson({'lineNumber': 5, 'column': 10});
       expect(pos.line, 5);
       expect(pos.column, 10);
     });
@@ -171,7 +168,9 @@ void main() {
       expect(range.containsPosition(const Position(line: 1, column: 5)), false);
       expect(range.containsPosition(const Position(line: 2, column: 4)), false);
       expect(
-          range.containsPosition(const Position(line: 4, column: 11)), false);
+        range.containsPosition(const Position(line: 4, column: 11)),
+        false,
+      );
       expect(range.containsPosition(const Position(line: 5, column: 1)), false);
     });
 
@@ -264,12 +263,7 @@ void main() {
 
     test('toJson includes all fields', () {
       const marker = MarkerData(
-        range: Range(
-          startLine: 1,
-          startColumn: 1,
-          endLine: 1,
-          endColumn: 10,
-        ),
+        range: Range(startLine: 1, startColumn: 1, endLine: 1, endColumn: 10),
         message: 'Test message',
         severity: MarkerSeverity.error,
         code: 'E001',
@@ -287,12 +281,7 @@ void main() {
 
     test('toJson excludes null optional fields', () {
       const marker = MarkerData(
-        range: Range(
-          startLine: 1,
-          startColumn: 1,
-          endLine: 1,
-          endColumn: 5,
-        ),
+        range: Range(startLine: 1, startColumn: 1, endLine: 1, endColumn: 5),
         message: 'Test',
       );
 
@@ -418,12 +407,7 @@ void main() {
 
     test('toJson excludes forceMoveMarkers when null', () {
       const edit = EditOperation(
-        range: Range(
-          startLine: 1,
-          startColumn: 1,
-          endLine: 1,
-          endColumn: 1,
-        ),
+        range: Range(startLine: 1, startColumn: 1, endLine: 1, endColumn: 1),
         text: 'test',
       );
 
@@ -484,7 +468,9 @@ void main() {
 
     test('fromJsonValue defaults to text', () {
       expect(
-          CompletionItemKind.fromJsonValue('Unknown'), CompletionItemKind.text);
+        CompletionItemKind.fromJsonValue('Unknown'),
+        CompletionItemKind.text,
+      );
     });
 
     test('maybeFromJsonValue returns null for unknown', () {
@@ -570,22 +556,10 @@ void main() {
     });
 
     test('hasSelection and hasMultipleCursors', () {
-      expect(
-        LiveStats.fromJson({'selChars': 5}).hasSelection,
-        true,
-      );
-      expect(
-        LiveStats.fromJson({'selChars': 0}).hasSelection,
-        false,
-      );
-      expect(
-        LiveStats.fromJson({'caretCount': 3}).hasMultipleCursors,
-        true,
-      );
-      expect(
-        LiveStats.fromJson({'caretCount': 1}).hasMultipleCursors,
-        false,
-      );
+      expect(LiveStats.fromJson({'selChars': 5}).hasSelection, true);
+      expect(LiveStats.fromJson({'selChars': 0}).hasSelection, false);
+      expect(LiveStats.fromJson({'caretCount': 3}).hasMultipleCursors, true);
+      expect(LiveStats.fromJson({'caretCount': 1}).hasMultipleCursors, false);
     });
 
     test('allStats returns all statistics', () {
@@ -633,10 +607,7 @@ void main() {
           'endLineNumber': 1,
           'endColumn': 5,
         },
-        'cursorPosition': {
-          'lineNumber': 1,
-          'column': 3,
-        },
+        'cursorPosition': {'lineNumber': 1, 'column': 3},
         'language': 'dart',
         'theme': 'vs-dark',
       });
@@ -670,12 +641,7 @@ void main() {
 
     test('toJson', () {
       const match = FindMatch(
-        range: Range(
-          startLine: 1,
-          startColumn: 1,
-          endLine: 1,
-          endColumn: 5,
-        ),
+        range: Range(startLine: 1, startColumn: 1, endLine: 1, endColumn: 5),
         match: 'test',
       );
 
@@ -784,7 +750,7 @@ void main() {
         fileMatch: ['*.json', 'config.*'],
         schema: {
           'type': 'object',
-          'required': ['name']
+          'required': ['name'],
         },
       );
 
@@ -794,7 +760,7 @@ void main() {
       expect(json['fileMatch'], ['*.json', 'config.*']);
       expect(json['schema'], {
         'type': 'object',
-        'required': ['name']
+        'required': ['name'],
       });
     });
 

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -66,4 +66,12 @@ void main() {
     // The route-bearing Uri.base must never drive asset resolution (#14).
     expect(source, isNot(contains('Uri.base')));
   });
+
+  test('web iframe declares scroll containment at the frame boundary', () {
+    final source = webControllerSource();
+
+    expect(source, contains("..style.display = 'block'"));
+    expect(source, contains("..style.touchAction = 'none'"));
+    expect(source, contains("..style.overscrollBehavior = 'none'"));
+  });
 }

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -8,8 +8,9 @@ void main() {
 
   test('web focus handler only amplifies Monaco focus on desktop', () {
     final source = webControllerSource();
-    final focusBlockStart = source
-        .indexOf('// When Monaco reports focus, unfocus Flutter widgets.');
+    final focusBlockStart = source.indexOf(
+      '// When Monaco reports focus, unfocus Flutter widgets.',
+    );
     final focusBlockEnd = source.indexOf('// Forward to all channels');
 
     expect(focusBlockStart, isNonNegative);
@@ -52,8 +53,7 @@ void main() {
     expect(source, contains('Unknown Monaco load error'));
   });
 
-  test(
-      'web Monaco vs path resolves via the Flutter asset manager, not '
+  test('web Monaco vs path resolves via the Flutter asset manager, not '
       'Uri.base', () {
     final source = webControllerSource();
 

--- a/test/widgets/monaco_editor_test.dart
+++ b/test/widgets/monaco_editor_test.dart
@@ -453,6 +453,9 @@ void main() {
           await first.down(target);
           await tester.pumpAndSettle();
           await first.up();
+          // Monaco reports the editor focused after the first click; a second
+          // click on the already-focused editor must not replay focus.
+          bundle.webview.emitToChannel('flutterChannel', '{"event":"focus"}');
           await tester.pump();
 
           bundle.webview.executed.clear();
@@ -469,6 +472,54 @@ void main() {
             isNot(contains('REQUEST_NATIVE_FOCUS')),
           );
           bundle.webview.assertNotExecuted('forceFocus');
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets(
+          'desktop click re-asserts focus after Monaco blurs (alt-tab/dialog '
+          'desync)', (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        try {
+          final bundle = await _createBundle();
+          await tester.pumpWidget(_wrap(MonacoEditor(
+            controller: bundle.controller,
+          )));
+          await tester.pumpAndSettle();
+
+          final target = tester.getCenter(find.byKey(const Key('webview')));
+          // First click focuses; Monaco then reports focused.
+          final first = await tester.createGesture(
+            kind: PointerDeviceKind.mouse,
+            buttons: kPrimaryMouseButton,
+          );
+          await first.down(target);
+          await tester.pumpAndSettle();
+          await first.up();
+          bundle.webview.emitToChannel('flutterChannel', '{"event":"focus"}');
+          await tester.pump();
+
+          // The editor silently loses native focus (alt-tab / dialog): Monaco
+          // reports a blur while Flutter still thinks the view is focused.
+          bundle.webview.emitToChannel('flutterChannel', '{"event":"blur"}');
+          await tester.pump();
+          bundle.webview.executed.clear();
+
+          // A click must now re-assert focus so typing recovers.
+          final second = await tester.createGesture(
+            kind: PointerDeviceKind.mouse,
+            buttons: kPrimaryMouseButton,
+          );
+          await second.down(target);
+          await tester.pumpAndSettle();
+          await second.up();
+
+          expect(
+            bundle.webview.executed,
+            contains('REQUEST_NATIVE_FOCUS'),
+          );
+          bundle.webview.assertExecuted('forceFocus');
         } finally {
           debugDefaultTargetPlatformOverride = null;
         }

--- a/test/widgets/monaco_editor_test.dart
+++ b/test/widgets/monaco_editor_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -372,6 +373,102 @@ void main() {
             find.ancestor(of: webview, matching: monacoPointerWrapper),
             findsOneWidget,
           );
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets('desktop primary mouse down requests editor focus',
+          (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        try {
+          final bundle = await _createBundle();
+          await tester.pumpWidget(_wrap(MonacoEditor(
+            controller: bundle.controller,
+          )));
+          await tester.pumpAndSettle();
+          bundle.webview.executed.clear();
+
+          final gesture = await tester.createGesture(
+            kind: PointerDeviceKind.mouse,
+            buttons: kPrimaryMouseButton,
+          );
+          await gesture
+              .down(tester.getCenter(find.byKey(const Key('webview'))));
+          await tester.pumpAndSettle();
+          await gesture.up();
+
+          expect(bundle.webview.executed, contains('REQUEST_NATIVE_FOCUS'));
+          bundle.webview.assertExecuted('forceFocus');
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets('desktop secondary mouse down does not force editor focus',
+          (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        try {
+          final bundle = await _createBundle();
+          await tester.pumpWidget(_wrap(MonacoEditor(
+            controller: bundle.controller,
+          )));
+          await tester.pumpAndSettle();
+          bundle.webview.executed.clear();
+
+          final gesture = await tester.createGesture(
+            kind: PointerDeviceKind.mouse,
+            buttons: kSecondaryMouseButton,
+          );
+          await gesture
+              .down(tester.getCenter(find.byKey(const Key('webview'))));
+          await tester.pumpAndSettle();
+          await gesture.up();
+
+          expect(
+            bundle.webview.executed,
+            isNot(contains('REQUEST_NATIVE_FOCUS')),
+          );
+          bundle.webview.assertNotExecuted('forceFocus');
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets('desktop repeated primary mouse down does not refocus',
+          (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        try {
+          final bundle = await _createBundle();
+          await tester.pumpWidget(_wrap(MonacoEditor(
+            controller: bundle.controller,
+          )));
+          await tester.pumpAndSettle();
+
+          final target = tester.getCenter(find.byKey(const Key('webview')));
+          final first = await tester.createGesture(
+            kind: PointerDeviceKind.mouse,
+            buttons: kPrimaryMouseButton,
+          );
+          await first.down(target);
+          await tester.pumpAndSettle();
+          await first.up();
+          await tester.pump();
+
+          bundle.webview.executed.clear();
+          final second = await tester.createGesture(
+            kind: PointerDeviceKind.mouse,
+            buttons: kPrimaryMouseButton,
+          );
+          await second.down(target);
+          await tester.pumpAndSettle();
+          await second.up();
+
+          expect(
+            bundle.webview.executed,
+            isNot(contains('REQUEST_NATIVE_FOCUS')),
+          );
+          bundle.webview.assertNotExecuted('forceFocus');
         } finally {
           debugDefaultTargetPlatformOverride = null;
         }

--- a/test/widgets/monaco_editor_test.dart
+++ b/test/widgets/monaco_editor_test.dart
@@ -43,26 +43,35 @@ void main() {
 
       testWidgets('custom loadingBuilder is used', (tester) async {
         final bundle = await _createBundle(ready: false);
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          loadingBuilder: (context) => const Text('Custom Loading'),
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              loadingBuilder: (context) => const Text('Custom Loading'),
+            ),
+          ),
+        );
         expect(find.text('Custom Loading'), findsOneWidget);
       });
 
-      testWidgets('transitions to ready state and fires onReady',
-          (tester) async {
+      testWidgets('transitions to ready state and fires onReady', (
+        tester,
+      ) async {
         final bundle = await _createBundle(ready: false);
         MonacoController? receivedController;
         var readyCount = 0;
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          onReady: (c) {
-            receivedController = c;
-            readyCount++;
-          },
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              onReady: (c) {
+                receivedController = c;
+                readyCount++;
+              },
+            ),
+          ),
+        );
 
         bundle.controller.completeReadyForTesting();
         await tester.pump();
@@ -72,23 +81,29 @@ void main() {
         expect(receivedController, bundle.controller);
       });
 
-      testWidgets('error state shows error and retry only when owned',
-          (tester) async {
+      testWidgets('error state shows error and retry only when owned', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
         bundle.webview.throwOnContains('setValue');
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          initialValue: 'trigger error',
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              initialValue: 'trigger error',
+            ),
+          ),
+        );
         await tester.pump();
 
         expect(find.text('Failed to Initialize Editor'), findsOneWidget);
         expect(find.text('Retry'), findsNothing); // Not owned
       });
 
-      testWidgets('owned controller disposed when bootstrap fails',
-          (tester) async {
+      testWidgets('owned controller disposed when bootstrap fails', (
+        tester,
+      ) async {
         FakePlatformWebViewController? failingWebview;
 
         Future<MonacoController> factory() async {
@@ -102,10 +117,9 @@ void main() {
           );
         }
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controllerFactory: factory,
-          initialValue: 'boom',
-        )));
+        await tester.pumpWidget(
+          _wrap(MonacoEditor(controllerFactory: factory, initialValue: 'boom')),
+        );
         await tester.pump();
 
         expect(find.text('Failed to Initialize Editor'), findsOneWidget);
@@ -113,8 +127,9 @@ void main() {
         expect(failingWebview!.disposed, true);
       });
 
-      testWidgets('error state shows retry when widget owns controller',
-          (tester) async {
+      testWidgets('error state shows retry when widget owns controller', (
+        tester,
+      ) async {
         var factoryCalls = 0;
         Future<MonacoController> factory() async {
           factoryCalls++;
@@ -130,9 +145,9 @@ void main() {
           );
         }
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controllerFactory: factory,
-        )));
+        await tester.pumpWidget(
+          _wrap(MonacoEditor(controllerFactory: factory)),
+        );
         await tester.pump();
 
         expect(find.text('Failed to Initialize Editor'), findsOneWidget);
@@ -150,11 +165,16 @@ void main() {
         final bundle = await _createBundle();
         bundle.webview.throwOnContains('setValue');
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          initialValue: 'trigger',
-          errorBuilder: (context, error, st) => Text('Custom Error: $error'),
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              initialValue: 'trigger',
+              errorBuilder: (context, error, st) =>
+                  Text('Custom Error: $error'),
+            ),
+          ),
+        );
         await tester.pump();
 
         expect(find.textContaining('Custom Error'), findsOneWidget);
@@ -164,10 +184,14 @@ void main() {
     group('initial values', () {
       testWidgets('initialValue applied once', (tester) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          initialValue: 'initial content',
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              initialValue: 'initial content',
+            ),
+          ),
+        );
         await tester.pump();
 
         final setValueScripts = bundle.webview.scriptsContaining('"setValue"');
@@ -175,10 +199,14 @@ void main() {
         expect(setValueScripts.first, contains('"initial content"'));
 
         // Update widget with different initialValue
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          initialValue: 'new content',
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              initialValue: 'new content',
+            ),
+          ),
+        );
         await tester.pump();
 
         // Should NOT set the new value (initialValue is applied only once)
@@ -189,19 +217,24 @@ void main() {
         );
       });
 
-      testWidgets('initialSelection applied after initialValue',
-          (tester) async {
+      testWidgets('initialSelection applied after initialValue', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          initialValue: 'content',
-          initialSelection: const Range(
-            startLine: 1,
-            startColumn: 1,
-            endLine: 1,
-            endColumn: 5,
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              initialValue: 'content',
+              initialSelection: const Range(
+                startLine: 1,
+                startColumn: 1,
+                endLine: 1,
+                endColumn: 5,
+              ),
+            ),
           ),
-        )));
+        );
         await tester.pump();
 
         final scripts = bundle.webview.executed;
@@ -214,28 +247,37 @@ void main() {
     });
 
     group('options updates', () {
-      testWidgets('options change triggers updateOptions/theme/language',
-          (tester) async {
+      testWidgets('options change triggers updateOptions/theme/language', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          options: const EditorOptions(
-            language: MonacoLanguage.dart,
-            theme: MonacoTheme.vsDark,
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              options: const EditorOptions(
+                language: MonacoLanguage.dart,
+                theme: MonacoTheme.vsDark,
+              ),
+            ),
           ),
-        )));
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.clearExecuted();
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          options: const EditorOptions(
-            language: MonacoLanguage.python,
-            theme: MonacoTheme.vs,
-            fontSize: 16,
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              options: const EditorOptions(
+                language: MonacoLanguage.python,
+                theme: MonacoTheme.vs,
+                fontSize: 16,
+              ),
+            ),
           ),
-        )));
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.assertExecuted('updateOptions');
@@ -250,18 +292,21 @@ void main() {
           theme: MonacoTheme.vsDark,
         );
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          options: options,
-        )));
+        await tester.pumpWidget(
+          _wrap(MonacoEditor(controller: bundle.controller, options: options)),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.clearExecuted();
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          options: options, // Same options
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              options: options, // Same options
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.assertNotExecuted('updateOptions');
@@ -269,15 +314,15 @@ void main() {
     });
 
     group('autofocus', () {
-      testWidgets('autofocus triggers ensureEditorFocus on desktop',
-          (tester) async {
+      testWidgets('autofocus triggers ensureEditorFocus on desktop', (
+        tester,
+      ) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
         try {
           final bundle = await _createBundle();
-          await tester.pumpWidget(_wrap(MonacoEditor(
-            controller: bundle.controller,
-            autofocus: true,
-          )));
+          await tester.pumpWidget(
+            _wrap(MonacoEditor(controller: bundle.controller, autofocus: true)),
+          );
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 100));
           await tester.pumpAndSettle();
@@ -288,15 +333,15 @@ void main() {
         }
       });
 
-      testWidgets('autofocus skips programmatic focus on mobile',
-          (tester) async {
+      testWidgets('autofocus skips programmatic focus on mobile', (
+        tester,
+      ) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
         try {
           final bundle = await _createBundle();
-          await tester.pumpWidget(_wrap(MonacoEditor(
-            controller: bundle.controller,
-            autofocus: true,
-          )));
+          await tester.pumpWidget(
+            _wrap(MonacoEditor(controller: bundle.controller, autofocus: true)),
+          );
           await tester.pumpAndSettle();
 
           bundle.webview.assertNotExecuted('forceFocus');
@@ -307,10 +352,9 @@ void main() {
 
       testWidgets('autofocus false does not trigger focus', (tester) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          autofocus: false,
-        )));
+        await tester.pumpWidget(
+          _wrap(MonacoEditor(controller: bundle.controller, autofocus: false)),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.assertNotExecuted('forceFocus');
@@ -329,14 +373,15 @@ void main() {
             widget.behavior == HitTestBehavior.translucent,
       );
 
-      testWidgets('mobile renders bare webview without focus wrappers',
-          (tester) async {
+      testWidgets('mobile renders bare webview without focus wrappers', (
+        tester,
+      ) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
         try {
           final bundle = await _createBundle();
-          await tester.pumpWidget(_wrap(MonacoEditor(
-            controller: bundle.controller,
-          )));
+          await tester.pumpWidget(
+            _wrap(MonacoEditor(controller: bundle.controller)),
+          );
           await tester.pumpAndSettle();
 
           final webview = find.byKey(const Key('webview'));
@@ -358,9 +403,9 @@ void main() {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
         try {
           final bundle = await _createBundle();
-          await tester.pumpWidget(_wrap(MonacoEditor(
-            controller: bundle.controller,
-          )));
+          await tester.pumpWidget(
+            _wrap(MonacoEditor(controller: bundle.controller)),
+          );
           await tester.pumpAndSettle();
 
           final webview = find.byKey(const Key('webview'));
@@ -378,14 +423,15 @@ void main() {
         }
       });
 
-      testWidgets('desktop primary mouse down requests editor focus',
-          (tester) async {
+      testWidgets('desktop primary mouse down requests editor focus', (
+        tester,
+      ) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
         try {
           final bundle = await _createBundle();
-          await tester.pumpWidget(_wrap(MonacoEditor(
-            controller: bundle.controller,
-          )));
+          await tester.pumpWidget(
+            _wrap(MonacoEditor(controller: bundle.controller)),
+          );
           await tester.pumpAndSettle();
           bundle.webview.executed.clear();
 
@@ -393,8 +439,9 @@ void main() {
             kind: PointerDeviceKind.mouse,
             buttons: kPrimaryMouseButton,
           );
-          await gesture
-              .down(tester.getCenter(find.byKey(const Key('webview'))));
+          await gesture.down(
+            tester.getCenter(find.byKey(const Key('webview'))),
+          );
           await tester.pumpAndSettle();
           await gesture.up();
 
@@ -405,14 +452,15 @@ void main() {
         }
       });
 
-      testWidgets('desktop secondary mouse down does not force editor focus',
-          (tester) async {
+      testWidgets('desktop secondary mouse down does not force editor focus', (
+        tester,
+      ) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
         try {
           final bundle = await _createBundle();
-          await tester.pumpWidget(_wrap(MonacoEditor(
-            controller: bundle.controller,
-          )));
+          await tester.pumpWidget(
+            _wrap(MonacoEditor(controller: bundle.controller)),
+          );
           await tester.pumpAndSettle();
           bundle.webview.executed.clear();
 
@@ -420,8 +468,9 @@ void main() {
             kind: PointerDeviceKind.mouse,
             buttons: kSecondaryMouseButton,
           );
-          await gesture
-              .down(tester.getCenter(find.byKey(const Key('webview'))));
+          await gesture.down(
+            tester.getCenter(find.byKey(const Key('webview'))),
+          );
           await tester.pumpAndSettle();
           await gesture.up();
 
@@ -435,14 +484,15 @@ void main() {
         }
       });
 
-      testWidgets('desktop repeated primary mouse down does not refocus',
-          (tester) async {
+      testWidgets('desktop repeated primary mouse down does not refocus', (
+        tester,
+      ) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
         try {
           final bundle = await _createBundle();
-          await tester.pumpWidget(_wrap(MonacoEditor(
-            controller: bundle.controller,
-          )));
+          await tester.pumpWidget(
+            _wrap(MonacoEditor(controller: bundle.controller)),
+          );
           await tester.pumpAndSettle();
 
           final target = tester.getCenter(find.byKey(const Key('webview')));
@@ -478,67 +528,71 @@ void main() {
       });
 
       testWidgets(
-          'desktop click re-asserts focus after Monaco blurs (alt-tab/dialog '
-          'desync)', (tester) async {
-        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
-        try {
-          final bundle = await _createBundle();
-          await tester.pumpWidget(_wrap(MonacoEditor(
-            controller: bundle.controller,
-          )));
-          await tester.pumpAndSettle();
+        'desktop click re-asserts focus after Monaco blurs (alt-tab/dialog '
+        'desync)',
+        (tester) async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+          try {
+            final bundle = await _createBundle();
+            await tester.pumpWidget(
+              _wrap(MonacoEditor(controller: bundle.controller)),
+            );
+            await tester.pumpAndSettle();
 
-          final target = tester.getCenter(find.byKey(const Key('webview')));
-          // First click focuses; Monaco then reports focused.
-          final first = await tester.createGesture(
-            kind: PointerDeviceKind.mouse,
-            buttons: kPrimaryMouseButton,
-          );
-          await first.down(target);
-          await tester.pumpAndSettle();
-          await first.up();
-          bundle.webview.emitToChannel('flutterChannel', '{"event":"focus"}');
-          await tester.pump();
+            final target = tester.getCenter(find.byKey(const Key('webview')));
+            // First click focuses; Monaco then reports focused.
+            final first = await tester.createGesture(
+              kind: PointerDeviceKind.mouse,
+              buttons: kPrimaryMouseButton,
+            );
+            await first.down(target);
+            await tester.pumpAndSettle();
+            await first.up();
+            bundle.webview.emitToChannel('flutterChannel', '{"event":"focus"}');
+            await tester.pump();
 
-          // The editor silently loses native focus (alt-tab / dialog): Monaco
-          // reports a blur while Flutter still thinks the view is focused.
-          bundle.webview.emitToChannel('flutterChannel', '{"event":"blur"}');
-          await tester.pump();
-          bundle.webview.executed.clear();
+            // The editor silently loses native focus (alt-tab / dialog): Monaco
+            // reports a blur while Flutter still thinks the view is focused.
+            bundle.webview.emitToChannel('flutterChannel', '{"event":"blur"}');
+            await tester.pump();
+            bundle.webview.executed.clear();
 
-          // A click must now re-assert focus so typing recovers.
-          final second = await tester.createGesture(
-            kind: PointerDeviceKind.mouse,
-            buttons: kPrimaryMouseButton,
-          );
-          await second.down(target);
-          await tester.pumpAndSettle();
-          await second.up();
+            // A click must now re-assert focus so typing recovers.
+            final second = await tester.createGesture(
+              kind: PointerDeviceKind.mouse,
+              buttons: kPrimaryMouseButton,
+            );
+            await second.down(target);
+            await tester.pumpAndSettle();
+            await second.up();
 
-          expect(
-            bundle.webview.executed,
-            contains('REQUEST_NATIVE_FOCUS'),
-          );
-          bundle.webview.assertExecuted('forceFocus');
-        } finally {
-          debugDefaultTargetPlatformOverride = null;
-        }
-      });
+            expect(bundle.webview.executed, contains('REQUEST_NATIVE_FOCUS'));
+            bundle.webview.assertExecuted('forceFocus');
+          } finally {
+            debugDefaultTargetPlatformOverride = null;
+          }
+        },
+      );
     });
 
     group('content change callbacks', () {
-      testWidgets('onContentChanged debounces non-flush events',
-          (tester) async {
+      testWidgets('onContentChanged debounces non-flush events', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
         final calls = <String>[];
         bundle.webview.injectCommandSuccess('getValue', value: 'A');
         bundle.webview.injectCommandSuccess('getValue', value: 'B');
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          contentDebounce: const Duration(milliseconds: 30),
-          onContentChanged: calls.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              contentDebounce: const Duration(milliseconds: 30),
+              onContentChanged: calls.add,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -564,11 +618,15 @@ void main() {
         final calls = <String>[];
         bundle.webview.injectCommandSuccess('getValue', value: 'flushed');
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          contentDebounce: const Duration(milliseconds: 200),
-          onContentChanged: calls.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              contentDebounce: const Duration(milliseconds: 200),
+              onContentChanged: calls.add,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -581,17 +639,22 @@ void main() {
         expect(calls.first, 'flushed');
       });
 
-      testWidgets('fullTextOnFlushOnly blocks non-flush updates',
-          (tester) async {
+      testWidgets('fullTextOnFlushOnly blocks non-flush updates', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
         final calls = <String>[];
         bundle.webview.injectCommandSuccess('getValue', value: 'content');
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          fullTextOnFlushOnly: true,
-          onContentChanged: calls.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              fullTextOnFlushOnly: true,
+              onContentChanged: calls.add,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -613,10 +676,14 @@ void main() {
         final bundle = await _createBundle();
         final flags = <bool>[];
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          onRawContentChanged: flags.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              onRawContentChanged: flags.add,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -639,11 +706,15 @@ void main() {
         bundle.webview.injectCommandSuccess('getValue', value: 'v1');
         bundle.webview.injectCommandSuccess('getValue', value: 'v2');
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          contentDebounce: Duration.zero,
-          onContentChanged: calls1.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              contentDebounce: Duration.zero,
+              onContentChanged: calls1.add,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -654,11 +725,15 @@ void main() {
         expect(calls1.length, 1);
 
         // Change callback
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          contentDebounce: Duration.zero,
-          onContentChanged: calls2.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              contentDebounce: Duration.zero,
+              onContentChanged: calls2.add,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -679,12 +754,16 @@ void main() {
         var focusCount = 0;
         var blurCount = 0;
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          onSelectionChanged: (_) => selectionCount++,
-          onFocus: () => focusCount++,
-          onBlur: () => blurCount++,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              onSelectionChanged: (_) => selectionCount++,
+              onFocus: () => focusCount++,
+              onBlur: () => blurCount++,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -704,10 +783,11 @@ void main() {
         final bundle = await _createBundle();
         final stats = <LiveStats>[];
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          onLiveStats: stats.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(controller: bundle.controller, onLiveStats: stats.add),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -724,10 +804,11 @@ void main() {
     group('status bar', () {
       testWidgets('status bar renders stats', (tester) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          showStatusBar: true,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(controller: bundle.controller, showStatusBar: true),
+          ),
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -742,12 +823,15 @@ void main() {
 
       testWidgets('custom statusBarBuilder used', (tester) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          statusBarBuilder: (context, stats) => Text(
-            'Lines: ${stats.lineCount.value}',
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              statusBarBuilder: (context, stats) =>
+                  Text('Lines: ${stats.lineCount.value}'),
+            ),
           ),
-        )));
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -759,23 +843,26 @@ void main() {
         expect(find.text('Lines: 42'), findsOneWidget);
       });
 
-      testWidgets('MonacoEditorTheme customizes default status bar',
-          (tester) async {
+      testWidgets('MonacoEditorTheme customizes default status bar', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(
-          MonacoEditorTheme(
-            data: const MonacoEditorThemeData(
-              statusBarBackgroundColor: Colors.black,
-              statusBarBorderColor: Colors.red,
-              statusBarTextStyle: TextStyle(color: Colors.green),
-              statusBarSpacing: 8,
-            ),
-            child: MonacoEditor(
-              controller: bundle.controller,
-              showStatusBar: true,
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditorTheme(
+              data: const MonacoEditorThemeData(
+                statusBarBackgroundColor: Colors.black,
+                statusBarBorderColor: Colors.red,
+                statusBarTextStyle: TextStyle(color: Colors.green),
+                statusBarSpacing: 8,
+              ),
+              child: MonacoEditor(
+                controller: bundle.controller,
+                showStatusBar: true,
+              ),
             ),
           ),
-        ));
+        );
         await tester.pumpAndSettle();
 
         bundle.webview.emitToChannel(
@@ -799,10 +886,11 @@ void main() {
 
       testWidgets('status bar hidden when showStatusBar false', (tester) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          showStatusBar: false,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(controller: bundle.controller, showStatusBar: false),
+          ),
+        );
         await tester.pumpAndSettle();
 
         expect(find.text('Ln'), findsNothing);
@@ -818,18 +906,26 @@ void main() {
         bundleA.webview.injectCommandSuccess('getValue', value: 'A');
         bundleB.webview.injectCommandSuccess('getValue', value: 'B');
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundleA.controller,
-          contentDebounce: Duration.zero,
-          onContentChanged: calls.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundleA.controller,
+              contentDebounce: Duration.zero,
+              onContentChanged: calls.add,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundleB.controller,
-          contentDebounce: Duration.zero,
-          onContentChanged: calls.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundleB.controller,
+              contentDebounce: Duration.zero,
+              onContentChanged: calls.add,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         // Old controller event should not trigger callback
@@ -852,23 +948,32 @@ void main() {
     });
 
     group('customCss handling', () {
-      testWidgets('customCss change does not rebuild when not owned',
-          (tester) async {
+      testWidgets('customCss change does not rebuild when not owned', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
         var readyCount = 0;
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          onReady: (_) => readyCount++,
-          customCss: null,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              onReady: (_) => readyCount++,
+              customCss: null,
+            ),
+          ),
+        );
         await tester.pump();
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          onReady: (_) => readyCount++,
-          customCss: 'body { background: red; }',
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              onReady: (_) => readyCount++,
+              customCss: 'body { background: red; }',
+            ),
+          ),
+        );
         await tester.pump();
 
         expect(readyCount, 1); // Not rebuilt
@@ -890,16 +995,19 @@ void main() {
           );
         }
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controllerFactory: factory,
-          customCss: null,
-        )));
+        await tester.pumpWidget(
+          _wrap(MonacoEditor(controllerFactory: factory, customCss: null)),
+        );
         await tester.pump();
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controllerFactory: factory,
-          customCss: 'body { background: red; }',
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controllerFactory: factory,
+              customCss: 'body { background: red; }',
+            ),
+          ),
+        );
         await tester.pump();
 
         expect(factoryCalls, 2);
@@ -925,18 +1033,26 @@ void main() {
           return controller;
         }
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controllerFactory: factory,
-          customCss: null,
-          onReady: (_) => readyCount++,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controllerFactory: factory,
+              customCss: null,
+              onReady: (_) => readyCount++,
+            ),
+          ),
+        );
         await tester.pump();
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controllerFactory: factory,
-          customCss: 'body { background: red; }',
-          onReady: (_) => readyCount++,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controllerFactory: factory,
+              customCss: 'body { background: red; }',
+              onReady: (_) => readyCount++,
+            ),
+          ),
+        );
         await tester.pump();
 
         expect(controllers.length, 2);
@@ -955,11 +1071,15 @@ void main() {
         final calls = <String>[];
         bundle.webview.injectCommandSuccess('getValue', value: 'A');
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          contentDebounce: const Duration(milliseconds: 100),
-          onContentChanged: calls.add,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              contentDebounce: const Duration(milliseconds: 100),
+              onContentChanged: calls.add,
+            ),
+          ),
+        );
         await tester.pump();
 
         bundle.webview.emitToChannel(
@@ -988,9 +1108,9 @@ void main() {
           );
         }
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controllerFactory: factory,
-        )));
+        await tester.pumpWidget(
+          _wrap(MonacoEditor(controllerFactory: factory)),
+        );
         await tester.pump();
 
         expect(webviews.length, 1);
@@ -1001,13 +1121,14 @@ void main() {
         expect(webviews.first.disposed, true);
       });
 
-      testWidgets('external controller not disposed on unmount',
-          (tester) async {
+      testWidgets('external controller not disposed on unmount', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-        )));
+        await tester.pumpWidget(
+          _wrap(MonacoEditor(controller: bundle.controller)),
+        );
         await tester.pump();
 
         await tester.pumpWidget(const SizedBox.shrink());
@@ -1017,13 +1138,18 @@ void main() {
     });
 
     group('styling', () {
-      testWidgets('backgroundColor applies both native and host-page layers',
-          (tester) async {
+      testWidgets('backgroundColor applies both native and host-page layers', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          backgroundColor: Colors.red,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              backgroundColor: Colors.red,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         final container = tester.widget<Container>(
@@ -1038,8 +1164,9 @@ void main() {
 
         // Native WebView API was invoked.
         expect(
-          bundle.webview.executed
-              .any((s) => s.startsWith('SET_BACKGROUND_COLOR')),
+          bundle.webview.executed.any(
+            (s) => s.startsWith('SET_BACKGROUND_COLOR'),
+          ),
           true,
           reason: 'setBackgroundColor must hit the native WebView container',
         );
@@ -1055,32 +1182,44 @@ void main() {
         );
       });
 
-      testWidgets('host-page background failure does not break initialization',
-          (tester) async {
+      testWidgets(
+        'host-page background failure does not break initialization',
+        (tester) async {
+          final bundle = await _createBundle();
+          bundle.webview.throwOnContains('"setHostPageBackground"');
+
+          await tester.pumpWidget(
+            _wrap(
+              MonacoEditor(
+                controller: bundle.controller,
+                backgroundColor: Colors.red,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Native layer succeeds; HTML host-page failure is best-effort.
+          expect(find.byKey(const Key('webview')), findsOneWidget);
+          expect(find.text('Failed to Initialize Editor'), findsNothing);
+        },
+      );
+
+      testWidgets('native background failure does not break initialization', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
-        bundle.webview.throwOnContains('"setHostPageBackground"');
+        bundle.webview.setBackgroundColorError = StateError(
+          'Simulated macOS native background failure',
+        );
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          backgroundColor: Colors.red,
-        )));
-        await tester.pumpAndSettle();
-
-        // Native layer succeeds; HTML host-page failure is best-effort.
-        expect(find.byKey(const Key('webview')), findsOneWidget);
-        expect(find.text('Failed to Initialize Editor'), findsNothing);
-      });
-
-      testWidgets('native background failure does not break initialization',
-          (tester) async {
-        final bundle = await _createBundle();
-        bundle.webview.setBackgroundColorError =
-            StateError('Simulated macOS native background failure');
-
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          backgroundColor: Colors.red,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              backgroundColor: Colors.red,
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
 
         // Native failure is best-effort; HTML host-page recolor still runs.
@@ -1090,10 +1229,14 @@ void main() {
 
       testWidgets('padding applied', (tester) async {
         final bundle = await _createBundle();
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          padding: const EdgeInsets.all(16),
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              padding: const EdgeInsets.all(16),
+            ),
+          ),
+        );
         await tester.pump();
 
         final container = tester.widget<Container>(
@@ -1111,10 +1254,14 @@ void main() {
         final bundle = await _createBundle();
         const constraints = BoxConstraints(maxHeight: 300);
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          constraints: constraints,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              constraints: constraints,
+            ),
+          ),
+        );
         await tester.pump();
 
         final container = tester.widget<Container>(
@@ -1133,10 +1280,14 @@ void main() {
       testWidgets('interactionEnabled applied before ready', (tester) async {
         final bundle = await _createBundle(ready: false);
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          interactionEnabled: false,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              interactionEnabled: false,
+            ),
+          ),
+        );
         await tester.pump();
 
         expect(bundle.webview.interactionEnabled, false);
@@ -1146,20 +1297,29 @@ void main() {
         );
       });
 
-      testWidgets('interactionEnabled updates while connecting',
-          (tester) async {
+      testWidgets('interactionEnabled updates while connecting', (
+        tester,
+      ) async {
         final bundle = await _createBundle(ready: false);
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          interactionEnabled: false,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              interactionEnabled: false,
+            ),
+          ),
+        );
         await tester.pump();
 
-        await tester.pumpWidget(_wrap(MonacoEditor(
-          controller: bundle.controller,
-          interactionEnabled: true,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditor(
+              controller: bundle.controller,
+              interactionEnabled: true,
+            ),
+          ),
+        );
         await tester.pump();
 
         final joined = bundle.webview.executed.join('\n');
@@ -1171,15 +1331,17 @@ void main() {
     group('default chrome theming', () {
       testWidgets('MonacoEditorTheme customizes loading UI', (tester) async {
         final bundle = await _createBundle(ready: false);
-        await tester.pumpWidget(_wrap(
-          MonacoEditorTheme(
-            data: const MonacoEditorThemeData(
-              loadingIndicatorColor: Colors.orange,
-              loadingBackgroundColor: Colors.black,
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditorTheme(
+              data: const MonacoEditorThemeData(
+                loadingIndicatorColor: Colors.orange,
+                loadingBackgroundColor: Colors.black,
+              ),
+              child: MonacoEditor(controller: bundle.controller),
             ),
-            child: MonacoEditor(controller: bundle.controller),
           ),
-        ));
+        );
 
         final progress = tester.widget<CircularProgressIndicator>(
           find.byType(CircularProgressIndicator),
@@ -1187,51 +1349,55 @@ void main() {
         expect(progress.color, Colors.orange);
       });
 
-      testWidgets('MonacoEditorTheme customizes default error UI',
-          (tester) async {
+      testWidgets('MonacoEditorTheme customizes default error UI', (
+        tester,
+      ) async {
         final bundle = await _createBundle();
         bundle.webview.injectCommandFailure('setValue', message: 'fail');
 
-        await tester.pumpWidget(_wrap(
-          MonacoEditorTheme(
-            data: const MonacoEditorThemeData(
-              errorIconColor: Colors.purple,
-            ),
-            child: MonacoEditor(
-              controller: bundle.controller,
-              initialValue: 'trigger',
+        await tester.pumpWidget(
+          _wrap(
+            MonacoEditorTheme(
+              data: const MonacoEditorThemeData(errorIconColor: Colors.purple),
+              child: MonacoEditor(
+                controller: bundle.controller,
+                initialValue: 'trigger',
+              ),
             ),
           ),
-        ));
+        );
         await tester.pump();
 
         final icon = tester.widget<Icon>(find.byIcon(Icons.error_outline));
         expect(icon.color, Colors.purple);
       });
 
-      testWidgets('MonacoEditorTheme composes nested overrides',
-          (tester) async {
+      testWidgets('MonacoEditorTheme composes nested overrides', (
+        tester,
+      ) async {
         MonacoEditorThemeData? resolvedTheme;
 
-        await tester.pumpWidget(MaterialApp(
-          home: MonacoEditorTheme(
-            data: const MonacoEditorThemeData(
-              loadingIndicatorColor: Colors.orange,
-              errorIconColor: Colors.purple,
-            ),
-            child: MonacoEditorTheme(
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MonacoEditorTheme(
               data: const MonacoEditorThemeData(
-                statusBarBackgroundColor: Colors.black,
+                loadingIndicatorColor: Colors.orange,
+                errorIconColor: Colors.purple,
               ),
-              child: Builder(
-                builder: (context) {
-                  resolvedTheme = MonacoEditorTheme.of(context);
-                  return const SizedBox.shrink();
-                },
+              child: MonacoEditorTheme(
+                data: const MonacoEditorThemeData(
+                  statusBarBackgroundColor: Colors.black,
+                ),
+                child: Builder(
+                  builder: (context) {
+                    resolvedTheme = MonacoEditorTheme.of(context);
+                    return const SizedBox.shrink();
+                  },
+                ),
               ),
             ),
           ),
-        ));
+        );
 
         expect(resolvedTheme, isNotNull);
         expect(resolvedTheme!.loadingIndicatorColor, Colors.orange);
@@ -1240,57 +1406,63 @@ void main() {
       });
 
       testWidgets(
-          'MonacoEditorTheme propagates into dialog routes via captureAll',
-          (tester) async {
-        final bundle = await _createBundle();
-        MonacoEditorThemeData? capturedTheme;
+        'MonacoEditorTheme propagates into dialog routes via captureAll',
+        (tester) async {
+          final bundle = await _createBundle();
+          MonacoEditorThemeData? capturedTheme;
 
-        await tester.pumpWidget(MaterialApp(
-          home: MonacoEditorTheme(
-            data: const MonacoEditorThemeData(
-              loadingIndicatorColor: Colors.cyan,
-              statusBarBackgroundColor: Colors.black,
-            ),
-            child: Builder(
-              builder: (context) {
-                return Scaffold(
-                  body: Column(children: [
-                    Expanded(
-                      child: MonacoEditor(controller: bundle.controller),
-                    ),
-                    ElevatedButton(
-                      key: const Key('openDialog'),
-                      onPressed: () {
-                        showDialog<void>(
-                          context: context,
-                          builder: (dialogContext) => Builder(
-                            builder: (innerContext) {
-                              capturedTheme =
-                                  MonacoEditorTheme.of(innerContext);
-                              return const SizedBox.shrink();
-                            },
+          await tester.pumpWidget(
+            MaterialApp(
+              home: MonacoEditorTheme(
+                data: const MonacoEditorThemeData(
+                  loadingIndicatorColor: Colors.cyan,
+                  statusBarBackgroundColor: Colors.black,
+                ),
+                child: Builder(
+                  builder: (context) {
+                    return Scaffold(
+                      body: Column(
+                        children: [
+                          Expanded(
+                            child: MonacoEditor(controller: bundle.controller),
                           ),
-                        );
-                      },
-                      child: const Text('open'),
-                    ),
-                  ]),
-                );
-              },
+                          ElevatedButton(
+                            key: const Key('openDialog'),
+                            onPressed: () {
+                              showDialog<void>(
+                                context: context,
+                                builder: (dialogContext) => Builder(
+                                  builder: (innerContext) {
+                                    capturedTheme = MonacoEditorTheme.of(
+                                      innerContext,
+                                    );
+                                    return const SizedBox.shrink();
+                                  },
+                                ),
+                              );
+                            },
+                            child: const Text('open'),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
             ),
-          ),
-        ));
-        await tester.pumpAndSettle();
+          );
+          await tester.pumpAndSettle();
 
-        await tester.tap(find.byKey(const Key('openDialog')));
-        await tester.pumpAndSettle();
+          await tester.tap(find.byKey(const Key('openDialog')));
+          await tester.pumpAndSettle();
 
-        // showDialog uses InheritedTheme.captureAll, which invokes our
-        // MonacoEditorTheme.wrap to carry the data across the dialog route.
-        expect(capturedTheme, isNotNull);
-        expect(capturedTheme!.loadingIndicatorColor, Colors.cyan);
-        expect(capturedTheme!.statusBarBackgroundColor, Colors.black);
-      });
+          // showDialog uses InheritedTheme.captureAll, which invokes our
+          // MonacoEditorTheme.wrap to carry the data across the dialog route.
+          expect(capturedTheme, isNotNull);
+          expect(capturedTheme!.loadingIndicatorColor, Colors.cyan);
+          expect(capturedTheme!.statusBarBackgroundColor, Colors.black);
+        },
+      );
     });
   });
 }

--- a/test/widgets/monaco_focus_guard_test.dart
+++ b/test/widgets/monaco_focus_guard_test.dart
@@ -22,10 +22,9 @@ void main() {
     testWidgets('resumed triggers ensureEditorFocus', (tester) async {
       final webview = FakePlatformWebViewController();
       final controller = await _controller(webview);
-      await tester.pumpWidget(_wrap(MonacoFocusGuard(
-        controller: controller,
-        ensureAttempts: 1,
-      )));
+      await tester.pumpWidget(
+        _wrap(MonacoFocusGuard(controller: controller, ensureAttempts: 1)),
+      );
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
       await tester.pump();
       expect(webview.executed.join('\n').contains('forceFocus'), true);
@@ -36,34 +35,36 @@ void main() {
       final controller = await _controller(webview);
       final observer = RouteObserver<PageRoute<dynamic>>();
 
-      await tester.pumpWidget(MaterialApp(
-        navigatorObservers: [observer],
-        home: Builder(
-          builder: (context) {
-            return Scaffold(
-              body: Column(
-                children: [
-                  MonacoFocusGuard(
-                    controller: controller,
-                    routeObserver: observer,
-                    ensureAttempts: 1,
-                  ),
-                  ElevatedButton(
-                    onPressed: () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute<void>(
-                          builder: (_) => const Scaffold(body: Text('next')),
-                        ),
-                      );
-                    },
-                    child: const Text('push'),
-                  ),
-                ],
-              ),
-            );
-          },
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorObservers: [observer],
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: Column(
+                  children: [
+                    MonacoFocusGuard(
+                      controller: controller,
+                      routeObserver: observer,
+                      ensureAttempts: 1,
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute<void>(
+                            builder: (_) => const Scaffold(body: Text('next')),
+                          ),
+                        );
+                      },
+                      child: const Text('push'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
         ),
-      ));
+      );
 
       await tester.tap(find.text('push'));
       await tester.pumpAndSettle();
@@ -79,33 +80,35 @@ void main() {
       final controller = await _controller(webview);
       final observer = MonacoRouteObserver();
 
-      await tester.pumpWidget(MaterialApp(
-        navigatorObservers: [observer],
-        home: Builder(
-          builder: (context) {
-            return Scaffold(
-              body: Column(
-                children: [
-                  MonacoFocusGuard(
-                    controller: controller,
-                    modalRouteObserver: observer,
-                    autoDisableInteraction: true,
-                  ),
-                  ElevatedButton(
-                    onPressed: () {
-                      showDialog<void>(
-                        context: context,
-                        builder: (_) => const Text('Dialog'),
-                      );
-                    },
-                    child: const Text('Show Dialog'),
-                  ),
-                ],
-              ),
-            );
-          },
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorObservers: [observer],
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: Column(
+                  children: [
+                    MonacoFocusGuard(
+                      controller: controller,
+                      modalRouteObserver: observer,
+                      autoDisableInteraction: true,
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        showDialog<void>(
+                          context: context,
+                          builder: (_) => const Text('Dialog'),
+                        );
+                      },
+                      child: const Text('Show Dialog'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
         ),
-      ));
+      );
 
       // Initial state: interaction enabled
       expect(webview.interactionEnabled, true);


### PR DESCRIPTION
## Summary

- Prepare `flutter_monaco` 2.0.0 with the hosted `webview_flutter_windows` dependency and the matching Dart 3.12 / Flutter 3.44 floor.
- Fix Windows focus recovery so Monaco can regain typing after native-focus loss without stealing focus from Flutter text inputs or replaying focus on right-click/repeated clicks.
- Add mobile web scroll containment, visual-viewport keyboard fit, and the iOS/macOS worker newline escape fix.
- Reformat under the Dart 3.12 formatter required by the new SDK floor.

## Validation

- `flutter pub get`
- `dart format --output=none --set-exit-if-changed .`
- `dart fix --apply`
- `flutter analyze`
- `flutter test`
- `dart pub publish --dry-run`
- `pana`: 150/160, matching the repo CI threshold; the missing 10 points are the documented lack of Linux support, not a regression in the supported platforms.

## Release notes

- Current published version is `1.7.1`; this PR prepares `2.0.0` because the Windows dependency move raises the supported Dart/Flutter floor.
- No publish, tag, or GitHub release is created by this PR itself; the existing auto-release flow handles that after merge.