### PR TITLE
Make showcase metadata dynamic

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,3 @@
+LSP-Support/
+build/
+*.log

--- a/example/lib/showcase/data/samples.dart
+++ b/example/lib/showcase/data/samples.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+
 import 'package:flutter_monaco/flutter_monaco.dart';
+
+import 'showcase_metadata.dart';
 
 /// The curated set of languages offered in the playground language picker,
 /// in display order. Every entry has a matching sample in [_samples].
@@ -22,8 +26,14 @@ const List<MonacoLanguage> kPlaygroundLanguages = [
 
 /// Returns the sample source for [language], or a short plaintext placeholder
 /// when no curated sample exists.
-String sampleFor(MonacoLanguage language) =>
-    _samples[language] ?? '// ${language.label} sample\n';
+String sampleFor(
+  MonacoLanguage language, {
+  ShowcaseMetadata metadata = ShowcaseMetadata.fallback,
+}) {
+  if (language == MonacoLanguage.json) return _jsonSample(metadata);
+  if (language == MonacoLanguage.markdown) return _markdownSample(metadata);
+  return _samples[language] ?? '// ${language.label} sample\n';
+}
 
 final Map<MonacoLanguage, String> _samples = {
   MonacoLanguage.dart: r'''
@@ -102,20 +112,6 @@ def total_path(points: Iterable[Point]) -> float:
 
 
 print(total_path([Point(0, 0), Point(3, 4), Point(3, 0)]))
-''',
-  MonacoLanguage.json: r'''
-{
-  "name": "flutter_monaco",
-  "version": "1.7.1",
-  "description": "VS Code's editor, inside your Flutter app.",
-  "platforms": ["web", "ios", "android", "macos", "windows"],
-  "features": {
-    "languages": 100,
-    "themes": ["vs", "vs-dark", "hc-black", "hc-light"],
-    "intelliSense": true,
-    "diagnostics": true
-  }
-}
 ''',
   MonacoLanguage.rust: r'''
 #[derive(Debug, Clone)]
@@ -237,24 +233,6 @@ jobs:
   transform: translateY(-2px);
 }
 ''',
-  MonacoLanguage.markdown: r'''
-# flutter_monaco
-
-> VS Code's editor, inside your Flutter app.
-
-## Features
-
-- **100+ languages** with syntax highlighting
-- **Theming** - 4 built-ins + define your own
-- **IntelliSense** - custom completion providers
-- **Diagnostics** - markers + JSON schema validation
-
-```dart
-MonacoEditor(
-  options: EditorOptions(language: MonacoLanguage.dart),
-)
-```
-''',
   MonacoLanguage.java: r'''
 import java.util.List;
 import java.util.stream.Collectors;
@@ -303,3 +281,35 @@ for reading in readings {
 }
 ''',
 };
+
+String _jsonSample(ShowcaseMetadata metadata) {
+  const encoder = JsonEncoder.withIndent('  ');
+  return '${encoder.convert({
+    'name': metadata.packageName,
+    'version': metadata.version,
+    'description': metadata.productSummary,
+    'platforms': [for (final platform in metadata.platforms) platform.id],
+    'features': {'typedLanguages': metadata.typedLanguageCount, 'playgroundLanguages': kPlaygroundLanguages.length, 'themes': metadata.showcasedThemeCount, 'intelliSense': true, 'diagnostics': true},
+    if (metadata.publishedAt != null) 'publishedAt': metadata.publishedAt!.toUtc().toIso8601String(),
+  })}\n';
+}
+
+String _markdownSample(ShowcaseMetadata metadata) =>
+    '''
+# ${metadata.packageName}
+
+> ${metadata.productSummary}
+
+## Current package data
+
+- **Version** - ${metadata.versionLabel}
+- **Platforms** - ${metadata.platformSummary}
+- **Languages** - ${metadata.typedLanguageCount} typed entries
+- **Theming** - ${metadata.showcasedThemeCount} demo themes
+
+```dart
+MonacoEditor(
+  options: EditorOptions(language: MonacoLanguage.dart),
+)
+```
+''';

