### PR TITLE
Release flutter_monaco 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-07-06
+
+### Fixed
+- Flutter Web: disabling editor interaction now returns the keyboard to Flutter, not just the pointer. `setInteractionEnabled(false)` (and the `MonacoFocusGuard` route-overlay path that calls it) previously made the iframe pointer-inert and blurred Monaco's textarea, but the parent document's focus stayed ON the iframe element, so every key event kept dispatching inside the iframe: Escape could not close a dialog shown over the editor, Tab could not traverse it, and a button-only alert stayed keyboard-dead until its first click. The interaction toggle now performs the same two-sided handoff as the desktop platforms: blur inside the iframe, then move the parent document's focus onto the editor's own `<flutter-view>` host (multi-view safe, `tabindex` fallback, no scroll jump), so Flutter overlays receive keys immediately. `MonacoController.releaseNativeInputFocus()` performs the same handoff on web instead of being a no-op.
+
+### Docs
+- Documented that `MonacoFocusGuard` bridges route overlays only within its own `Navigator`: with nested navigators (for example `showDialog` with its default `useRootNavigator: true` while the editor lives in a nested navigator), the observer on one navigator never notifies a guard subscribed to a route of another. Apps with nested navigators should observe every navigator that can host overlays and drive `setInteractionEnabled` from that (see the focus guide).
+
 ## [2.2.1] - 2026-07-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -734,6 +734,8 @@ MonacoFocusGuard(
 )
 ```
 
+> **Nested navigators:** the guard only sees routes pushed on the `Navigator` its own route belongs to. If your editor lives inside a nested navigator while dialogs go to the root navigator (`showDialog`'s default `useRootNavigator: true`), the root observer never notifies the guard. In that layout, observe every navigator that can host overlays and call `controller.setInteractionEnabled(...)` from your own observer instead - `setInteractionEnabled(false)` also hands the keyboard back to Flutter so Escape/Tab reach the dialog.
+
 #### 2. Static overlays (FABs, drawers, in-tree stacked widgets)
 
 Persistent widgets that share the page with the editor - a `floatingActionButton`, a `Drawer`, a persistent footer, anything inside a `Stack` over the editor - do not push a route, so the focus guard cannot fire for them. The package provides two complementary tools:

--- a/doc/focus-and-platform-views.md
+++ b/doc/focus-and-platform-views.md
@@ -40,7 +40,14 @@ Windows focus is solved at the correct layer by the `webview_flutter_windows` pa
 
 ### Web
 
-The iframe participates in the browser's focus system; `requestNativeFocus()` is a no-op. The platform-specific problem on Web is pointer swallowing by the iframe, handled by the first-party DOM overlay shield (`MonacoScaffold`, `MonacoOverlayBoundary`, `MonacoWebInteractionCoordinator`, `runWithInteractionDisabled`). See the README section "Web: Handling Overlays".
+The iframe participates in the browser's focus system; `requestNativeFocus()` is a no-op. Web has TWO platform-specific problems, and both exist because the browser arbitrates input BEFORE Flutter ever sees it:
+
+- Pointer: the browser's DOM hit test picks the target first. Flutter paints into `pointer-events: none` canvases, so over the editor's rect the topmost interactive DOM element is the iframe, and events dispatched inside an iframe never bubble to the parent document. A Flutter widget painted above the editor (a dialog, a menu) is visible but unreachable - Flutter's hit testing never runs. This is handled by the first-party DOM overlay shield (`MonacoScaffold`, `MonacoOverlayBoundary`, `MonacoWebInteractionCoordinator`, `runWithInteractionDisabled`) and by `setInteractionEnabled(false)` for route overlays. See the README section "Web: Handling Overlays".
+- Keyboard: web's layer-2 "native focus" is the parent document's focus. While the iframe element is the parent `document.activeElement`, every key event dispatches inside the iframe's document and Flutter receives nothing. `setInteractionEnabled(false)` and `releaseNativeInputFocus()` therefore perform a two-sided handoff: blur Monaco inside the iframe AND move the parent document's focus onto the editor's `<flutter-view>` host, so overlays get Escape/Tab/typing without needing a first click.
+
+Nested navigators caveat: `MonacoFocusGuard` observes route pushes only within the `Navigator` its route belongs to. `showDialog` defaults to `useRootNavigator: true`, so an app that hosts the editor inside a nested navigator MUST either observe the root navigator too and drive `setInteractionEnabled` itself, or pass `useRootNavigator: false` consistently. An observer attached to one navigator never notifies a guard subscribed to a route of another navigator.
+
+Also note: while Monaco holds document focus on web, app-global key handlers (`HardwareKeyboard` handlers, `Shortcuts` on ancestors) do not fire - keys never leave the iframe. If the app needs global shortcuts to work while typing in the editor, they must be registered as Monaco keybindings and forwarded over the bridge.
 
 ### Android / iOS (native mobile)
 

--- a/lib/src/platform/web_view_controller/web.dart
+++ b/lib/src/platform/web_view_controller/web.dart
@@ -60,6 +60,13 @@ String _monacoVsAssetUrl() {
 /// widgets. Desktop web also reasserts Monaco focus while mobile web avoids
 /// amplifying accidental focus during scroll gestures.
 ///
+/// The reverse handoff is explicit: [releaseNativeFocus] (also run by
+/// [setInteractionEnabled] `false`) blurs Monaco inside the iframe AND
+/// returns the parent document's focus to the Flutter view host, so Flutter
+/// overlays receive keyboard events (Escape, Tab, typing) without needing a
+/// first click. While the iframe element is the parent document's
+/// activeElement, no key event can reach Flutter at all.
+///
 /// See also:
 /// - [MonacoAssets.generateIndexHtml] for HTML generation with web-specific
 ///   worker shims.
@@ -245,23 +252,10 @@ class WebViewController implements PlatformWebViewController {
     _applyInteractionEnabled();
 
     if (!enabled) {
-      // Best-effort: blur Monaco's textarea so keyboard input doesn't keep going to the editor.
-      try {
-        _iframe?.contentWindow?.callMethod(
-          'eval'.toJS,
-          '''
-            (function() {
-              try {
-                var ta = document.querySelector('textarea.inputarea');
-                if (ta && ta.blur) ta.blur();
-                var ae = document.activeElement;
-                if (ae && ae.blur) ae.blur();
-              } catch (e) {}
-            })();
-          '''
-              .toJS,
-        );
-      } catch (_) {}
+      // A pointer-inert editor must not keep the keyboard either: hand
+      // document focus back to Flutter so overlays receive key events
+      // (Escape closes a dialog, Tab traverses it) without a first click.
+      await releaseNativeFocus();
     }
   }
 
@@ -276,8 +270,77 @@ class WebViewController implements PlatformWebViewController {
 
   @override
   Future<void> releaseNativeFocus() async {
-    // No-op on web; the browser owns focus arbitration between the iframe
-    // and the Flutter view.
+    // Web's "native focus" (layer 2 of the focus model) is the browser's
+    // document focus. While the parent document's activeElement is the
+    // editor iframe, every key event dispatches inside the iframe's
+    // document; Flutter's keyboard listeners live on the Flutter view host
+    // in the parent document and receive nothing. Blurring inside the
+    // iframe alone is not enough - keys keep draining into the iframe's
+    // body. The handoff is two-sided, mirroring the desktop
+    // implementations: blur Monaco's textarea INSIDE the iframe, then move
+    // the parent document's focus onto the Flutter view host so keys flow
+    // to Flutter again.
+    _blurInsideIframe();
+    if (_iframeHoldsDocumentFocus) {
+      _focusFlutterHost();
+    }
+  }
+
+  /// Whether the parent document currently routes keyboard input into the
+  /// editor's iframe. Compared by element id (set in [initialize]) because
+  /// JS-interop reference equality is compiler-dependent.
+  bool get _iframeHoldsDocumentFocus {
+    final viewId = _viewId;
+    if (viewId == null) return false;
+    final active = web.document.activeElement;
+    return active != null && active.tagName == 'IFRAME' && active.id == viewId;
+  }
+
+  void _blurInsideIframe() {
+    // Best-effort: blur Monaco's textarea so the editor stops handling keys
+    // and its caret stops blinking while it is interaction-disabled.
+    try {
+      _iframe?.contentWindow?.callMethod(
+        'eval'.toJS,
+        '''
+          (function() {
+            try {
+              var ta = document.querySelector('textarea.inputarea');
+              if (ta && ta.blur) ta.blur();
+              var ae = document.activeElement;
+              if (ae && ae.blur) ae.blur();
+            } catch (e) {}
+          })();
+        '''
+            .toJS,
+      );
+    } catch (_) {}
+  }
+
+  /// Moves the parent document's focus from the editor iframe onto the
+  /// Flutter view host element, so the framework's key listeners receive
+  /// events again.
+  void _focusFlutterHost() {
+    final iframe = _iframe;
+    if (iframe == null) return;
+    try {
+      // closest() keeps this correct under multi-view embeddings: focus the
+      // <flutter-view> THIS editor lives in, not the first one on the page.
+      final host = iframe.closest('flutter-view');
+      if (host == null || !host.isA<web.HTMLElement>()) {
+        // Unknown host DOM (engine change / exotic embedding): at least pull
+        // focus off the iframe so keys stop draining into an inert editor.
+        iframe.blur();
+        return;
+      }
+      final hostElement = host as web.HTMLElement;
+      if (!hostElement.hasAttribute('tabindex')) {
+        // Programmatic focus() requires focusability; -1 keeps the host out
+        // of the user's Tab order.
+        hostElement.tabIndex = -1;
+      }
+      hostElement.focus(web.FocusOptions(preventScroll: true));
+    } catch (_) {}
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 2.2.1
+version: 2.2.2
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -74,4 +74,47 @@ void main() {
     expect(source, contains("..style.touchAction = 'none'"));
     expect(source, contains("..style.overscrollBehavior = 'none'"));
   });
+
+  test('disabling interaction returns the keyboard to Flutter, not just '
+      'the pointer', () {
+    final source = webControllerSource();
+
+    // setInteractionEnabled(false) must run the full two-sided handoff.
+    final disableStart = source.indexOf(
+      'Future<void> setInteractionEnabled(bool enabled) async {',
+    );
+    final disableEnd = source.indexOf(
+      'Future<NativeFocusResult> requestNativeFocus()',
+    );
+    expect(disableStart, isNonNegative);
+    expect(disableEnd, greaterThan(disableStart));
+    final disableBlock = source.substring(disableStart, disableEnd);
+    expect(disableBlock, contains('await releaseNativeFocus();'));
+
+    // releaseNativeFocus is the web layer-2 handoff: blur INSIDE the iframe
+    // AND move the parent document's focus onto the Flutter view host.
+    // Regressing it to a no-op silently kills Escape/Tab on dialogs shown
+    // over the editor (they only recover after a first click).
+    final releaseStart = source.indexOf(
+      'Future<void> releaseNativeFocus() async {',
+    );
+    expect(releaseStart, isNonNegative);
+    expect(source, contains('_blurInsideIframe();'));
+    expect(source, contains('if (_iframeHoldsDocumentFocus)'));
+    expect(source, contains('_focusFlutterHost();'));
+
+    // Parent-document focus checks compare by element id: JS-interop
+    // reference equality is compiler-dependent (dart2js vs dart2wasm).
+    expect(source, contains('bool get _iframeHoldsDocumentFocus'));
+    expect(
+      source,
+      contains("active.tagName == 'IFRAME' && active.id == viewId"),
+    );
+
+    // The host focus must be multi-view safe (the editor's OWN view),
+    // programmatically focusable, and must not scroll the page.
+    expect(source, contains("iframe.closest('flutter-view')"));
+    expect(source, contains('hostElement.tabIndex = -1;'));
+    expect(source, contains('web.FocusOptions(preventScroll: true)'));
+  });
 }


### PR DESCRIPTION
## Summary
- Web: `setInteractionEnabled(false)` now performs a two-sided focus handoff - blurs Monaco inside the iframe AND moves the browser's document focus back to the editor's own `flutter-view` host. Keyboard input (Escape, Tab, typing) reaches Flutter overlays immediately, without requiring a first click.
- Docs: web focus model (browser DOM layer-0 pointer routing; document focus as the web native-focus layer), nested-navigator caveat for `MonacoFocusGuard`, global-hotkeys limitation while Monaco holds document focus.
- New source-fence test locks the handoff markers in `web.dart`.

## Testing
- `dart analyze` clean, 339 tests pass.
- Manually validated in Chrome via context_collector web: dialogs over a focused Monaco editor are now fully interactive (buttons, barrier tap, Escape, typing without pre-click).

Merging to main auto-tags `flutter_monaco-v2.2.2` and publishes to pub.dev.