### PR TITLE
Prepare flutter_monaco 2.1.1 focus handoff release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-06-21
+
+### Fixed
+- Fixed desktop editor input recovery after Flutter text fields or dialogs leave a stale text-input client active before Monaco is focused.
+
 ## [2.1.0] - 2026-06-21
 
 ### Added

--- a/lib/src/core/monaco_controller.dart
+++ b/lib/src/core/monaco_controller.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:convert_object/convert_object.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/core/monaco_bridge.dart';
 import 'package:flutter_monaco/src/platform/platform_webview.dart';
@@ -18,7 +19,8 @@ typedef CompletionProvider =
 ///
 /// The distinction matters on desktop platform views: background maintenance
 /// must not steal the keyboard from Flutter text inputs, while direct user
-/// interaction with Monaco is an intentional keyboard handoff.
+/// interaction with Monaco is an intentional keyboard handoff that may release
+/// Flutter's active text input before Monaco is focused.
 enum MonacoFocusIntent {
   /// Focus requested because the user directly interacted with Monaco.
   user,
@@ -593,6 +595,25 @@ class MonacoController {
         intent == MonacoFocusIntent.user;
   }
 
+  static bool _shouldReleaseFlutterTextInput(MonacoFocusIntent intent) {
+    if (kIsWeb || intent != MonacoFocusIntent.user) return false;
+    return defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.windows ||
+        defaultTargetPlatform == TargetPlatform.linux;
+  }
+
+  static Future<void> _releaseFlutterTextInputForUserFocus() async {
+    if (_flutterTextInputHasFocus()) {
+      try {
+        FocusManager.instance.primaryFocus?.unfocus();
+      } catch (_) {}
+    }
+    try {
+      await SystemChannels.textInput.invokeMethod<void>('TextInput.hide');
+    } catch (_) {}
+    await Future<void>.delayed(Duration.zero);
+  }
+
   static String _forceFocusScript(MonacoFocusIntent intent) {
     final replayArg = _shouldReplayInputFocus(intent)
         ? '({ replayInputFocus: true })'
@@ -634,9 +655,11 @@ class MonacoController {
   /// resume cannot steal the keyboard from a focused TextField.
   ///
   /// Pass [MonacoFocusIntent.user] only from direct user interaction with the
-  /// editor, such as a primary pointer down inside the Monaco view. On macOS
-  /// that intent also replays the in-page focus path because WKWebView native
-  /// input readiness can become stale while Monaco still reports DOM focus.
+  /// editor, such as a primary pointer down inside the Monaco view. On desktop
+  /// that intent first releases Flutter's text-input channel so a stale
+  /// TextField/dialog client cannot keep swallowing native input. On macOS it
+  /// also replays the in-page focus path because WKWebView native input
+  /// readiness can become stale while Monaco still reports DOM focus.
   Future<void> ensureEditorFocus({
     int attempts = 3,
     Duration interval = const Duration(milliseconds: 24),
@@ -653,6 +676,11 @@ class MonacoController {
         (defaultTargetPlatform == TargetPlatform.android ||
             defaultTargetPlatform == TargetPlatform.iOS);
     final effectiveAttempts = isMobileNative ? 1 : attempts;
+    if (effectiveAttempts <= 0) return;
+
+    if (_shouldReleaseFlutterTextInput(intent)) {
+      await _releaseFlutterTextInputForUserFocus();
+    }
 
     for (var i = 0; i < effectiveAttempts; i++) {
       // Re-evaluated per attempt: a text input losing focus mid-loop (e.g.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/core/monaco_controller_test.dart
+++ b/test/core/monaco_controller_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/core/monaco_bridge.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1218,6 +1219,20 @@ void main() {
         'focused Flutter text input',
         (tester) async {
           final bundle = await _createBundle();
+          final textInputCalls = <MethodCall>[];
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            SystemChannels.textInput,
+            (call) async {
+              textInputCalls.add(call);
+              return null;
+            },
+          );
+          addTearDown(() {
+            tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+              SystemChannels.textInput,
+              null,
+            );
+          });
           final focusNode = FocusNode();
           addTearDown(focusNode.dispose);
 
@@ -1230,6 +1245,7 @@ void main() {
           );
           await tester.pump();
           expect(focusNode.hasPrimaryFocus, isTrue);
+          textInputCalls.clear();
 
           // While the TextField owns the keyboard, both helpers must no-op:
           // on Windows requestNativeFocus would move real Win32 focus to the
@@ -1249,6 +1265,10 @@ void main() {
             bundle.webview.executed,
             isNot(contains('REQUEST_NATIVE_FOCUS')),
           );
+          expect(
+            textInputCalls.map((call) => call.method),
+            isNot(contains('TextInput.hide')),
+          );
 
           // Once the text input releases the keyboard, focusing works again.
           focusNode.unfocus();
@@ -1256,6 +1276,83 @@ void main() {
           await tester.runAsync(() => bundle.controller.focus());
           expect(bundle.webview.executed, contains('REQUEST_NATIVE_FOCUS'));
           expect(bundle.webview.executed.join('\n'), contains('forceFocus'));
+        },
+      );
+
+      testWidgets(
+        'user focus intent releases Flutter text input before editor focus',
+        (tester) async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+          final textInputCalls = <MethodCall>[];
+          FakePlatformWebViewController? activeWebview;
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            SystemChannels.textInput,
+            (call) async {
+              textInputCalls.add(call);
+              activeWebview?.executed.add('TEXT_INPUT:${call.method}');
+              return null;
+            },
+          );
+          addTearDown(() {
+            tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+              SystemChannels.textInput,
+              null,
+            );
+            debugDefaultTargetPlatformOverride = null;
+          });
+
+          try {
+            final bundle = await _createBundle();
+            activeWebview = bundle.webview;
+            final focusNode = FocusNode();
+            addTearDown(focusNode.dispose);
+
+            await tester.pumpWidget(
+              MaterialApp(
+                home: Scaffold(
+                  body: TextField(focusNode: focusNode, autofocus: true),
+                ),
+              ),
+            );
+            await tester.pump();
+            expect(focusNode.hasPrimaryFocus, isTrue);
+
+            bundle.webview.executed.clear();
+            textInputCalls.clear();
+
+            await tester.runAsync(
+              () => bundle.controller.ensureEditorFocus(
+                attempts: 1,
+                interval: Duration.zero,
+                intent: MonacoFocusIntent.user,
+              ),
+            );
+            await tester.pump();
+
+            expect(focusNode.hasPrimaryFocus, isFalse);
+            expect(
+              textInputCalls.map((call) => call.method),
+              contains('TextInput.hide'),
+            );
+
+            final calls = bundle.webview.executed;
+            expect(calls, contains('TEXT_INPUT:TextInput.hide'));
+            expect(calls, contains('REQUEST_NATIVE_FOCUS'));
+            expect(calls.join('\n'), contains('forceFocus'));
+
+            final textInputIndex = calls.indexOf('TEXT_INPUT:TextInput.hide');
+            final nativeFocusIndex = calls.indexOf('REQUEST_NATIVE_FOCUS');
+            final forceFocusIndex = calls.indexWhere(
+              (call) => call.contains('forceFocus'),
+            );
+            expect(textInputIndex, isNonNegative);
+            expect(nativeFocusIndex, isNonNegative);
+            expect(forceFocusIndex, isNonNegative);
+            expect(textInputIndex, lessThan(nativeFocusIndex));
+            expect(nativeFocusIndex, lessThan(forceFocusIndex));
+          } finally {
+            debugDefaultTargetPlatformOverride = null;
+          }
         },
       );
 


### PR DESCRIPTION
## Summary
- Prepare `flutter_monaco` 2.1.1.
- Make `MonacoFocusIntent.user` release Flutter's text-input channel before handing input to the WebView and Monaco.
- Keep maintenance focus cooperative so background sync/layout/resume cannot steal from Flutter text fields or dialogs.

## Root Cause
Direct cause: `MonacoFocusIntent.user` replayed native/WebView/Monaco focus while Flutter could still have a stale `EditableText` text-input client active after a dialog.

Deep cause: the package invariant only separated user vs maintenance focus, but user focus did not yet mean a complete keyboard ownership transfer from Flutter text input to Monaco.

Broken invariant: explicit editor user focus must mean Monaco can receive native text input, not only that Monaco focus was replayed.

## Validation
- `flutter pub get`
- `dart format .`
- `dart fix --apply`
- `dart analyze`
- `flutter analyze`
- `flutter test test/core/monaco_controller_test.dart test/widgets/monaco_editor_test.dart test/core/monaco_assets_test.dart test/platform/native_web_view_controller_source_test.dart`
- `flutter test`
- `dart pub publish --dry-run` reports 0 warnings
- `pana` reports 150/160, matching the repo gate. The missing 10 points are from intentionally unsupported Linux, which should not be declared falsely.