--- a/example/lib/showcase/data/showcase_metadata.dart
+++ b/example/lib/showcase/data/showcase_metadata.dart
@@ -1,0 +1,425 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_monaco/flutter_monaco.dart';
+import 'package:http/http.dart' as http;
+import 'package:yaml/yaml.dart';
+
+import '../util/links.dart';
+
+const String _packageName = 'flutter_monaco';
+const String _repositoryPath = 'omar-hanafy/flutter_monaco';
+
+class ShowcasePlatform {
+  const ShowcasePlatform({required this.id, required this.label});
+
+  final String id;
+  final String label;
+
+  static ShowcasePlatform fromId(String id) {
+    final normalized = id.toLowerCase();
+    return ShowcasePlatform(
+      id: normalized,
+      label: switch (normalized) {
+        'ios' => 'iOS',
+        'macos' => 'macOS',
+        'android' => 'Android',
+        'windows' => 'Windows',
+        'web' => 'Web',
+        'linux' => 'Linux',
+        _ => id,
+      },
+    );
+  }
+}
+
+class ShowcaseMetadata {
+  const ShowcaseMetadata({
+    required this.packageName,
+    required this.version,
+    required this.description,
+    required this.pubDevUrl,
+    required this.repositoryUrl,
+    required this.apiDocsUrl,
+    required this.issueUrl,
+    required this.changelogUrl,
+    required this.licenseUrl,
+    required this.licenseLabel,
+    required this.topics,
+    required this.platforms,
+    required this.sdkConstraint,
+    required this.flutterConstraint,
+    this.publishedAt,
+    this.repositoryUpdatedAt,
+    this.likeCount,
+    this.downloadCount30Days,
+    this.pubPointsGranted,
+    this.pubPointsMax,
+    this.starCount,
+    this.forkCount,
+    this.openIssueCount,
+    this.hasLivePubDev = false,
+    this.hasLiveGitHub = false,
+  });
+
+  static const fallback = ShowcaseMetadata(
+    packageName: _packageName,
+    version: '2.0.0',
+    description:
+        "Integrate Monaco Editor (VS Code's editor) in Flutter apps with "
+        'syntax highlighting, themes, IntelliSense, and a full Dart API.',
+    pubDevUrl: Links.pubDev,
+    repositoryUrl: Links.github,
+    apiDocsUrl: Links.apiDocs,
+    issueUrl: Links.issues,
+    changelogUrl: Links.changelog,
+    licenseUrl: Links.license,
+    licenseLabel: 'MIT',
+    topics: ['vscode', 'monaco', 'editor', 'markdown', 'ide'],
+    platforms: [
+      ShowcasePlatform(id: 'android', label: 'Android'),
+      ShowcasePlatform(id: 'ios', label: 'iOS'),
+      ShowcasePlatform(id: 'macos', label: 'macOS'),
+      ShowcasePlatform(id: 'windows', label: 'Windows'),
+      ShowcasePlatform(id: 'web', label: 'Web'),
+    ],
+    sdkConstraint: '>=3.12.0 <4.0.0',
+    flutterConstraint: '>=3.44.0',
+  );
+
+  final String packageName;
+  final String version;
+  final String description;
+  final String pubDevUrl;
+  final String repositoryUrl;
+  final String apiDocsUrl;
+  final String issueUrl;
+  final String changelogUrl;
+  final String licenseUrl;
+  final String licenseLabel;
+  final List<String> topics;
+  final List<ShowcasePlatform> platforms;
+  final String sdkConstraint;
+  final String flutterConstraint;
+  final DateTime? publishedAt;
+  final DateTime? repositoryUpdatedAt;
+  final int? likeCount;
+  final int? downloadCount30Days;
+  final int? pubPointsGranted;
+  final int? pubPointsMax;
+  final int? starCount;
+  final int? forkCount;
+  final int? openIssueCount;
+  final bool hasLivePubDev;
+  final bool hasLiveGitHub;
+
+  int get typedLanguageCount => MonacoLanguage.values.length;
+  int get builtInThemeCount => MonacoTheme.values.length;
+  int get showcasedThemeCount => PlaygroundThemeCount.total;
+
+  String get versionLabel => 'v$version';
+  String get sourceLabel => hasLivePubDev ? 'Live pub.dev' : 'Bundled pubspec';
+
+  String get platformSummary =>
+      platforms.map((platform) => platform.label).join(', ');
+
+  String get productSummary =>
+      "Integrate Monaco Editor (VS Code's editor) in Flutter apps. "
+      '$typedLanguageCount typed language entries, ${platforms.length} '
+      'supported platforms, theming, IntelliSense, and a full Dart API.';
+
+  String get publishedLabel {
+    final date = publishedAt;
+    if (date == null) return 'Bundled version';
+    return 'Published ${formatShortDate(date)}';
+  }
+
+  String get updatedLabel {
+    final date = repositoryUpdatedAt;
+    if (date == null) return sourceLabel;
+    return 'Updated ${formatShortDate(date)}';
+  }
+
+  String get scoreLabel {
+    final granted = pubPointsGranted;
+    final max = pubPointsMax;
+    if (granted == null || max == null) return 'Pub points';
+    return '$granted/$max pub points';
+  }
+
+  ShowcaseMetadata copyWith({
+    String? packageName,
+    String? version,
+    String? description,
+    String? pubDevUrl,
+    String? repositoryUrl,
+    String? apiDocsUrl,
+    String? issueUrl,
+    String? changelogUrl,
+    String? licenseUrl,
+    String? licenseLabel,
+    List<String>? topics,
+    List<ShowcasePlatform>? platforms,
+    String? sdkConstraint,
+    String? flutterConstraint,
+    DateTime? publishedAt,
+    DateTime? repositoryUpdatedAt,
+    int? likeCount,
+    int? downloadCount30Days,
+    int? pubPointsGranted,
+    int? pubPointsMax,
+    int? starCount,
+    int? forkCount,
+    int? openIssueCount,
+    bool? hasLivePubDev,
+    bool? hasLiveGitHub,
+  }) {
+    return ShowcaseMetadata(
+      packageName: packageName ?? this.packageName,
+      version: version ?? this.version,
+      description: description ?? this.description,
+      pubDevUrl: pubDevUrl ?? this.pubDevUrl,
+      repositoryUrl: repositoryUrl ?? this.repositoryUrl,
+      apiDocsUrl: apiDocsUrl ?? this.apiDocsUrl,
+      issueUrl: issueUrl ?? this.issueUrl,
+      changelogUrl: changelogUrl ?? this.changelogUrl,
+      licenseUrl: licenseUrl ?? this.licenseUrl,
+      licenseLabel: licenseLabel ?? this.licenseLabel,
+      topics: topics ?? this.topics,
+      platforms: platforms ?? this.platforms,
+      sdkConstraint: sdkConstraint ?? this.sdkConstraint,
+      flutterConstraint: flutterConstraint ?? this.flutterConstraint,
+      publishedAt: publishedAt ?? this.publishedAt,
+      repositoryUpdatedAt: repositoryUpdatedAt ?? this.repositoryUpdatedAt,
+      likeCount: likeCount ?? this.likeCount,
+      downloadCount30Days: downloadCount30Days ?? this.downloadCount30Days,
+      pubPointsGranted: pubPointsGranted ?? this.pubPointsGranted,
+      pubPointsMax: pubPointsMax ?? this.pubPointsMax,
+      starCount: starCount ?? this.starCount,
+      forkCount: forkCount ?? this.forkCount,
+      openIssueCount: openIssueCount ?? this.openIssueCount,
+      hasLivePubDev: hasLivePubDev ?? this.hasLivePubDev,
+      hasLiveGitHub: hasLiveGitHub ?? this.hasLiveGitHub,
+    );
+  }
+}
+
+abstract final class PlaygroundThemeCount {
+  static const int custom = 1;
+  static int get total => MonacoTheme.values.length + custom;
+}
+
+class ShowcaseMetadataLoader {
+  ShowcaseMetadataLoader({http.Client? client, AssetBundle? bundle})
+    : _client = client ?? http.Client(),
+      _bundle = bundle ?? rootBundle,
+      _ownsClient = client == null;
+
+  final http.Client _client;
+  final AssetBundle _bundle;
+  final bool _ownsClient;
+
+  static final Uri _pubPackageUri = Uri.https(
+    'pub.dev',
+    '/api/packages/$_packageName',
+  );
+  static final Uri _pubScoreUri = Uri.https(
+    'pub.dev',
+    '/api/packages/$_packageName/score',
+  );
+  static final Uri _githubRepoUri = Uri.https(
+    'api.github.com',
+    '/repos/$_repositoryPath',
+  );
+
+  Future<ShowcaseMetadata> load() async {
+    var metadata = await _loadBundledPubspec();
+    metadata = await _mergePubDevPackage(metadata);
+    metadata = await _mergePubDevScore(metadata);
+    metadata = await _mergeGitHub(metadata);
+    return metadata;
+  }
+
+  void dispose() {
+    if (_ownsClient) _client.close();
+  }
+
+  Future<ShowcaseMetadata> _loadBundledPubspec() async {
+    try {
+      final source = await _bundle.loadString(
+        'packages/$_packageName/pubspec.yaml',
+      );
+      return parseShowcasePubspec(source);
+    } catch (_) {
+      return ShowcaseMetadata.fallback;
+    }
+  }
+
+  Future<ShowcaseMetadata> _mergePubDevPackage(
+    ShowcaseMetadata metadata,
+  ) async {
+    try {
+      final response = await _client.get(_pubPackageUri);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        return metadata;
+      }
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, Object?>) return metadata;
+      return parsePubDevPackage(decoded, base: metadata);
+    } catch (_) {
+      return metadata;
+    }
+  }
+
+  Future<ShowcaseMetadata> _mergePubDevScore(ShowcaseMetadata metadata) async {
+    try {
+      final response = await _client.get(_pubScoreUri);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        return metadata;
+      }
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, Object?>) return metadata;
+      return metadata.copyWith(
+        likeCount: _int(decoded['likeCount']),
+        downloadCount30Days: _int(decoded['downloadCount30Days']),
+        pubPointsGranted: _int(decoded['grantedPoints']),
+        pubPointsMax: _int(decoded['maxPoints']),
+      );
+    } catch (_) {
+      return metadata;
+    }
+  }
+
+  Future<ShowcaseMetadata> _mergeGitHub(ShowcaseMetadata metadata) async {
+    try {
+      final response = await _client.get(_githubRepoUri);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        return metadata;
+      }
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, Object?>) return metadata;
+      final license = decoded['license'];
+      return metadata.copyWith(
+        repositoryUrl: _string(decoded['html_url']) ?? metadata.repositoryUrl,
+        starCount: _int(decoded['stargazers_count']),
+        forkCount: _int(decoded['forks_count']),
+        openIssueCount: _int(decoded['open_issues_count']),
+        repositoryUpdatedAt:
+            _date(decoded['pushed_at']) ?? _date(decoded['updated_at']),
+        licenseLabel: license is Map<String, Object?>
+            ? _string(license['spdx_id']) ?? metadata.licenseLabel
+            : metadata.licenseLabel,
+        hasLiveGitHub: true,
+      );
+    } catch (_) {
+      return metadata;
+    }
+  }
+}
+
+ShowcaseMetadata parseShowcasePubspec(
+  String source, {
+  ShowcaseMetadata base = ShowcaseMetadata.fallback,
+}) {
+  final decoded = loadYaml(source);
+  if (decoded is! YamlMap) return base;
+  return _metadataFromPubspecMap(decoded, base: base);
+}
+
+ShowcaseMetadata parsePubDevPackage(
+  Map<String, Object?> packageJson, {
+  ShowcaseMetadata base = ShowcaseMetadata.fallback,
+}) {
+  final latest = packageJson['latest'];
+  if (latest is! Map<String, Object?>) return base;
+  final pubspec = latest['pubspec'];
+  final published = _date(latest['published']);
+  final metadata = pubspec is Map
+      ? _metadataFromPubspecMap(pubspec, base: base)
+      : base;
+  return metadata.copyWith(publishedAt: published, hasLivePubDev: true);
+}
+
+ShowcaseMetadata _metadataFromPubspecMap(
+  Map pubspec, {
+  required ShowcaseMetadata base,
+}) {
+  final packageName = _string(pubspec['name']) ?? base.packageName;
+  final repository = _string(pubspec['repository']) ?? base.repositoryUrl;
+  final environment = pubspec['environment'];
+
+  return base.copyWith(
+    packageName: packageName,
+    version: _string(pubspec['version']) ?? base.version,
+    description: _string(pubspec['description']) ?? base.description,
+    pubDevUrl: 'https://pub.dev/packages/$packageName',
+    repositoryUrl: repository,
+    apiDocsUrl: 'https://pub.dev/documentation/$packageName/latest/',
+    issueUrl: _string(pubspec['issue_tracker']) ?? '$repository/issues',
+    changelogUrl: '$repository/blob/main/CHANGELOG.md',
+    licenseUrl: '$repository/blob/main/LICENSE',
+    topics: _stringList(pubspec['topics']) ?? base.topics,
+    platforms: _platforms(pubspec['platforms']) ?? base.platforms,
+    sdkConstraint: environment is Map
+        ? _string(environment['sdk']) ?? base.sdkConstraint
+        : base.sdkConstraint,
+    flutterConstraint: environment is Map
+        ? _string(environment['flutter']) ?? base.flutterConstraint
+        : base.flutterConstraint,
+  );
+}
+
+List<ShowcasePlatform>? _platforms(Object? value) {
+  if (value is Map) {
+    return value.keys
+        .map((key) => key.toString())
+        .where((key) => key.trim().isNotEmpty)
+        .map(ShowcasePlatform.fromId)
+        .toList();
+  }
+  return null;
+}
+
+List<String>? _stringList(Object? value) {
+  if (value is Iterable) {
+    return value.map((item) => item.toString()).toList();
+  }
+  return null;
+}
+
+String? _string(Object? value) => value is String ? value : null;
+
+int? _int(Object? value) => value is int ? value : null;
+
+DateTime? _date(Object? value) {
+  if (value is! String) return null;
+  return DateTime.tryParse(value);
+}
+
+String compactNumber(int value) {
+  if (value < 1000) return '$value';
+  final thousands = value / 1000;
+  final text = thousands >= 10
+      ? thousands.toStringAsFixed(0)
+      : thousands.toStringAsFixed(1);
+  return '${text.replaceAll(RegExp(r'\.0$'), '')}k';
+}
+
+String formatShortDate(DateTime date) {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  final local = date.toLocal();
+  return '${months[local.month - 1]} ${local.day}, ${local.year}';
+}

