### PR TITLE
Prepare flutter_monaco 2.1.0 focus release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-06-21
+
+### Added
+- Added `MonacoFocusIntent` so apps can distinguish direct user-initiated editor focus recovery from background focus maintenance.
+
+### Fixed
+- Fixed macOS WKWebView input readiness recovery when Monaco appears focused but typing and paste are ignored.
+- Kept background focus nudges cooperative with focused Flutter text inputs, and preserved the Windows WebView2 no-replay behavior for right-clicks and repeated primary clicks.
+
 ## [2.0.0] - 2026-06-20
 
 ### Changed

--- a/lib/flutter_monaco.dart
+++ b/lib/flutter_monaco.dart
@@ -59,7 +59,8 @@ export 'src/core/monaco_actions.dart' show MonacoAction;
 // Core exports
 export 'src/core/monaco_assets.dart' show MonacoAssets;
 export 'src/core/monaco_constants.dart' show MonacoConstants;
-export 'src/core/monaco_controller.dart' show MonacoController;
+export 'src/core/monaco_controller.dart'
+    show MonacoController, MonacoFocusIntent;
 export 'src/core/monaco_js_error.dart' show MonacoJavaScriptException;
 
 // Model exports

--- a/lib/src/core/monaco_assets.dart
+++ b/lib/src/core/monaco_assets.dart
@@ -809,11 +809,13 @@ class MonacoAssets {
                   focus: () => E().focus(),
                   layout: () => { try { E().layout(); } catch (_) {} },
                   // Force focus robustly: wait for visibility, layout, focus editor and hidden textarea
-                  forceFocus: () => {
+                  forceFocus: (options = {}) => {
                     try {
                       const ed = E();
                       const node = getEditorNode();
                       if (!ed || !node) return;
+                      const replayInputFocus =
+                        options && options.replayInputFocus === true;
 
                       if (isMobileInputPlatform()) {
                         focusEditorTextAreaNow();
@@ -833,7 +835,7 @@ class MonacoAssets {
                         // the flicker for EVERY caller, not just guarded pointers.
                         const input = node.querySelector(
                           'textarea.inputarea, .native-edit-context');
-                        if (input && document.activeElement === input) {
+                        if (!replayInputFocus && input && document.activeElement === input) {
                           return;
                         }
                         try { window.focus && window.focus(); } catch (_) {}

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -14,6 +14,19 @@ import 'package:flutter_monaco/src/platform/platform_webview.dart';
 typedef CompletionProvider =
     Future<CompletionList> Function(CompletionRequest request);
 
+/// Describes why Monaco input focus is being requested.
+///
+/// The distinction matters on desktop platform views: background maintenance
+/// must not steal the keyboard from Flutter text inputs, while direct user
+/// interaction with Monaco is an intentional keyboard handoff.
+enum MonacoFocusIntent {
+  /// Focus requested because the user directly interacted with Monaco.
+  user,
+
+  /// Focus requested by background maintenance such as route or lifecycle sync.
+  maintenance,
+}
+
 /// Manages the lifecycle and interaction with a Monaco Editor instance.
 ///
 /// The [MonacoController] bridges Dart and the underlying JavaScript editor,
@@ -75,10 +88,12 @@ class MonacoController {
   /// Stream emitting the new [Range] whenever the cursor selection changes.
   Stream<Range?> get onSelectionChanged => _onSelectionChanged.stream;
 
-  /// Stream emitting events when the editor gains focus.
+  /// Stream emitting Monaco DOM focus events.
+  ///
+  /// This is not a native input-readiness guarantee on desktop platform views.
   Stream<void> get onFocus => _onFocus.stream;
 
-  /// Stream emitting events when the editor loses focus.
+  /// Stream emitting Monaco DOM blur events.
   Stream<void> get onBlur => _onBlur.stream;
 
   /// Creates and initializes a new [MonacoController].
@@ -568,6 +583,24 @@ class MonacoController {
     return context.findAncestorStateOfType<EditableTextState>() != null;
   }
 
+  static bool _shouldRespectFlutterTextInput(MonacoFocusIntent intent) {
+    return intent == MonacoFocusIntent.maintenance;
+  }
+
+  static bool _shouldReplayInputFocus(MonacoFocusIntent intent) {
+    return !kIsWeb &&
+        defaultTargetPlatform == TargetPlatform.macOS &&
+        intent == MonacoFocusIntent.user;
+  }
+
+  static String _forceFocusScript(MonacoFocusIntent intent) {
+    final replayArg = _shouldReplayInputFocus(intent)
+        ? '({ replayInputFocus: true })'
+        : '()';
+    return 'window.flutterMonaco && window.flutterMonaco.forceFocus && '
+        'window.flutterMonaco.forceFocus$replayArg';
+  }
+
   /// Requests focus for the editor widget.
   ///
   /// Uses a robust method that waits for visibility and layout before attempting focus.
@@ -575,9 +608,9 @@ class MonacoController {
   /// inside the editor.
   ///
   /// This is cooperative: it does nothing while a Flutter text input owns
-  /// the primary focus, so background refocus calls cannot steal the
-  /// keyboard from a focused TextField (e.g. in a dialog). For an
-  /// intentional handoff, unfocus the field first.
+  /// the primary focus, so programmatic calls cannot steal the keyboard from
+  /// a focused TextField (e.g. in a dialog). For direct pointer interaction,
+  /// use [ensureEditorFocus] with [MonacoFocusIntent.user].
   Future<void> focus() async {
     if (!_interactionEnabled) return;
     await _ensureReady();
@@ -587,7 +620,7 @@ class MonacoController {
     await _webViewController.requestNativeFocus();
     // Use robust in-page helper (waits for visibility, layouts, focuses textarea)
     await _webViewController.runJavaScript(
-      'window.flutterMonaco && window.flutterMonaco.forceFocus && window.flutterMonaco.forceFocus()',
+      _forceFocusScript(MonacoFocusIntent.maintenance),
     );
   }
 
@@ -595,13 +628,19 @@ class MonacoController {
   ///
   /// [attempts] defaults to 3, with [interval] of 24ms.
   ///
-  /// Like [focus], this is cooperative: attempts made while a Flutter text
-  /// input owns the primary focus are skipped, so refocus nudges (after
-  /// content updates, route pops, app resume) cannot steal the keyboard
-  /// from a focused TextField.
+  /// Like [focus], this defaults to cooperative background maintenance:
+  /// attempts made while a Flutter text input owns the primary focus are
+  /// skipped, so refocus nudges after content updates, route pops, or app
+  /// resume cannot steal the keyboard from a focused TextField.
+  ///
+  /// Pass [MonacoFocusIntent.user] only from direct user interaction with the
+  /// editor, such as a primary pointer down inside the Monaco view. On macOS
+  /// that intent also replays the in-page focus path because WKWebView native
+  /// input readiness can become stale while Monaco still reports DOM focus.
   Future<void> ensureEditorFocus({
     int attempts = 3,
     Duration interval = const Duration(milliseconds: 24),
+    MonacoFocusIntent intent = MonacoFocusIntent.maintenance,
   }) async {
     if (!_interactionEnabled) return;
     await _ensureReady();
@@ -618,7 +657,8 @@ class MonacoController {
     for (var i = 0; i < effectiveAttempts; i++) {
       // Re-evaluated per attempt: a text input losing focus mid-loop (e.g.
       // a closing dialog) lets the remaining attempts proceed.
-      if (!_flutterTextInputHasFocus()) {
+      if (!_shouldRespectFlutterTextInput(intent) ||
+          !_flutterTextInputHasFocus()) {
         if (!nativeFocusRequested) {
           // On Windows, hand real Win32 keyboard focus to WebView2 first;
           // the JS focus below cannot take effect without it.
@@ -626,9 +666,7 @@ class MonacoController {
           nativeFocusRequested = true;
         }
         try {
-          await _webViewController.runJavaScript(
-            'window.flutterMonaco && window.flutterMonaco.forceFocus && window.flutterMonaco.forceFocus()',
-          );
+          await _webViewController.runJavaScript(_forceFocusScript(intent));
         } catch (_) {}
       }
       if (i + 1 < effectiveAttempts) {

--- a/lib/src/platform/platform_webview_interface.dart
+++ b/lib/src/platform/platform_webview_interface.dart
@@ -140,7 +140,10 @@ abstract class PlatformWebViewController {
   ///
   /// On Windows, WebView2 must hold real Win32 keyboard focus before any
   /// in-page (JavaScript) focus call has an effect, so this moves native
-  /// focus to the WebView2 control. On all other platforms this is a no-op;
-  /// their WebViews participate in the regular platform focus system.
+  /// focus to the WebView2 control.
+  ///
+  /// On `webview_flutter` platforms, including macOS WKWebView, the package
+  /// does not expose a reliable first-responder handoff, so this is a no-op.
+  /// Callers must still run the in-page Monaco focus helper after this method.
   Future<void> requestNativeFocus();
 }

--- a/lib/src/platform/web_view_controller/native.dart
+++ b/lib/src/platform/web_view_controller/native.dart
@@ -50,8 +50,9 @@ abstract class WebViewController implements PlatformWebViewController {
 
   @override
   Future<void> requestNativeFocus() async {
-    // No-op by default. webview_flutter platforms participate in the regular
-    // platform focus system; only Windows needs an explicit handoff.
+    // No-op by default. The webview_flutter API used for Android, iOS, and
+    // macOS does not expose a reliable native first-responder handoff here;
+    // only Windows WebView2 has an explicit focus method available.
   }
 
   /// Generates and caches the Monaco editor HTML file for native platforms.

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -26,19 +26,18 @@ bool _pointerMayClaimKeyboard(PointerDownEvent event) {
   return true;
 }
 
-bool _pointerShouldNudgeFocus(
+bool _pointerShouldRecoverInputFocus(
   PointerDownEvent event, {
   required bool hasFlutterFocus,
-  required bool editorReportsFocused,
+  required bool monacoReportsFocused,
+  TargetPlatform? platform,
 }) {
-  // Re-assert focus only when the editor is not already fully focused: it
-  // lacks Flutter focus (key routing) OR Monaco itself reports unfocused (its
-  // input cannot receive keystrokes). Reading Monaco's own focus signal - not
-  // just the Flutter-focus proxy - lets a click recover typing after the
-  // editor silently lost native focus (alt-tab, a dialog, a tab switch),
-  // while an already-focused editor is still left alone (no replay).
   if (!_pointerMayClaimKeyboard(event)) return false;
-  return !hasFlutterFocus || !editorReportsFocused;
+  final targetPlatform = platform ?? defaultTargetPlatform;
+  if (targetPlatform == TargetPlatform.macOS) {
+    return true;
+  }
+  return !hasFlutterFocus || !monacoReportsFocused;
 }
 
 /// A widget that renders a Monaco Editor instance.
@@ -241,11 +240,10 @@ class _MonacoEditorState extends State<MonacoEditor> {
   /// FocusNode to explicitly request platform view focus for the WebView.
   final FocusNode _webFocusNode = FocusNode(debugLabel: 'MonacoWebViewFocus');
 
-  /// Whether Monaco itself reports the editor focused (its input can receive
-  /// keystrokes), driven by the controller's focus/blur stream. Lets a
-  /// pointer-down tell "already focused, leave it alone" apart from "Flutter
-  /// thinks it's focused but Monaco lost it" (the alt-tab/dialog desync).
-  bool _editorReportsFocused = false;
+  /// Whether Monaco itself reports DOM focus, driven by the controller's
+  /// focus/blur stream. On macOS this is not proof that WKWebView is still
+  /// native input-ready.
+  bool _monacoReportsFocused = false;
 
   @override
   void initState() {
@@ -439,12 +437,12 @@ class _MonacoEditorState extends State<MonacoEditor> {
       _streamSubscriptions.add(selectionSub);
     }
     final focusSub = _controller!.onFocus.listen((_) {
-      _editorReportsFocused = true;
+      _monacoReportsFocused = true;
       widget.onFocus?.call();
     });
     _streamSubscriptions.add(focusSub);
     final blurSub = _controller!.onBlur.listen((_) {
-      _editorReportsFocused = false;
+      _monacoReportsFocused = false;
       widget.onBlur?.call();
     });
     _streamSubscriptions.add(blurSub);
@@ -581,15 +579,20 @@ class _MonacoEditorState extends State<MonacoEditor> {
             behavior: HitTestBehavior.translucent,
             onPointerDown: (event) {
               if (!widget.interactionEnabled) return;
-              if (!_pointerShouldNudgeFocus(
+              if (!_pointerShouldRecoverInputFocus(
                 event,
                 hasFlutterFocus: _webFocusNode.hasFocus,
-                editorReportsFocused: _editorReportsFocused,
+                monacoReportsFocused: _monacoReportsFocused,
               )) {
                 return;
               }
               _webFocusNode.requestFocus();
-              unawaited(_controller!.ensureEditorFocus(attempts: 1));
+              unawaited(
+                _controller!.ensureEditorFocus(
+                  attempts: 1,
+                  intent: MonacoFocusIntent.user,
+                ),
+              );
             },
             child: _controller!.webViewWidget,
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/core/monaco_assets_test.dart
+++ b/test/core/monaco_assets_test.dart
@@ -174,6 +174,14 @@ void main() {
 
       expect(html, contains('if (isMobileInputPlatform())'));
       expect(html, contains('focusEditorTextAreaNow();'));
+      expect(html, contains('forceFocus: (options = {}) =>'));
+      expect(html, contains('const replayInputFocus ='));
+      expect(
+        html,
+        contains(
+          'if (!replayInputFocus && input && document.activeElement === input)',
+        ),
+      );
       expect(html, contains('ta.focus({ preventScroll: true });'));
     });
 

--- a/test/core/monaco_controller_test.dart
+++ b/test/core/monaco_controller_test.dart
@@ -1162,6 +1162,40 @@ void main() {
         }
       });
 
+      test('user focus intent replays input focus on macOS', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        try {
+          final bundle = await _createBundle();
+          await bundle.controller.ensureEditorFocus(
+            attempts: 1,
+            interval: Duration.zero,
+            intent: MonacoFocusIntent.user,
+          );
+          expect(
+            bundle.webview.executed.join('\n'),
+            contains('forceFocus({ replayInputFocus: true })'),
+          );
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      test('maintenance focus intent keeps default idempotent focus', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        try {
+          final bundle = await _createBundle();
+          await bundle.controller.ensureEditorFocus(
+            attempts: 1,
+            interval: Duration.zero,
+          );
+          final joined = bundle.webview.executed.join('\n');
+          expect(joined, contains('forceFocus()'));
+          expect(joined, isNot(contains('replayInputFocus')));
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
       test('ensureEditorFocus uses one attempt on mobile', () async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
         try {

--- a/test/platform/native_web_view_controller_source_test.dart
+++ b/test/platform/native_web_view_controller_source_test.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  String nativeControllerSource() => File(
+    'lib/src/platform/web_view_controller/native.dart',
+  ).readAsStringSync();
+
+  test('native focus handoff is only implemented by Windows WebView2', () {
+    final source = nativeControllerSource();
+
+    final baseFocusStart = source.indexOf(
+      '@override\n  Future<void> requestNativeFocus() async {',
+    );
+    final baseFocusEnd = source.indexOf('/// Generates and caches');
+    expect(baseFocusStart, isNonNegative);
+    expect(baseFocusEnd, greaterThan(baseFocusStart));
+
+    final baseFocusBlock = source.substring(baseFocusStart, baseFocusEnd);
+    expect(baseFocusBlock, contains('No-op by default'));
+    expect(baseFocusBlock, isNot(contains('_controller.focus()')));
+
+    final windowsClassStart = source.indexOf('class WindowsWebViewController');
+    final windowsFocusStart = source.indexOf(
+      '@override\n  Future<void> requestNativeFocus() async {',
+      windowsClassStart,
+    );
+    final windowsFocusEnd = source.indexOf(
+      '@override\n  Future<void> enableJavaScript()',
+      windowsFocusStart,
+    );
+    expect(windowsClassStart, isNonNegative);
+    expect(windowsFocusStart, greaterThan(windowsClassStart));
+    expect(windowsFocusEnd, greaterThan(windowsFocusStart));
+
+    final windowsFocusBlock = source.substring(
+      windowsFocusStart,
+      windowsFocusEnd,
+    );
+    expect(windowsFocusBlock, contains('await _controller.focus();'));
+  });
+}

--- a/test/widgets/monaco_editor_test.dart
+++ b/test/widgets/monaco_editor_test.dart
@@ -484,7 +484,7 @@ void main() {
         }
       });
 
-      testWidgets('desktop repeated primary mouse down does not refocus', (
+      testWidgets('macOS repeated primary mouse down replays input readiness', (
         tester,
       ) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
@@ -503,8 +503,51 @@ void main() {
           await first.down(target);
           await tester.pumpAndSettle();
           await first.up();
-          // Monaco reports the editor focused after the first click; a second
-          // click on the already-focused editor must not replay focus.
+          // Monaco reports the editor focused after the first click, but on
+          // macOS that cached DOM focus is not proof of native input readiness.
+          bundle.webview.emitToChannel('flutterChannel', '{"event":"focus"}');
+          await tester.pump();
+
+          bundle.webview.executed.clear();
+          final second = await tester.createGesture(
+            kind: PointerDeviceKind.mouse,
+            buttons: kPrimaryMouseButton,
+          );
+          await second.down(target);
+          await tester.pumpAndSettle();
+          await second.up();
+
+          expect(bundle.webview.executed, contains('REQUEST_NATIVE_FOCUS'));
+          bundle.webview.assertExecuted(
+            'forceFocus({ replayInputFocus: true })',
+          );
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets('Windows repeated primary mouse down does not refocus', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+        try {
+          final bundle = await _createBundle();
+          await tester.pumpWidget(
+            _wrap(MonacoEditor(controller: bundle.controller)),
+          );
+          await tester.pumpAndSettle();
+
+          final target = tester.getCenter(find.byKey(const Key('webview')));
+          final first = await tester.createGesture(
+            kind: PointerDeviceKind.mouse,
+            buttons: kPrimaryMouseButton,
+          );
+          await first.down(target);
+          await tester.pumpAndSettle();
+          await first.up();
+          // Monaco reports the editor focused after the first click; Windows
+          // must not replay focus because WebView2 focus replay flickers the
+          // caret and can tear down the context menu.
           bundle.webview.emitToChannel('flutterChannel', '{"event":"focus"}');
           await tester.pump();
 


### PR DESCRIPTION
## Summary
- Prepare `flutter_monaco` 2.1.0.
- Add `MonacoFocusIntent` to separate user-initiated focus recovery from background maintenance.
- Fix macOS primary pointer entry so Monaco input readiness is reasserted even when cached focus signals still report focused.
- Preserve Windows WebView2 no-replay behavior for right-clicks and repeated primary clicks.

## Validation
- `flutter pub get`
- `dart format .`
- `dart fix --apply`
- `dart analyze`
- `flutter analyze`
- `flutter test test/widgets/monaco_editor_test.dart test/core/monaco_controller_test.dart test/core/monaco_assets_test.dart test/platform/native_web_view_controller_source_test.dart`
- `flutter test`
- `dart pub publish --dry-run` reports 0 warnings
- `pana` reports 150/160, matching the repo gate. The missing 10 points are from intentionally unsupported Linux, which should not be declared falsely.