--- a/example/lib/showcase/sections/features_section.dart
+++ b/example/lib/showcase/sections/features_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 
+import '../data/showcase_metadata.dart';
 import '../state/showcase_controller.dart';
 import '../theme/showcase_text.dart';
 import '../theme/showcase_tokens.dart';
@@ -10,9 +11,14 @@ import '../widgets/section_container.dart';
 /// The features grid. Each card's "Try it" scrolls to the playground and runs
 /// the matching live demo on the shared editor.
 class FeaturesSection extends StatelessWidget {
-  const FeaturesSection({super.key, required this.controller});
+  const FeaturesSection({
+    super.key,
+    required this.controller,
+    required this.metadata,
+  });
 
   final ShowcaseController controller;
+  final ShowcaseMetadata metadata;
 
   void _go(VoidCallback action) {
     controller.scrollToPlayground();
@@ -26,10 +32,10 @@ class FeaturesSection extends StatelessWidget {
     final cards = <FeatureCard>[
       FeatureCard(
         icon: Icons.translate_rounded,
-        title: '100+ languages',
+        title: '${metadata.typedLanguageCount} typed languages',
         body:
             'Syntax highlighting for Dart, TypeScript, Python, Rust, Go, '
-            'SQL and 100+ more - switch instantly.',
+            'SQL and more - switch instantly.',
         snippet: 'controller.setLanguage(MonacoLanguage.rust);',
         onTry: () => _go(() => controller.setLanguage(MonacoLanguage.rust)),
       ),
@@ -37,8 +43,8 @@ class FeaturesSection extends StatelessWidget {
         icon: Icons.palette_outlined,
         title: 'Theming',
         body:
-            'Four built-in themes, or register your own token colors with '
-            'defineTheme.',
+            '${metadata.builtInThemeCount} built-in themes, plus custom token '
+            'colors with defineTheme.',
         snippet: 'controller.defineTheme(midnightTheme);',
         onTry: () =>
             _go(() => controller.setPlaygroundTheme(PlaygroundTheme.midnight)),
@@ -91,7 +97,7 @@ class FeaturesSection extends StatelessWidget {
             constraints: const BoxConstraints(maxWidth: 620),
             child: Text(
               'A typed Dart API over the full Monaco surface - drive any of '
-              'these on the live editor below.',
+              'these on the live ${metadata.versionLabel} editor below.',
               style: ShowcaseText.bodyLg.copyWith(color: c.textSecondary),
             ),
           ),

--- a/example/lib/showcase/sections/get_started_section.dart
+++ b/example/lib/showcase/sections/get_started_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../data/showcase_metadata.dart';
 import '../theme/showcase_text.dart';
 import '../theme/showcase_tokens.dart';
 import '../util/links.dart';
@@ -26,7 +27,9 @@ MonacoEditor(
 
 /// "Get started in seconds" - three numbered steps with copyable code.
 class GetStartedSection extends StatelessWidget {
-  const GetStartedSection({super.key});
+  const GetStartedSection({super.key, required this.metadata});
+
+  final ShowcaseMetadata metadata;
 
   @override
   Widget build(BuildContext context) {
@@ -46,10 +49,16 @@ class GetStartedSection extends StatelessWidget {
             style: ShowcaseText.bodyLg.copyWith(color: c.textSecondary),
           ),
           const SizedBox(height: Insets.xl),
-          const _Step(
+          _Step(
             number: 1,
             title: 'Add the dependency',
-            child: CopyField(text: 'flutter pub add flutter_monaco'),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const CopyField(text: 'flutter pub add flutter_monaco'),
+                _DependencyNote(metadata: metadata),
+              ],
+            ),
           ),
           const _Step(
             number: 2,
@@ -134,6 +143,25 @@ class _Step extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _DependencyNote extends StatelessWidget {
+  const _DependencyNote({required this.metadata});
+
+  final ShowcaseMetadata metadata;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.showcaseColors;
+    return Padding(
+      padding: const EdgeInsets.only(top: Insets.sm),
+      child: Text(
+        'Latest ${metadata.versionLabel} - Dart ${metadata.sdkConstraint}, '
+        'Flutter ${metadata.flutterConstraint}.',
+        style: ShowcaseText.small.copyWith(color: c.textFaint),
       ),
     );
   }

--- a/example/lib/showcase/sections/hero_section.dart
+++ b/example/lib/showcase/sections/hero_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../data/showcase_metadata.dart';
 import '../theme/showcase_text.dart';
 import '../theme/showcase_tokens.dart';
 import '../util/links.dart';
@@ -11,8 +12,13 @@ import '../widgets/section_container.dart';
 /// The hero: headline, subhead, CTAs, install line, and platform badges,
 /// over a soft accent-gradient glow.
 class HeroSection extends StatelessWidget {
-  const HeroSection({super.key, required this.onTryPlayground});
+  const HeroSection({
+    super.key,
+    required this.metadata,
+    required this.onTryPlayground,
+  });
 
+  final ShowcaseMetadata metadata;
   final VoidCallback onTryPlayground;
 
   @override
@@ -31,7 +37,9 @@ class HeroSection extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _EyebrowPill(text: "Powered by VS Code's Monaco engine"),
+              _EyebrowPill(
+                text: '${metadata.versionLabel} - ${metadata.sourceLabel}',
+              ),
               const SizedBox(height: Insets.lg),
               Text(
                 "VS Code's editor,",
@@ -57,9 +65,7 @@ class HeroSection extends StatelessWidget {
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 640),
                 child: Text(
-                  'Embed Monaco - the engine behind VS Code - with 100+ '
-                  'languages, rich theming, IntelliSense, and a full Dart API. '
-                  'On web, desktop, and mobile.',
+                  metadata.productSummary,
                   style: ShowcaseText.bodyLg.copyWith(color: c.textSecondary),
                 ),
               ),
@@ -78,23 +84,88 @@ class HeroSection extends StatelessWidget {
                     label: 'View on pub.dev',
                     icon: Icons.open_in_new_rounded,
                     variant: GradientButtonVariant.outline,
-                    onPressed: () => openUrl(Links.pubDev),
+                    onPressed: () => openUrl(metadata.pubDevUrl),
                   ),
                   GradientButton(
                     label: 'GitHub',
                     icon: Icons.star_outline_rounded,
                     variant: GradientButtonVariant.ghost,
-                    onPressed: () => openUrl(Links.github),
+                    onPressed: () => openUrl(metadata.repositoryUrl),
                   ),
                 ],
               ),
               const SizedBox(height: Insets.xl),
               const CopyField(text: 'flutter pub add flutter_monaco'),
+              const SizedBox(height: Insets.lg),
+              _LiveFacts(metadata: metadata),
               const SizedBox(height: Insets.xl),
-              const PlatformBadges(),
+              PlatformBadges(platforms: metadata.platforms),
             ],
           ),
         ),
+      ],
+    );
+  }
+}
+
+class _LiveFacts extends StatelessWidget {
+  const _LiveFacts({required this.metadata});
+
+  final ShowcaseMetadata metadata;
+
+  @override
+  Widget build(BuildContext context) {
+    final facts = <(IconData, String)>[
+      (Icons.history_rounded, metadata.publishedLabel),
+      (
+        Icons.translate_rounded,
+        '${metadata.typedLanguageCount} typed languages',
+      ),
+      (Icons.palette_outlined, '${metadata.showcasedThemeCount} demo themes'),
+      if (metadata.downloadCount30Days != null)
+        (
+          Icons.download_rounded,
+          '${compactNumber(metadata.downloadCount30Days!)} downloads / 30d',
+        ),
+      if (metadata.likeCount != null)
+        (
+          Icons.favorite_border_rounded,
+          '${compactNumber(metadata.likeCount!)} likes',
+        ),
+      if (metadata.starCount != null)
+        (
+          Icons.star_outline_rounded,
+          '${compactNumber(metadata.starCount!)} stars',
+        ),
+    ];
+    final c = context.showcaseColors;
+    return Wrap(
+      spacing: Insets.sm,
+      runSpacing: Insets.sm,
+      children: [
+        for (final (icon, label) in facts)
+          Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: Insets.md,
+              vertical: Insets.sm,
+            ),
+            decoration: BoxDecoration(
+              color: c.surface,
+              borderRadius: BorderRadius.circular(Radii.pill),
+              border: Border.all(color: c.border),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, size: 15, color: c.textSecondary),
+                const SizedBox(width: 6),
+                Text(
+                  label,
+                  style: ShowcaseText.small.copyWith(color: c.textSecondary),
+                ),
+              ],
+            ),
+          ),
       ],
     );
   }

--- a/example/lib/showcase/sections/site_footer.dart
+++ b/example/lib/showcase/sections/site_footer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
+import '../data/showcase_metadata.dart';
 import '../theme/showcase_text.dart';
 import '../theme/showcase_tokens.dart';
 import '../util/links.dart';
@@ -8,29 +9,31 @@ import '../widgets/section_container.dart';
 
 /// The page footer: link columns + brand line.
 class SiteFooter extends StatelessWidget {
-  const SiteFooter({super.key});
+  const SiteFooter({super.key, required this.metadata});
+
+  final ShowcaseMetadata metadata;
 
   @override
   Widget build(BuildContext context) {
     final c = context.showcaseColors;
     final mobile = Breakpoints.isMobile(MediaQuery.sizeOf(context).width);
 
-    final brand = _Brand();
+    final brand = _Brand(metadata: metadata);
     final columns = [
       _LinkColumn(
         title: 'Package',
-        links: const [
-          ('pub.dev', Links.pubDev),
-          ('API docs', Links.apiDocs),
-          ('Changelog', Links.changelog),
+        links: [
+          ('pub.dev', metadata.pubDevUrl),
+          ('API docs', metadata.apiDocsUrl),
+          ('Changelog', metadata.changelogUrl),
         ],
       ),
       _LinkColumn(
         title: 'Source',
-        links: const [
-          ('GitHub', Links.github),
-          ('Issues', Links.issues),
-          ('License', Links.license),
+        links: [
+          ('GitHub', metadata.repositoryUrl),
+          ('Issues', metadata.issueUrl),
+          ('License', metadata.licenseUrl),
         ],
       ),
       _LinkColumn(
@@ -75,7 +78,7 @@ class SiteFooter extends StatelessWidget {
                 style: ShowcaseText.small.copyWith(color: c.textFaint),
               ),
               Text(
-                'v$kPackageVersion - MIT License',
+                '${metadata.versionLabel} - ${metadata.licenseLabel} License',
                 style: ShowcaseText.monoLabel.copyWith(color: c.textFaint),
               ),
             ],
@@ -87,6 +90,10 @@ class SiteFooter extends StatelessWidget {
 }
 
 class _Brand extends StatelessWidget {
+  const _Brand({required this.metadata});
+
+  final ShowcaseMetadata metadata;
+
   @override
   Widget build(BuildContext context) {
     final c = context.showcaseColors;
@@ -116,7 +123,7 @@ class _Brand extends StatelessWidget {
         ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 320),
           child: Text(
-            "VS Code's editor, inside your Flutter app.",
+            metadata.productSummary,
             style: ShowcaseText.body.copyWith(color: c.textSecondary),
           ),
         ),
@@ -124,7 +131,7 @@ class _Brand extends StatelessWidget {
         MouseRegion(
           cursor: SystemMouseCursors.click,
           child: GestureDetector(
-            onTap: () => openUrl(Links.github),
+            onTap: () => openUrl(metadata.repositoryUrl),
             child: SvgPicture.asset(
               'assets/github.svg',
               package: 'flutter_monaco',

--- a/example/lib/showcase/sections/site_nav.dart
+++ b/example/lib/showcase/sections/site_nav.dart
@@ -28,6 +28,7 @@ class SiteNav extends StatelessWidget {
     final width = MediaQuery.sizeOf(context).width;
     final compact = Breakpoints.isMobile(width);
     final horizontal = compact ? Insets.lg : Insets.xl;
+    final metadata = controller.metadata;
 
     return Container(
       height: height,
@@ -38,7 +39,7 @@ class SiteNav extends StatelessWidget {
       ),
       child: Row(
         children: [
-          _Logo(),
+          _Logo(versionLabel: metadata.versionLabel),
           const Spacer(),
           if (!compact) ...[
             _NavLink(label: 'Features', onTap: onTapFeatures),
@@ -48,32 +49,34 @@ class SiteNav extends StatelessWidget {
           ],
           ThemeToggle(controller: controller),
           const SizedBox(width: Insets.xs),
-          Tooltip(
-            message: 'GitHub',
-            child: Material(
-              color: Colors.transparent,
-              shape: const CircleBorder(),
-              clipBehavior: Clip.antiAlias,
-              child: InkWell(
-                onTap: () => openUrl(Links.github),
-                child: Padding(
-                  padding: const EdgeInsets.all(Insets.sm),
-                  child: SvgPicture.asset(
-                    'assets/github.svg',
-                    package: 'flutter_monaco',
-                    width: 20,
-                    height: 20,
-                    colorFilter: ColorFilter.mode(
-                      c.textSecondary,
-                      BlendMode.srcIn,
+          if (!compact) ...[
+            Tooltip(
+              message: 'GitHub',
+              child: Material(
+                color: Colors.transparent,
+                shape: const CircleBorder(),
+                clipBehavior: Clip.antiAlias,
+                child: InkWell(
+                  onTap: () => openUrl(metadata.repositoryUrl),
+                  child: Padding(
+                    padding: const EdgeInsets.all(Insets.sm),
+                    child: SvgPicture.asset(
+                      'assets/github.svg',
+                      package: 'flutter_monaco',
+                      width: 20,
+                      height: 20,
+                      colorFilter: ColorFilter.mode(
+                        c.textSecondary,
+                        BlendMode.srcIn,
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
-          ),
-          const SizedBox(width: Insets.sm),
-          _PubButton(compact: compact),
+            const SizedBox(width: Insets.sm),
+          ],
+          _PubButton(compact: compact, url: metadata.pubDevUrl),
         ],
       ),
     );
@@ -81,6 +84,10 @@ class SiteNav extends StatelessWidget {
 }
 
 class _Logo extends StatelessWidget {
+  const _Logo({required this.versionLabel});
+
+  final String versionLabel;
+
   @override
   Widget build(BuildContext context) {
     final c = context.showcaseColors;
@@ -113,7 +120,7 @@ class _Logo extends StatelessWidget {
             border: Border.all(color: c.border),
           ),
           child: Text(
-            'v$kPackageVersion',
+            versionLabel,
             style: ShowcaseText.monoLabel.copyWith(color: c.textFaint),
           ),
         ),
@@ -145,30 +152,36 @@ class _NavLink extends StatelessWidget {
 }
 
 class _PubButton extends StatelessWidget {
-  const _PubButton({required this.compact});
+  const _PubButton({required this.compact, required this.url});
 
   final bool compact;
+  final String url;
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        onTap: () => openUrl(Links.pubDev),
-        child: Container(
-          padding: EdgeInsets.symmetric(
-            horizontal: compact ? Insets.md : Insets.lg,
-            vertical: 9,
-          ),
-          decoration: BoxDecoration(
-            gradient: accentGradient,
-            borderRadius: BorderRadius.circular(Radii.sm),
-          ),
-          child: Text(
-            compact ? 'pub.dev' : 'Get it on pub.dev',
-            style: ShowcaseText.small.copyWith(color: Colors.white),
-          ),
-        ),
+    final child = Container(
+      width: compact ? 40 : null,
+      height: compact ? 40 : null,
+      padding: compact
+          ? EdgeInsets.zero
+          : const EdgeInsets.symmetric(horizontal: Insets.lg, vertical: 9),
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        gradient: accentGradient,
+        borderRadius: BorderRadius.circular(Radii.sm),
+      ),
+      child: compact
+          ? const Icon(Icons.open_in_new_rounded, color: Colors.white, size: 18)
+          : Text(
+              'Get it on pub.dev',
+              style: ShowcaseText.small.copyWith(color: Colors.white),
+            ),
+    );
+    return Tooltip(
+      message: 'pub.dev',
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(onTap: () => openUrl(url), child: child),
       ),
     );
   }

--- a/example/lib/showcase/showcase_app.dart
+++ b/example/lib/showcase/showcase_app.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 
@@ -31,6 +33,7 @@ class _ShowcaseAppState extends State<ShowcaseApp> {
   void initState() {
     super.initState();
     _controller.onRequestScrollToPlayground = () => _scrollTo(_playgroundKey);
+    unawaited(_controller.loadMetadata());
   }
 
   void _scrollTo(GlobalKey key) {
@@ -56,6 +59,7 @@ class _ShowcaseAppState extends State<ShowcaseApp> {
       listenable: _controller,
       builder: (context, _) {
         final isDark = _controller.brightness == Brightness.dark;
+        final metadata = _controller.metadata;
         return MaterialApp(
           title: "flutter_monaco - VS Code's editor in Flutter",
           debugShowCheckedModeBanner: false,
@@ -77,6 +81,7 @@ class _ShowcaseAppState extends State<ShowcaseApp> {
                     child: Column(
                       children: [
                         HeroSection(
+                          metadata: metadata,
                           onTryPlayground: () => _scrollTo(_playgroundKey),
                         ),
                         PlaygroundSection(
@@ -87,9 +92,10 @@ class _ShowcaseAppState extends State<ShowcaseApp> {
                         FeaturesSection(
                           key: _featuresKey,
                           controller: _controller,
+                          metadata: metadata,
                         ),
-                        const GetStartedSection(),
-                        const SiteFooter(),
+                        GetStartedSection(metadata: metadata),
+                        SiteFooter(metadata: metadata),
                       ],
                     ),
                   ),

--- a/example/lib/showcase/state/showcase_controller.dart
+++ b/example/lib/showcase/state/showcase_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter_monaco/flutter_monaco.dart';
 
 import '../data/demo_snippets.dart';
 import '../data/samples.dart';
+import '../data/showcase_metadata.dart';
 
 /// The editor theme choices exposed in the playground theme picker: the four
 /// built-in Monaco themes plus one custom theme registered at runtime.
@@ -43,9 +44,20 @@ enum PlaygroundTheme {
 /// is never rebuilt with new options/content; instead every change is applied
 /// imperatively here, which keeps the editor instance stable.
 class ShowcaseController extends ChangeNotifier {
+  ShowcaseController({ShowcaseMetadataLoader? metadataLoader})
+    : _metadataLoader = metadataLoader ?? ShowcaseMetadataLoader();
+
+  final ShowcaseMetadataLoader _metadataLoader;
+
   // --- Page state ---
   Brightness _brightness = Brightness.dark;
   Brightness get brightness => _brightness;
+
+  ShowcaseMetadata _metadata = ShowcaseMetadata.fallback;
+  ShowcaseMetadata get metadata => _metadata;
+
+  bool _metadataLoading = false;
+  bool get metadataLoading => _metadataLoading;
 
   /// Set by the app so feature cards can scroll the page to the playground.
   VoidCallback? onRequestScrollToPlayground;
@@ -90,7 +102,8 @@ class ShowcaseController extends ChangeNotifier {
   late final EditorOptions initialEditorOptions = _buildOptions();
 
   /// Initial document for the editor widget.
-  String get initialValue => sampleFor(MonacoLanguage.dart);
+  String get initialValue =>
+      sampleFor(MonacoLanguage.dart, metadata: _metadata);
 
   EditorOptions _buildOptions() => EditorOptions(
     language: _language,
@@ -122,6 +135,24 @@ class ShowcaseController extends ChangeNotifier {
       debugPrint('[ShowcaseController] attachEditor failed: $e');
     }
     notifyListeners();
+  }
+
+  Future<void> loadMetadata() async {
+    if (_metadataLoading) return;
+    _metadataLoading = true;
+    notifyListeners();
+    try {
+      _metadata = await _metadataLoader.load();
+      final editor = _editor;
+      if (editor != null && _language == MonacoLanguage.json) {
+        await editor.setValue(sampleFor(_language, metadata: _metadata));
+      }
+    } catch (e) {
+      debugPrint('[ShowcaseController] metadata load failed: $e');
+    } finally {
+      _metadataLoading = false;
+      notifyListeners();
+    }
   }
 
   // --- Page theme ---
@@ -164,7 +195,7 @@ class ShowcaseController extends ChangeNotifier {
     await editor.clearAllMarkers();
     await editor.clearDecorations();
     await editor.setLanguage(language);
-    await editor.setValue(sampleFor(language));
+    await editor.setValue(sampleFor(language, metadata: _metadata));
   }
 
   // --- Options ---
@@ -221,7 +252,7 @@ class ShowcaseController extends ChangeNotifier {
     await editor.clearAllMarkers();
     await editor.clearDecorations();
     await editor.setLanguage(_language);
-    await editor.setValue(sampleFor(_language));
+    await editor.setValue(sampleFor(_language, metadata: _metadata));
   }
 
   /// Scrolls the page to the playground (used by feature-card "Try it" links).
@@ -285,5 +316,11 @@ class ShowcaseController extends ChangeNotifier {
   void _setHint(String message) {
     _hint = message;
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _metadataLoader.dispose();
+    super.dispose();
   }
 }

--- a/example/lib/showcase/util/links.dart
+++ b/example/lib/showcase/util/links.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-/// The package version shown in the nav pill and footer.
-const String kPackageVersion = '1.7.1';
-
 /// External destinations referenced across the showcase.
 abstract final class Links {
   static const String pubDev = 'https://pub.dev/packages/flutter_monaco';

--- a/example/lib/showcase/widgets/platform_badges.dart
+++ b/example/lib/showcase/widgets/platform_badges.dart
@@ -1,19 +1,14 @@
 import 'package:flutter/material.dart';
 
+import '../data/showcase_metadata.dart';
 import '../theme/showcase_text.dart';
 import '../theme/showcase_tokens.dart';
 
 /// A small chip row of the platforms the package supports.
 class PlatformBadges extends StatelessWidget {
-  const PlatformBadges({super.key});
+  const PlatformBadges({super.key, required this.platforms});
 
-  static const _items = <(IconData, String)>[
-    (Icons.public, 'Web'),
-    (Icons.phone_iphone, 'iOS'),
-    (Icons.android, 'Android'),
-    (Icons.laptop_mac, 'macOS'),
-    (Icons.desktop_windows, 'Windows'),
-  ];
+  final List<ShowcasePlatform> platforms;
 
   @override
   Widget build(BuildContext context) {
@@ -22,7 +17,7 @@ class PlatformBadges extends StatelessWidget {
       spacing: Insets.sm,
       runSpacing: Insets.sm,
       children: [
-        for (final (icon, label) in _items)
+        for (final platform in platforms)
           Container(
             padding: const EdgeInsets.symmetric(
               horizontal: Insets.md,
@@ -36,10 +31,10 @@ class PlatformBadges extends StatelessWidget {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(icon, size: 15, color: c.textSecondary),
+                Icon(iconFor(platform), size: 15, color: c.textSecondary),
                 const SizedBox(width: 6),
                 Text(
-                  label,
+                  platform.label,
                   style: ShowcaseText.small.copyWith(color: c.textSecondary),
                 ),
               ],
@@ -48,4 +43,14 @@ class PlatformBadges extends StatelessWidget {
       ],
     );
   }
+
+  IconData iconFor(ShowcasePlatform platform) => switch (platform.id) {
+    'web' => Icons.public,
+    'ios' => Icons.phone_iphone,
+    'android' => Icons.android,
+    'macos' => Icons.laptop_mac,
+    'windows' => Icons.desktop_windows,
+    'linux' => Icons.terminal,
+    _ => Icons.devices_other,
+  };
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,9 +9,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  http: ^1.5.0
   url_launcher: ^6.3.2
   flutter_svg: ^2.2.3
   package_info_plus: ^9.0.0
+  yaml: ^3.1.3
   flutter_monaco:
     path: ../
 

--- a/example/test/showcase/layout_test.dart
+++ b/example/test/showcase/layout_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_monaco_example/showcase/sections/features_section.dart';
 import 'package:flutter_monaco_example/showcase/sections/get_started_section.dart';
 import 'package:flutter_monaco_example/showcase/sections/hero_section.dart';
+import 'package:flutter_monaco_example/showcase/data/showcase_metadata.dart';
 import 'package:flutter_monaco_example/showcase/state/showcase_controller.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -41,9 +42,15 @@ void main() {
   }
 
   Map<String, Widget> sections(ShowcaseController controller) => {
-    'hero': HeroSection(onTryPlayground: () {}),
-    'features': FeaturesSection(controller: controller),
-    'getStarted': const GetStartedSection(),
+    'hero': HeroSection(
+      metadata: ShowcaseMetadata.fallback,
+      onTryPlayground: () {},
+    ),
+    'features': FeaturesSection(
+      controller: controller,
+      metadata: ShowcaseMetadata.fallback,
+    ),
+    'getStarted': const GetStartedSection(metadata: ShowcaseMetadata.fallback),
   };
 
   testWidgets('sections render without overflow at tablet and desktop', (
@@ -76,7 +83,10 @@ void main() {
 
     await errorsFor(
       tester,
-      FeaturesSection(controller: controller),
+      FeaturesSection(
+        controller: controller,
+        metadata: ShowcaseMetadata.fallback,
+      ),
       const Size(390, 3600),
     );
     expect(find.text('Everything the editor can do'), findsOneWidget);

--- a/example/test/showcase/metadata_test.dart
+++ b/example/test/showcase/metadata_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_monaco_example/showcase/data/showcase_metadata.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('showcase metadata', () {
+    test('parses package metadata from pubspec yaml', () {
+      final metadata = parseShowcasePubspec('''
+name: flutter_monaco
+description: Current description
+version: 2.1.0
+repository: https://github.com/omar-hanafy/flutter_monaco
+issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues
+topics:
+  - monaco
+  - editor
+platforms:
+  android:
+  ios:
+  web:
+environment:
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
+''');
+
+      expect(metadata.packageName, 'flutter_monaco');
+      expect(metadata.version, '2.1.0');
+      expect(metadata.description, 'Current description');
+      expect(metadata.topics, ['monaco', 'editor']);
+      expect(metadata.platforms.map((platform) => platform.id), [
+        'android',
+        'ios',
+        'web',
+      ]);
+      expect(metadata.sdkConstraint, '>=3.12.0 <4.0.0');
+      expect(metadata.flutterConstraint, '>=3.44.0');
+    });
+
+    test('merges latest pub.dev package metadata', () {
+      final metadata = parsePubDevPackage({
+        'latest': {
+          'version': '2.2.0',
+          'published': '2026-06-21T10:00:00.000Z',
+          'pubspec': {
+            'name': 'flutter_monaco',
+            'description': 'Live description',
+            'version': '2.2.0',
+            'repository': 'https://github.com/omar-hanafy/flutter_monaco',
+            'platforms': {'windows': null, 'web': null},
+            'environment': {'sdk': '>=3.12.0 <4.0.0'},
+          },
+        },
+      });
+
+      expect(metadata.version, '2.2.0');
+      expect(metadata.description, 'Live description');
+      expect(metadata.hasLivePubDev, isTrue);
+      expect(metadata.publishedAt, isNotNull);
+      expect(metadata.platforms.map((platform) => platform.label), [
+        'Windows',
+        'Web',
+      ]);
+    });
+  });
+}

--- a/example/test/showcase/samples_test.dart
+++ b/example/test/showcase/samples_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco_example/showcase/data/demo_snippets.dart';
 import 'package:flutter_monaco_example/showcase/data/samples.dart';
+import 'package:flutter_monaco_example/showcase/data/showcase_metadata.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -27,8 +28,30 @@ void main() {
     });
 
     test('the JSON sample is valid JSON', () {
-      final decoded = jsonDecode(sampleFor(MonacoLanguage.json));
+      final decoded = jsonDecode(
+        sampleFor(MonacoLanguage.json, metadata: ShowcaseMetadata.fallback),
+      );
       expect(decoded, isA<Map<String, dynamic>>());
+    });
+
+    test('the JSON sample follows current package metadata', () {
+      final decoded =
+          jsonDecode(
+                sampleFor(
+                  MonacoLanguage.json,
+                  metadata: ShowcaseMetadata.fallback,
+                ),
+              )
+              as Map<String, dynamic>;
+
+      expect(decoded['version'], ShowcaseMetadata.fallback.version);
+      expect(decoded['platforms'], [
+        for (final platform in ShowcaseMetadata.fallback.platforms) platform.id,
+      ]);
+      expect(
+        (decoded['features'] as Map<String, dynamic>)['typedLanguages'],
+        MonacoLanguage.values.length,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a live showcase metadata loader with bundled pubspec fallback, pub.dev package/score fetches, and GitHub repo stats.
- Drive the nav version pill, hero facts, platform badges, feature counts, footer links, install notes, and JSON/Markdown samples from metadata instead of stale constants.
- Add showcase metadata tests and .pubignore rules for local-only/generated artifacts.

## Verification
- dart format --output=none --set-exit-if-changed .
- flutter analyze
- flutter test
- (cd example && flutter test)
- (cd example && flutter build web --wasm --release --base-href /flutter-monaco/ --target lib/showcase/main.dart)
- Playwright screenshots at 1280x1400 and 390x1000 against http://127.0.0.1:8765/flutter-monaco/
- HAR confirmed 200 responses for bundled pubspec, pub.dev package, pub.dev score, and GitHub repo metadata
- dart pub publish --dry-run: 0 warnings

## Notes
- Local reference files under LSP-Support/ remain untracked and are ignored by pub packaging.