### PR TITLE
Showcase v3 overhaul: live diff, custom actions, multi-document, and event demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-07-07
+
+### Added
+- **Edge scroll handoff for the diff editor.** `MonacoDiffEditor.scrollHandoff` takes the same `MonacoScrollHandoff` configuration as `MonacoEditor`: wheel or trackpad input over either pane keeps scrolling the diff until it reaches its vertical scroll edge, then unconsumed deltas are forwarded to the configured `ScrollController` or the nearest enclosing vertical scrollable, so the surrounding page keeps scrolling instead of dying over the editor. Headless integrations get the same building blocks as the single editor: `MonacoDiffController.onScrollHandoff` and `MonacoDiffController.setScrollHandoffSources`.
+
+### Fixed
+- **Multi-document: the boot document no longer dies on the first `activateDocument`.** Monaco's standalone editor takes ownership of a model created implicitly from the `value`/`language` create options and disposes it on the first `setModel`; the boot page now creates the initial model explicitly, so switching documents and back preserves the original document.
+
 ## [3.0.0] - 2026-07-07
 
 A ground-up rebuild of the package's spine - one wire protocol, a document/editor split, sparse options, typed errors and events - while keeping the battle-tested platform engineering (LSP, focus recovery, mobile web survival kit, scroll handoff, web overlay stack) intact. The README's "Migrating from 2.x to 3.0" section carries the complete symbol-level migration table; the highlights are below.

--- a/assets/monaco/bridge/boot.js
+++ b/assets/monaco/bridge/boot.js
@@ -48,6 +48,40 @@ window.__FMB = window.__FMB || {};
                 var diffCtx = {};
                 (window.__FMB || {}).diffApi(diffCtx);
                 diffCtx.bootDiff(params);
+                // Edge scroll handoff on diff pages: the modified editor is
+                // the vertical scroll master (side-by-side panes are
+                // height-aligned by Monaco's alignment zones, and inline
+                // mode renders inside the modified editor), while the
+                // accepted wheel region covers both panes of the pair.
+                diffCtx.E = function () {
+                  return window.diffEditor.getModifiedEditor();
+                };
+                diffCtx.post = function (name, data) {
+                  window.FlutterMonaco.emit(name, data);
+                };
+                diffCtx.handoffScope = {
+                  regionRoot: function () {
+                    var d = window.diffEditor;
+                    return d.getContainerDomNode
+                      ? d.getContainerDomNode()
+                      : document.getElementById('editor-container');
+                  },
+                  editorDoms: function () {
+                    var d = window.diffEditor;
+                    return [
+                      d.getOriginalEditor().getDomNode(),
+                      d.getModifiedEditor().getDomNode(),
+                    ];
+                  },
+                };
+                (window.__FMB || {}).scrollHandoff(diffCtx);
+                var diffScrollHandoff = (params || {}).scrollHandoff || {};
+                if (diffScrollHandoff.wheel || diffScrollHandoff.touch) {
+                  window.flutterMonaco.setScrollHandoff({
+                    wheel: !!diffScrollHandoff.wheel,
+                    touch: !!diffScrollHandoff.touch,
+                  });
+                }
                 window.FlutterMonaco.lifecycle('ready');
                 console.log('[Monaco] Diff Editor is ready and the Flutter bridge is installed.');
                 return;

--- a/assets/monaco/bridge/boot.js
+++ b/assets/monaco/bridge/boot.js
@@ -139,12 +139,19 @@ window.__FMB = window.__FMB || {};
               // The editor is born configured: sparse Monaco options from
               // Dart, plus the initial text/language/theme, in one create.
               var options = Object.assign({}, params.options || {});
-              options.value = typeof params.text === 'string' ? params.text : '';
-              options.language = params.language || 'plaintext';
               options.theme = params.theme || 'vs';
               if (options.automaticLayout === undefined) {
                 options.automaticLayout = true;
               }
+              // The boot document is created explicitly, NOT via the
+              // value/language create options: a standalone editor owns an
+              // implicitly created model and DISPOSES it on the first
+              // setModel (docs.activate), which would kill the boot
+              // document in multi-document use.
+              options.model = monaco.editor.createModel(
+                typeof params.text === 'string' ? params.text : '',
+                params.language || 'plaintext'
+              );
               monaco.editor.create(
                 document.getElementById('editor-container'),
                 options

--- a/assets/monaco/bridge/scroll-handoff.js
+++ b/assets/monaco/bridge/scroll-handoff.js
@@ -5,9 +5,14 @@
 'use strict';
 window.__FMB = window.__FMB || {};
 
-// Edge scroll handoff module. VERBATIM PORT.
+// Edge scroll handoff module. VERBATIM PORT, extended for diff pages:
+// ctx.handoffScope (optional) widens the accepted wheel region to a set of
+// editor DOM nodes under one region root, while ctx.E stays the vertical
+// scroll master whose metrics gate the handoff. Without a scope the region
+// is exactly the single editor, byte-for-byte the 2.3.0 behavior.
 window.__FMB.scrollHandoff = function (ctx) {
   const { E, post } = ctx;
+  const handoffScope = ctx.handoffScope || null;
                 // Edge scroll handoff (opt-in): forward scroll deltas the
                 // editor cannot consume to Flutter, which applies them to a
                 // host scrollable. Sources are toggled from Dart through
@@ -77,9 +82,21 @@ window.__FMB.scrollHandoff = function (ctx) {
                     if (!editorDom) return false;
                     let el = target;
                     if (el && el.nodeType !== 1) el = el.parentElement;
-                    if (!el || !el.closest || !editorDom.contains(el)) return false;
+                    if (!el || !el.closest) return false;
+                    // Diff pages accept both panes under the diff container;
+                    // single-editor pages keep the exact 2.3.0 region (the
+                    // one editor's DOM).
+                    const regionRoot = handoffScope && handoffScope.regionRoot
+                      ? handoffScope.regionRoot()
+                      : editorDom;
+                    if (!regionRoot || !regionRoot.contains(el)) return false;
                     if (el.closest(HANDOFF_BLOCKED_WIDGETS)) return false;
-                    if (el.closest('.monaco-editor') !== editorDom) return false;
+                    const ownerDoms = handoffScope && handoffScope.editorDoms
+                      ? handoffScope.editorDoms()
+                      : [editorDom];
+                    if (ownerDoms.indexOf(el.closest('.monaco-editor')) === -1) {
+                      return false;
+                    }
                     const scrollable = el.closest('.monaco-scrollable-element');
                     if (scrollable && !scrollable.classList.contains('editor-scrollable')) {
                       return false;
@@ -248,6 +265,9 @@ window.__FMB.scrollHandoff = function (ctx) {
                     handoffState.touchGesture = null;
                   };
 
+                  // Diff pages never run core.js, so the legacy namespace
+                  // object may not exist yet.
+                  window.flutterMonaco = window.flutterMonaco || {};
                   window.flutterMonaco.setScrollHandoff = function (cfg) {
                     const wheel = !!(cfg && cfg.wheel);
                     const touch = !!(cfg && cfg.touch);

--- a/example/lib/showcase/data/migration_diff.dart
+++ b/example/lib/showcase/data/migration_diff.dart
@@ -1,0 +1,91 @@
+/// Content for the live migration diff: the same small editor service written
+/// against flutter_monaco 2.x (original) and 3.0 (modified). The changed
+/// hunks are the real migration story - documents, typed errors, sparse
+/// options, typed action ids, and the sealed event union.
+library;
+
+/// The 2.x side of the migration diff.
+const String kMigrationOriginal = '''
+// editor_service.dart - written against flutter_monaco 2.x
+import 'package:flutter_monaco/flutter_monaco.dart';
+
+Future<MonacoController> boot() async {
+  // Blocked until ready on native, returned early on web.
+  final controller = await MonacoController.create(
+    options: const EditorOptions(
+      language: MonacoLanguage.dart,
+      fontSize: 14,
+      themeId: 'app-dark', // custom themes need a side-channel field
+    ),
+  );
+  return controller;
+}
+
+Future<void> save(MonacoController controller) async {
+  // '' could mean "empty document" or "bridge died" - no way to tell.
+  final text = await controller.getValue();
+  await upload(text);
+}
+
+Future<void> shrinkFont(MonacoController controller) async {
+  // Sent ALL ~40 options; every unset field reset to package defaults.
+  await controller.updateOptions(const EditorOptions(fontSize: 12));
+}
+
+Future<void> tidy(MonacoController controller) async {
+  await controller.format();
+  await controller.setValue('// formatted');
+}
+
+void watch(MonacoController controller) {
+  // Raw payloads; full-text pulls on every keystroke.
+  controller.onContentChanged.listen((_) async {
+    final text = await controller.getValue();
+    await upload(text);
+  });
+}
+''';
+
+/// The 3.0 side of the migration diff.
+const String kMigrationModified = '''
+// editor_service.dart - written against flutter_monaco 3.0
+import 'package:flutter_monaco/flutter_monaco.dart';
+
+Future<MonacoController> boot() async {
+  // Never blocks, on any platform; readiness is one explicit future.
+  final controller = await MonacoController.create(
+    options: const EditorOptions(
+      language: MonacoLanguage.dart,
+      fontSize: 14,
+      theme: MonacoTheme('app-dark'), // one open typed id, no side channel
+    ),
+  );
+  await controller.whenReady;
+  return controller;
+}
+
+Future<void> save(MonacoController controller) async {
+  // Documents are first-class; failed reads throw typed MonacoExceptions.
+  final text = await controller.document.getText();
+  await upload(text);
+}
+
+Future<void> shrinkFont(MonacoController controller) async {
+  // Sparse options: this changes the font size and nothing else.
+  await controller.updateOptions(const EditorOptions(fontSize: 12));
+}
+
+Future<void> tidy(MonacoController controller) async {
+  await controller.executeAction(MonacoAction.formatDocument);
+  await controller.document.setText('// formatted');
+}
+
+void watch(MonacoController controller) {
+  // One sealed event union with structured change ranges.
+  controller.events.listen((event) async {
+    if (event is MonacoContentChanged && !event.truncated) {
+      await uploadDeltas(event.changes!);
+    }
+  });
+}
+''';

--- a/example/lib/showcase/data/samples.dart
+++ b/example/lib/showcase/data/samples.dart
@@ -47,13 +47,26 @@ class DemoApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       home: Scaffold(
         body: MonacoEditor(
-          options: EditorOptions(
-            language: MonacoLanguage.dart,
-            theme: MonacoTheme.vsDark,
-          ),
+          options: const EditorOptions(language: MonacoLanguage.dart),
+          onReady: (controller) async {
+            // Dart-defined editor action, bound to Cmd/Ctrl+S (new in 3.0).
+            await controller.addAction(
+              MonacoActionDescriptor(
+                id: const MonacoAction('app.save'),
+                label: 'Save',
+                keybindings: const [
+                  MonacoKeybinding(key: MonacoKey.keyS, ctrlCmd: true),
+                ],
+              ),
+              () async {
+                final text = await controller.document.getText();
+                debugPrint('saved ${text.length} chars');
+              },
+            );
+          },
         ),
       ),
     );
@@ -287,9 +300,10 @@ String _jsonSample(ShowcaseMetadata metadata) {
   return '${encoder.convert({
     'name': metadata.packageName,
     'version': metadata.version,
+    'monaco': metadata.monacoVersion,
     'description': metadata.productSummary,
     'platforms': [for (final platform in metadata.platforms) platform.id],
-    'features': {'typedLanguages': metadata.typedLanguageCount, 'playgroundLanguages': kPlaygroundLanguages.length, 'themes': metadata.showcasedThemeCount, 'intelliSense': true, 'diagnostics': true},
+    'features': {'typedLanguages': metadata.typedLanguageCount, 'playgroundLanguages': kPlaygroundLanguages.length, 'themes': metadata.showcasedThemeCount, 'diffEditor': true, 'customActions': true, 'lsp': true, 'intelliSense': true, 'diagnostics': true},
     if (metadata.publishedAt != null) 'publishedAt': metadata.publishedAt!.toUtc().toIso8601String(),
   })}\n';
 }
@@ -303,9 +317,18 @@ String _markdownSample(ShowcaseMetadata metadata) =>
 ## Current package data
 
 - **Version** - ${metadata.versionLabel}
+- **Monaco** - ${metadata.monacoVersion}
 - **Platforms** - ${metadata.platformSummary}
 - **Languages** - ${metadata.typedLanguageCount} typed entries
 - **Theming** - ${metadata.showcasedThemeCount} demo themes
+
+## New in 3.0
+
+- One request-correlated wire protocol on every platform
+- `controller.document` - documents split from the editor, like Monaco itself
+- `MonacoDiffEditor` - side-by-side and inline diffs
+- `controller.addAction` - Dart actions with real keybindings
+- Sparse `EditorOptions` - update one field without resetting the rest
 
 ```dart
 MonacoEditor(

--- a/example/lib/showcase/data/showcase_metadata.dart
+++ b/example/lib/showcase/data/showcase_metadata.dart
@@ -65,7 +65,7 @@ class ShowcaseMetadata {
 
   static const fallback = ShowcaseMetadata(
     packageName: _packageName,
-    version: '3.0.0',
+    version: '3.1.0',
     description:
         "Integrate Monaco Editor (VS Code's editor) in Flutter apps with "
         'syntax highlighting, themes, IntelliSense, and a full Dart API.',

--- a/example/lib/showcase/data/showcase_metadata.dart
+++ b/example/lib/showcase/data/showcase_metadata.dart
@@ -51,6 +51,7 @@ class ShowcaseMetadata {
     required this.flutterConstraint,
     this.publishedAt,
     this.repositoryUpdatedAt,
+    this.latestPubVersion,
     this.likeCount,
     this.downloadCount30Days,
     this.pubPointsGranted,
@@ -64,7 +65,7 @@ class ShowcaseMetadata {
 
   static const fallback = ShowcaseMetadata(
     packageName: _packageName,
-    version: '2.0.0',
+    version: '3.0.0',
     description:
         "Integrate Monaco Editor (VS Code's editor) in Flutter apps with "
         'syntax highlighting, themes, IntelliSense, and a full Dart API.',
@@ -103,6 +104,11 @@ class ShowcaseMetadata {
   final String flutterConstraint;
   final DateTime? publishedAt;
   final DateTime? repositoryUpdatedAt;
+
+  /// The latest version published on pub.dev, which can trail [version]
+  /// (the bundled build this page actually runs) around a release.
+  final String? latestPubVersion;
+
   final int? likeCount;
   final int? downloadCount30Days;
   final int? pubPointsGranted;
@@ -117,6 +123,10 @@ class ShowcaseMetadata {
   int get builtInThemeCount => MonacoTheme.builtIn.length;
   int get showcasedThemeCount => PlaygroundThemeCount.total;
 
+  /// The Monaco Editor version bundled by the package (single source: the
+  /// package's own constant, so it tracks package upgrades automatically).
+  String get monacoVersion => MonacoAssets.monacoVersion;
+
   String get versionLabel => 'v$version';
   String get sourceLabel => hasLivePubDev ? 'Live pub.dev' : 'Bundled pubspec';
 
@@ -125,12 +135,18 @@ class ShowcaseMetadata {
 
   String get productSummary =>
       "Integrate Monaco Editor (VS Code's editor) in Flutter apps. "
-      '$typedLanguageCount typed language entries, ${platforms.length} '
-      'supported platforms, theming, IntelliSense, and a full Dart API.';
+      'One typed API across ${platforms.length} platforms: documents, '
+      'a live diff editor, Dart-defined actions with keybindings, LSP, '
+      'IntelliSense, and $typedLanguageCount typed language ids.';
 
   String get publishedLabel {
     final date = publishedAt;
     if (date == null) return 'Bundled version';
+    final pub = latestPubVersion;
+    if (pub != null && pub != version) {
+      // Around a release the running build can be ahead of pub.dev.
+      return 'v$pub on pub.dev · ${formatShortDate(date)}';
+    }
     return 'Published ${formatShortDate(date)}';
   }
 
@@ -164,6 +180,7 @@ class ShowcaseMetadata {
     String? flutterConstraint,
     DateTime? publishedAt,
     DateTime? repositoryUpdatedAt,
+    String? latestPubVersion,
     int? likeCount,
     int? downloadCount30Days,
     int? pubPointsGranted,
@@ -191,6 +208,7 @@ class ShowcaseMetadata {
       flutterConstraint: flutterConstraint ?? this.flutterConstraint,
       publishedAt: publishedAt ?? this.publishedAt,
       repositoryUpdatedAt: repositoryUpdatedAt ?? this.repositoryUpdatedAt,
+      latestPubVersion: latestPubVersion ?? this.latestPubVersion,
       likeCount: likeCount ?? this.likeCount,
       downloadCount30Days: downloadCount30Days ?? this.downloadCount30Days,
       pubPointsGranted: pubPointsGranted ?? this.pubPointsGranted,
@@ -332,12 +350,14 @@ ShowcaseMetadata parsePubDevPackage(
 }) {
   final latest = packageJson['latest'];
   if (latest is! Map<String, Object?>) return base;
-  final pubspec = latest['pubspec'];
-  final published = _date(latest['published']);
-  final metadata = pubspec is Map
-      ? _metadataFromPubspecMap(pubspec, base: base)
-      : base;
-  return metadata.copyWith(publishedAt: published, hasLivePubDev: true);
+  // The bundled pubspec describes the build actually running on this page,
+  // so pub.dev contributes provenance and live stats only - never the
+  // version/description of a possibly different published release.
+  return base.copyWith(
+    publishedAt: _date(latest['published']),
+    latestPubVersion: _string(latest['version']),
+    hasLivePubDev: true,
+  );
 }
 
 ShowcaseMetadata _metadataFromPubspecMap(

--- a/example/lib/showcase/sections/features_section.dart
+++ b/example/lib/showcase/sections/features_section.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_monaco/flutter_monaco.dart';
 
 import '../data/showcase_metadata.dart';
 import '../state/showcase_controller.dart';
 import '../theme/showcase_text.dart';
 import '../theme/showcase_tokens.dart';
+import '../util/links.dart';
 import '../widgets/feature_card.dart';
 import '../widgets/section_container.dart';
 
@@ -31,23 +31,41 @@ class FeaturesSection extends StatelessWidget {
 
     final cards = <FeatureCard>[
       FeatureCard(
-        icon: Icons.translate_rounded,
-        title: '${metadata.typedLanguageCount} typed languages',
+        icon: Icons.difference_outlined,
+        title: 'Diff editor',
         body:
-            'Syntax highlighting for Dart, TypeScript, Python, Rust, Go, '
-            'SQL and more - switch instantly.',
-        snippet: 'controller.setLanguage(MonacoLanguage.rust);',
-        onTry: () => _go(() => controller.setLanguage(MonacoLanguage.rust)),
+            'Side-by-side or inline diffs with revert arrows and change '
+            'navigation - new in 3.0.',
+        snippet: 'MonacoDiffEditor(original: a, modified: b)',
+        tryLabel: 'See it live',
+        onTry: controller.scrollToDiff,
       ),
       FeatureCard(
-        icon: Icons.palette_outlined,
-        title: 'Theming',
+        icon: Icons.keyboard_command_key_rounded,
+        title: 'Custom actions & keybindings',
         body:
-            '${metadata.builtInThemeCount} built-in themes, plus custom token '
-            'colors with defineTheme.',
-        snippet: 'controller.defineTheme(midnightTheme);',
-        onTry: () =>
-            _go(() => controller.setPlaygroundTheme(PlaygroundTheme.midnight)),
+            'Register Dart callbacks as real editor actions - Cmd/Ctrl+S '
+            'save hooks, command palette, context menu. New in 3.0.',
+        snippet: 'controller.addAction(descriptor, onSave);',
+        onTry: () => _go(controller.runCustomActionDemo),
+      ),
+      FeatureCard(
+        icon: Icons.tab_rounded,
+        title: 'Multi-document editing',
+        body:
+            'Documents are first-class handles with their own undo stacks, '
+            'languages, and dirty state - switch without losing anything.',
+        snippet: 'final doc = await controller.openDocument(...);',
+        onTry: () => _go(controller.runMultiDocumentDemo),
+      ),
+      FeatureCard(
+        icon: Icons.podcasts_rounded,
+        title: 'Typed event stream',
+        body:
+            'One sealed MonacoEvent union for content, selection, and focus '
+            '- with structured change ranges, not full-text pulls.',
+        snippet: 'controller.events.listen((event) { ... });',
+        onTry: () => _go(controller.runEventsDemo),
       ),
       FeatureCard(
         icon: Icons.auto_awesome_outlined,
@@ -55,6 +73,16 @@ class FeaturesSection extends StatelessWidget {
         body: 'Plug in static or async completion providers for any language.',
         snippet: 'controller.registerStaticCompletions(...);',
         onTry: () => _go(controller.runIntelliSenseDemo),
+      ),
+      FeatureCard(
+        icon: Icons.hub_outlined,
+        title: 'Language Server Protocol',
+        body:
+            'Connect real language servers over WebSocket, stdio, or a '
+            'custom transport - diagnostics, hover, rename, and more.',
+        snippet: 'controller.connectLanguageServer(...);',
+        tryLabel: 'See the example',
+        onTry: () => openUrl(Links.lspExample),
       ),
       FeatureCard(
         icon: Icons.fact_check_outlined,
@@ -73,13 +101,15 @@ class FeaturesSection extends StatelessWidget {
         onTry: () => _go(controller.runMarkersDemo),
       ),
       FeatureCard(
-        icon: Icons.terminal_rounded,
-        title: 'Full controller API',
+        icon: Icons.palette_outlined,
+        title: 'Theming, ${metadata.typedLanguageCount} languages',
         body:
-            'documents, edits, find/replace, custom actions, live stats and '
-            'more.',
-        snippet: 'final code = await controller.document.getText();',
-        onTry: () => _go(controller.runDecorationsDemo),
+            '${metadata.builtInThemeCount} built-in themes plus custom token '
+            'colors via defineTheme; ${metadata.typedLanguageCount} typed '
+            'language ids, open to custom ones.',
+        snippet: 'controller.defineTheme(midnightTheme);',
+        onTry: () =>
+            _go(() => controller.setPlaygroundTheme(PlaygroundTheme.midnight)),
       ),
     ];
 
@@ -96,8 +126,8 @@ class FeaturesSection extends StatelessWidget {
           ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 620),
             child: Text(
-              'A typed Dart API over the full Monaco surface - drive any of '
-              'these on the live ${metadata.versionLabel} editor below.',
+              'A typed Dart API over the full Monaco surface - every card '
+              'drives the live ${metadata.versionLabel} playground editor.',
               style: ShowcaseText.bodyLg.copyWith(color: c.textSecondary),
             ),
           ),

--- a/example/lib/showcase/sections/get_started_section.dart
+++ b/example/lib/showcase/sections/get_started_section.dart
@@ -20,8 +20,20 @@ MonacoEditor(
 const String _controllerSnippet = '''
 MonacoEditor(
   onReady: (controller) async {
+    // Documents are first-class handles (new in 3.0).
     await controller.document.setText('void main() {}');
-    final code = await controller.document.getText();
+
+    // Dart code on a real keybinding (new in 3.0).
+    await controller.addAction(
+      MonacoActionDescriptor(
+        id: const MonacoAction('app.save'),
+        label: 'Save',
+        keybindings: const [
+          MonacoKeybinding(key: MonacoKey.keyS, ctrlCmd: true),
+        ],
+      ),
+      () async => save(await controller.document.getText()),
+    );
   },
 )''';
 

--- a/example/lib/showcase/sections/hero_section.dart
+++ b/example/lib/showcase/sections/hero_section.dart
@@ -38,7 +38,9 @@ class HeroSection extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _EyebrowPill(
-                text: '${metadata.versionLabel} - ${metadata.sourceLabel}',
+                text:
+                    '${metadata.versionLabel} - Monaco '
+                    '${metadata.monacoVersion}',
               ),
               const SizedBox(height: Insets.lg),
               Text(
@@ -121,7 +123,9 @@ class _LiveFacts extends StatelessWidget {
         Icons.translate_rounded,
         '${metadata.typedLanguageCount} typed languages',
       ),
-      (Icons.palette_outlined, '${metadata.showcasedThemeCount} demo themes'),
+      (Icons.devices_rounded, '${metadata.platforms.length} platforms'),
+      (Icons.difference_outlined, 'Diff editor'),
+      (Icons.hub_outlined, 'LSP client'),
       if (metadata.downloadCount30Days != null)
         (
           Icons.download_rounded,

--- a/example/lib/showcase/sections/playground_section.dart
+++ b/example/lib/showcase/sections/playground_section.dart
@@ -93,9 +93,17 @@ class _EditorCard extends StatelessWidget {
         children: [
           _Toolbar(controller: controller),
           Divider(height: 1, color: c.border),
+          if (controller.tabs.isNotEmpty) ...[
+            _DocTabs(controller: controller),
+            Divider(height: 1, color: c.border),
+          ],
           // Keep the iframe-backed HtmlElementView as a direct sized child.
           // In the web showcase, Stack/Positioned.fill collapses its DOM rect.
+          // The key sits on the Column child: when the tab strip appears
+          // above, reconciliation must match this subtree by key or the
+          // editor is disposed and rebooted.
           SizedBox(
+            key: const ValueKey('showcase-playground-editor-box'),
             height: editorHeight,
             child: MonacoEditor(
               key: const ValueKey('showcase-playground-editor'),
@@ -103,6 +111,10 @@ class _EditorCard extends StatelessWidget {
               initialText: controller.initialValue,
               page: const MonacoPageConfig(customCss: kEditorCustomCss),
               backgroundColor: const Color(0xFF0D1117),
+              // Edge scroll handoff: once the editor hits its scroll edge,
+              // the wheel keeps scrolling the page (and the event feed shows
+              // the MonacoScrollHandoffEvent doing it).
+              scrollHandoff: const MonacoScrollHandoff.edge(),
               onReady: controller.attachEditor,
             ),
           ),
@@ -113,6 +125,7 @@ class _EditorCard extends StatelessWidget {
             ),
           if (controller.hint != null)
             _HintBanner(hint: controller.hint!, onClose: controller.reset),
+          if (controller.eventFeedOpen) _EventFeedPanel(controller: controller),
           Divider(height: 1, color: c.border),
           _LiveStatsBar(controller: controller),
         ],
@@ -507,6 +520,21 @@ class _DemosRow extends StatelessWidget {
           runSpacing: Insets.sm,
           children: [
             _DemoButton(
+              icon: Icons.keyboard_command_key_rounded,
+              label: 'Custom action (Ctrl/Cmd+S)',
+              onTap: controller.runCustomActionDemo,
+            ),
+            _DemoButton(
+              icon: Icons.tab_rounded,
+              label: 'Multi-document',
+              onTap: controller.runMultiDocumentDemo,
+            ),
+            _DemoButton(
+              icon: Icons.podcasts_rounded,
+              label: 'Event stream',
+              onTap: controller.runEventsDemo,
+            ),
+            _DemoButton(
               icon: Icons.auto_awesome_outlined,
               label: 'IntelliSense',
               onTap: controller.runIntelliSenseDemo,
@@ -623,6 +651,14 @@ class _LiveStatsBar extends StatelessWidget {
 
   final ShowcaseController controller;
 
+  /// The right-hand slot: live handshake data once the editor is up
+  /// (Monaco + protocol version straight from `controller.capabilities`).
+  String get _handshakeLabel {
+    final caps = controller.capabilities;
+    if (caps == null) return 'Monaco ${MonacoAssets.monacoVersion}';
+    return 'Monaco ${caps.monacoVersion} · protocol v${caps.protocolVersion}';
+  }
+
   @override
   Widget build(BuildContext context) {
     final c = context.showcaseColors;
@@ -643,13 +679,13 @@ class _LiveStatsBar extends StatelessWidget {
             const SizedBox(width: Insets.md),
           ],
           const Spacer(),
-          Text(right, style: style),
+          Text(right, style: style, overflow: TextOverflow.ellipsis),
         ],
       ),
     );
 
     if (stats == null) {
-      return bar(const ['Ready when the editor loads'], 'UTF-8');
+      return bar(const ['Ready when the editor loads'], _handshakeLabel);
     }
 
     return ValueListenableBuilder<MonacoLiveStats>(
@@ -658,11 +694,209 @@ class _LiveStatsBar extends StatelessWidget {
         final cursor = value.cursorPosition;
         return bar([
           'Ln ${cursor != null ? '${cursor.line}:${cursor.column}' : '1:1'}',
-          '${value.lineCount} lines',
+          // Stats arrive with the first edit/cursor event; hide the
+          // zero-valued placeholder until then.
+          if (value.lineCount > 0) '${value.lineCount} lines',
           if (value.selectedCharacters > 0)
             '${value.selectedCharacters} selected',
-        ], (value.language ?? controller.language).id.toUpperCase());
+          (value.language ?? controller.language).id.toUpperCase(),
+        ], _handshakeLabel);
       },
+    );
+  }
+}
+
+class _DocTabs extends StatelessWidget {
+  const _DocTabs({required this.controller});
+
+  final ShowcaseController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.showcaseColors;
+    return Container(
+      width: double.infinity,
+      color: c.surfaceAlt,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: ValueListenableBuilder<Set<String>>(
+          valueListenable: controller.dirtyDocs,
+          builder: (context, dirty, _) {
+            return Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final (index, tab) in controller.tabs.indexed)
+                  _DocTab(
+                    label: tab.label,
+                    active: index == controller.activeTab,
+                    dirty: dirty.contains(tab.uri?.toString()),
+                    closable: index > 0,
+                    onTap: () => controller.activateTab(index),
+                    onClose: () => controller.closeTab(index),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _DocTab extends StatelessWidget {
+  const _DocTab({
+    required this.label,
+    required this.active,
+    required this.dirty,
+    required this.closable,
+    required this.onTap,
+    required this.onClose,
+  });
+
+  final String label;
+  final bool active;
+  final bool dirty;
+  final bool closable;
+  final VoidCallback onTap;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.showcaseColors;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: Insets.md,
+            vertical: Insets.sm,
+          ),
+          decoration: BoxDecoration(
+            color: active ? c.surface : Colors.transparent,
+            border: Border(
+              top: BorderSide(
+                width: 2,
+                color: active ? ShowcaseColors.accentBlue : Colors.transparent,
+              ),
+              right: BorderSide(color: c.border),
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                label,
+                style: ShowcaseText.monoLabel.copyWith(
+                  color: active ? c.textPrimary : c.textSecondary,
+                ),
+              ),
+              if (dirty) ...[
+                const SizedBox(width: 6),
+                Container(
+                  width: 7,
+                  height: 7,
+                  decoration: const BoxDecoration(
+                    color: ShowcaseColors.accentCyan,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ],
+              if (closable) ...[
+                const SizedBox(width: 6),
+                InkWell(
+                  onTap: onClose,
+                  child: Icon(Icons.close, size: 13, color: c.textFaint),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EventFeedPanel extends StatelessWidget {
+  const _EventFeedPanel({required this.controller});
+
+  final ShowcaseController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.showcaseColors;
+    return Container(
+      width: double.infinity,
+      color: c.surfaceAlt,
+      padding: const EdgeInsets.symmetric(
+        horizontal: Insets.md,
+        vertical: Insets.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.podcasts_rounded,
+                size: 14,
+                color: ShowcaseColors.accentBlue,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                'controller.events - sealed MonacoEvent union, live',
+                style: ShowcaseText.label.copyWith(color: c.textSecondary),
+              ),
+              const Spacer(),
+              InkWell(
+                onTap: controller.closeEventFeed,
+                child: Icon(Icons.close, size: 15, color: c.textSecondary),
+              ),
+            ],
+          ),
+          const SizedBox(height: Insets.sm),
+          ValueListenableBuilder<List<ShowcaseEventEntry>>(
+            valueListenable: controller.eventLog,
+            builder: (context, entries, _) {
+              if (entries.isEmpty) {
+                return Text(
+                  'Waiting for events - type or select in the editor.',
+                  style: ShowcaseText.monoSm.copyWith(color: c.textFaint),
+                );
+              }
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (final entry in entries)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 2),
+                      child: Row(
+                        children: [
+                          Text(
+                            entry.type,
+                            style: ShowcaseText.monoSm.copyWith(
+                              color: ShowcaseColors.accentCyan,
+                            ),
+                          ),
+                          const SizedBox(width: Insets.sm),
+                          Expanded(
+                            child: Text(
+                              entry.detail,
+                              overflow: TextOverflow.ellipsis,
+                              style: ShowcaseText.monoSm.copyWith(
+                                color: c.textSecondary,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/example/lib/showcase/sections/rebuild_section.dart
+++ b/example/lib/showcase/sections/rebuild_section.dart
@@ -1,0 +1,428 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_monaco/flutter_monaco.dart';
+
+import '../data/migration_diff.dart';
+import '../data/showcase_metadata.dart';
+import '../theme/showcase_text.dart';
+import '../theme/showcase_tokens.dart';
+import '../util/links.dart';
+import '../widgets/gradient_button.dart';
+import '../widgets/section_container.dart';
+
+/// The 3.0 rebuild story: six pillar cards plus the proof - the 2.x -> 3.0
+/// migration rendered live by the new [MonacoDiffEditor].
+class RebuildSection extends StatefulWidget {
+  const RebuildSection({super.key, required this.metadata});
+
+  final ShowcaseMetadata metadata;
+
+  @override
+  State<RebuildSection> createState() => _RebuildSectionState();
+}
+
+class _RebuildSectionState extends State<RebuildSection> {
+  MonacoDiffController? _diff;
+  bool _sideBySide = true;
+  int? _changeCount;
+
+  Future<void> _onDiffReady(MonacoDiffController controller) async {
+    _diff = controller;
+    await _refreshChangeCount();
+  }
+
+  Future<void> _refreshChangeCount() async {
+    final diff = _diff;
+    if (diff == null) return;
+    try {
+      final count = await diff.getLineChangeCount();
+      if (mounted) setState(() => _changeCount = count);
+    } catch (e) {
+      debugPrint('[RebuildSection] change count failed: $e');
+    }
+  }
+
+  Future<void> _setSideBySide(bool value) async {
+    if (value == _sideBySide) return;
+    setState(() => _sideBySide = value);
+    await _diff?.updateDiffOptions(MonacoDiffOptions(renderSideBySide: value));
+  }
+
+  Future<void> _reveal(bool next) async {
+    final diff = _diff;
+    if (diff == null) return;
+    if (next) {
+      await diff.revealNextChange();
+    } else {
+      await diff.revealPreviousChange();
+    }
+    await _refreshChangeCount();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.showcaseColors;
+    final width = MediaQuery.sizeOf(context).width;
+    final mobile = Breakpoints.isMobile(width);
+
+    return SectionContainer(
+      background: c.brightness == Brightness.dark ? c.surface : c.surfaceAlt,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Rebuilt from the spine out in 3.0',
+            style: ShowcaseText.h1.copyWith(color: c.textPrimary),
+          ),
+          const SizedBox(height: Insets.md),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 680),
+            child: Text(
+              '3.0 replaces three ad-hoc JavaScript bridges with one '
+              'request-correlated protocol, splits documents from the '
+              'editor the way Monaco itself does, and turns every silent '
+              'failure into a typed exception. The diff below is the '
+              'migration itself - rendered live by the new MonacoDiffEditor.',
+              style: ShowcaseText.bodyLg.copyWith(color: c.textSecondary),
+            ),
+          ),
+          const SizedBox(height: Insets.xl),
+          const _PillarGrid(),
+          const SizedBox(height: Insets.xl),
+          _DiffCard(
+            sideBySide: _sideBySide,
+            changeCount: _changeCount,
+            onSideBySide: _setSideBySide,
+            onPrev: () => _reveal(false),
+            onNext: () => _reveal(true),
+            onReady: _onDiffReady,
+            editorHeight: mobile ? 380.0 : 460.0,
+          ),
+          const SizedBox(height: Insets.lg),
+          GradientButton(
+            label: 'Read the full migration guide',
+            icon: Icons.menu_book_outlined,
+            variant: GradientButtonVariant.outline,
+            onPressed: () => openUrl(widget.metadata.changelogUrl),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Pillar {
+  const _Pillar(this.icon, this.title, this.body);
+
+  final IconData icon;
+  final String title;
+  final String body;
+}
+
+const List<_Pillar> _pillars = [
+  _Pillar(
+    Icons.swap_calls_rounded,
+    'One wire protocol',
+    'A request-correlated envelope replaces three ad-hoc bridges - '
+        'identical behavior on Android, iOS, macOS, Windows, and Web.',
+  ),
+  _Pillar(
+    Icons.gpp_maybe_outlined,
+    'Errors are data',
+    'Reads never silently return defaults; every bridge failure is a '
+        'typed MonacoException with the operation name.',
+  ),
+  _Pillar(
+    Icons.article_outlined,
+    'Documents, split like Monaco',
+    'MonacoDocument mirrors ITextModel and the controller mirrors '
+        'ICodeEditor - multi-document editing is first-class.',
+  ),
+  _Pillar(
+    Icons.bolt_rounded,
+    'Born configured',
+    'Two-phase boot: the editor is created with your options, text, and '
+        'theme. No flash, no patch-after-ready, create() never blocks.',
+  ),
+  _Pillar(
+    Icons.sell_outlined,
+    'Open typed ids',
+    'Themes, languages, and actions are zero-cost extension types over '
+        'String - typed catalogs, open sets, custom ids welcome.',
+  ),
+  _Pillar(
+    Icons.tune_rounded,
+    'Options that tell the truth',
+    'EditorOptions is sparse: updateOptions(EditorOptions(fontSize: 16)) '
+        'changes the font size and nothing else.',
+  ),
+];
+
+class _PillarGrid extends StatelessWidget {
+  const _PillarGrid();
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final columns = width >= Breakpoints.desktop
+            ? 3
+            : width >= Breakpoints.tablet
+            ? 2
+            : 1;
+        const gap = Insets.md;
+        final itemWidth = (width - gap * (columns - 1)) / columns;
+        return Wrap(
+          spacing: gap,
+          runSpacing: gap,
+          children: [
+            for (final pillar in _pillars)
+              SizedBox(
+                width: itemWidth,
+                child: _PillarCard(pillar: pillar),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _PillarCard extends StatelessWidget {
+  const _PillarCard({required this.pillar});
+
+  final _Pillar pillar;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.showcaseColors;
+    return Container(
+      padding: const EdgeInsets.all(Insets.md),
+      decoration: BoxDecoration(
+        color: c.brightness == Brightness.dark ? c.page : Colors.white,
+        borderRadius: BorderRadius.circular(Radii.md),
+        border: Border.all(color: c.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(pillar.icon, size: 18, color: ShowcaseColors.accentBlue),
+              const SizedBox(width: Insets.sm),
+              Expanded(
+                child: Text(
+                  pillar.title,
+                  style: ShowcaseText.h3.copyWith(color: c.textPrimary),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: Insets.sm),
+          Text(
+            pillar.body,
+            style: ShowcaseText.body.copyWith(color: c.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DiffCard extends StatelessWidget {
+  const _DiffCard({
+    required this.sideBySide,
+    required this.changeCount,
+    required this.onSideBySide,
+    required this.onPrev,
+    required this.onNext,
+    required this.onReady,
+    required this.editorHeight,
+  });
+
+  final bool sideBySide;
+  final int? changeCount;
+  final ValueChanged<bool> onSideBySide;
+  final VoidCallback onPrev;
+  final VoidCallback onNext;
+  final Future<void> Function(MonacoDiffController) onReady;
+  final double editorHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.showcaseColors;
+    return Container(
+      decoration: BoxDecoration(
+        color: c.surface,
+        borderRadius: BorderRadius.circular(Radii.lg),
+        border: Border.all(color: c.border),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.18),
+            blurRadius: 40,
+            offset: const Offset(0, 16),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          Container(
+            color: c.surfaceAlt,
+            padding: const EdgeInsets.symmetric(
+              horizontal: Insets.md,
+              vertical: Insets.sm,
+            ),
+            child: Row(
+              children: [
+                Text(
+                  'editor_service.dart',
+                  style: ShowcaseText.monoLabel.copyWith(
+                    color: c.textSecondary,
+                  ),
+                ),
+                const SizedBox(width: Insets.md),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: Insets.sm,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: c.accentWash,
+                    borderRadius: BorderRadius.circular(Radii.pill),
+                  ),
+                  child: Text(
+                    changeCount == null
+                        ? '2.x -> 3.0'
+                        : '2.x -> 3.0 · $changeCount changed regions',
+                    style: ShowcaseText.monoLabel.copyWith(
+                      color: ShowcaseColors.accentBlue,
+                    ),
+                  ),
+                ),
+                const Spacer(),
+                _DiffModeToggle(
+                  sideBySide: sideBySide,
+                  onChanged: onSideBySide,
+                ),
+                const SizedBox(width: Insets.sm),
+                _DiffIconButton(
+                  icon: Icons.keyboard_arrow_up_rounded,
+                  tooltip: 'Previous change',
+                  onTap: onPrev,
+                ),
+                _DiffIconButton(
+                  icon: Icons.keyboard_arrow_down_rounded,
+                  tooltip: 'Next change',
+                  onTap: onNext,
+                ),
+              ],
+            ),
+          ),
+          Divider(height: 1, color: c.border),
+          // Same rule as the playground: keep the platform view a direct
+          // sized child so the iframe keeps a real DOM rect on web.
+          SizedBox(
+            height: editorHeight,
+            child: MonacoDiffEditor(
+              key: const ValueKey('showcase-migration-diff'),
+              original: kMigrationOriginal,
+              modified: kMigrationModified,
+              language: MonacoLanguage.dart,
+              // theme stays null: the diff follows the page brightness live.
+              options: const EditorOptions(
+                fontSize: 13,
+                minimap: MonacoMinimapOptions(enabled: false),
+                scrollBeyondLastLine: false,
+                padding: MonacoPadding(top: 12, bottom: 12),
+              ),
+              diffOptions: const MonacoDiffOptions(renderSideBySide: true),
+              onReady: onReady,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DiffModeToggle extends StatelessWidget {
+  const _DiffModeToggle({required this.sideBySide, required this.onChanged});
+
+  final bool sideBySide;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.showcaseColors;
+    Widget chip(String label, bool value) {
+      final active = sideBySide == value;
+      return MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: () => onChanged(value),
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: Insets.sm,
+              vertical: 3,
+            ),
+            decoration: BoxDecoration(
+              color: active ? c.accentWash : Colors.transparent,
+              borderRadius: BorderRadius.circular(Radii.pill),
+            ),
+            child: Text(
+              label,
+              style: ShowcaseText.monoLabel.copyWith(
+                color: active ? ShowcaseColors.accentBlue : c.textSecondary,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(2),
+      decoration: BoxDecoration(
+        color: c.surface,
+        borderRadius: BorderRadius.circular(Radii.pill),
+        border: Border.all(color: c.border),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [chip('Side by side', true), chip('Inline', false)],
+      ),
+    );
+  }
+}
+
+class _DiffIconButton extends StatelessWidget {
+  const _DiffIconButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.showcaseColors;
+    return Tooltip(
+      message: tooltip,
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(4),
+            child: Icon(icon, size: 18, color: c.textSecondary),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/showcase/sections/rebuild_section.dart
+++ b/example/lib/showcase/sections/rebuild_section.dart
@@ -336,6 +336,10 @@ class _DiffCard extends StatelessWidget {
                 padding: MonacoPadding(top: 12, bottom: 12),
               ),
               diffOptions: const MonacoDiffOptions(renderSideBySide: true),
+              // Edge scroll handoff: once the diff hits its vertical scroll
+              // edge, the wheel keeps scrolling the page instead of dying
+              // over the editor.
+              scrollHandoff: const MonacoScrollHandoff.edge(),
               onReady: onReady,
             ),
           ),

--- a/example/lib/showcase/sections/site_nav.dart
+++ b/example/lib/showcase/sections/site_nav.dart
@@ -5,6 +5,7 @@ import '../state/showcase_controller.dart';
 import '../theme/showcase_text.dart';
 import '../theme/showcase_tokens.dart';
 import '../util/links.dart';
+import '../widgets/gradient_button.dart';
 import '../widgets/theme_toggle.dart';
 
 /// The sticky top navigation bar.
@@ -163,29 +164,38 @@ class _PubButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final child = Container(
-      width: compact ? 40 : null,
-      height: compact ? 40 : null,
-      padding: compact
-          ? EdgeInsets.zero
-          : const EdgeInsets.symmetric(horizontal: Insets.lg, vertical: 9),
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        gradient: accentGradient,
-        borderRadius: BorderRadius.circular(Radii.sm),
-      ),
-      child: compact
-          ? const Icon(Icons.open_in_new_rounded, color: Colors.white, size: 18)
-          : Text(
-              'Get it on pub.dev',
-              style: ShowcaseText.small.copyWith(color: Colors.white),
-            ),
-    );
+    // Desktop: the shared CTA at its dense size, so it stays in scale with the
+    // rest of the nav row (and inherits its hover lift/glow).
+    if (!compact) {
+      return GradientButton(
+        label: 'Get it on pub.dev',
+        onPressed: () => openUrl(url),
+        dense: true,
+      );
+    }
+    // Mobile: an icon-only square that matches the 36px tap target of the
+    // adjacent theme toggle.
     return Tooltip(
       message: 'pub.dev',
       child: MouseRegion(
         cursor: SystemMouseCursors.click,
-        child: GestureDetector(onTap: () => openUrl(url), child: child),
+        child: GestureDetector(
+          onTap: () => openUrl(url),
+          child: Container(
+            width: 36,
+            height: 36,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              gradient: accentGradient,
+              borderRadius: BorderRadius.circular(Radii.sm),
+            ),
+            child: const Icon(
+              Icons.open_in_new_rounded,
+              color: Colors.white,
+              size: 18,
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/example/lib/showcase/sections/site_nav.dart
+++ b/example/lib/showcase/sections/site_nav.dart
@@ -14,11 +14,13 @@ class SiteNav extends StatelessWidget {
     required this.controller,
     required this.onTapFeatures,
     required this.onTapPlayground,
+    required this.onTapRebuild,
   });
 
   final ShowcaseController controller;
   final VoidCallback onTapFeatures;
   final VoidCallback onTapPlayground;
+  final VoidCallback onTapRebuild;
 
   static const double height = 64;
 
@@ -42,9 +44,11 @@ class SiteNav extends StatelessWidget {
           _Logo(versionLabel: metadata.versionLabel),
           const Spacer(),
           if (!compact) ...[
-            _NavLink(label: 'Features', onTap: onTapFeatures),
-            const SizedBox(width: Insets.lg),
             _NavLink(label: 'Playground', onTap: onTapPlayground),
+            const SizedBox(width: Insets.lg),
+            _NavLink(label: "What's new", onTap: onTapRebuild),
+            const SizedBox(width: Insets.lg),
+            _NavLink(label: 'Features', onTap: onTapFeatures),
             const SizedBox(width: Insets.lg),
           ],
           ThemeToggle(controller: controller),

--- a/example/lib/showcase/showcase_app.dart
+++ b/example/lib/showcase/showcase_app.dart
@@ -7,6 +7,7 @@ import 'sections/features_section.dart';
 import 'sections/get_started_section.dart';
 import 'sections/hero_section.dart';
 import 'sections/playground_section.dart';
+import 'sections/rebuild_section.dart';
 import 'sections/site_footer.dart';
 import 'sections/site_nav.dart';
 import 'state/showcase_controller.dart';
@@ -28,11 +29,13 @@ class _ShowcaseAppState extends State<ShowcaseApp> {
   final ScrollController _scrollController = ScrollController();
   final GlobalKey _featuresKey = GlobalKey();
   final GlobalKey _playgroundKey = GlobalKey();
+  final GlobalKey _rebuildKey = GlobalKey();
 
   @override
   void initState() {
     super.initState();
     _controller.onRequestScrollToPlayground = () => _scrollTo(_playgroundKey);
+    _controller.onRequestScrollToDiff = () => _scrollTo(_rebuildKey);
     unawaited(_controller.loadMetadata());
   }
 
@@ -74,6 +77,7 @@ class _ShowcaseAppState extends State<ShowcaseApp> {
                   controller: _controller,
                   onTapFeatures: () => _scrollTo(_featuresKey),
                   onTapPlayground: () => _scrollTo(_playgroundKey),
+                  onTapRebuild: () => _scrollTo(_rebuildKey),
                 ),
                 Expanded(
                   child: SingleChildScrollView(
@@ -89,6 +93,7 @@ class _ShowcaseAppState extends State<ShowcaseApp> {
                           controller: _controller,
                           routeObserver: _routeObserver,
                         ),
+                        RebuildSection(key: _rebuildKey, metadata: metadata),
                         FeaturesSection(
                           key: _featuresKey,
                           controller: _controller,

--- a/example/lib/showcase/state/showcase_controller.dart
+++ b/example/lib/showcase/state/showcase_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 
@@ -37,6 +39,37 @@ enum PlaygroundTheme {
       this == PlaygroundTheme.midnight;
 }
 
+/// One open document in the playground's tab strip. The primary tab (index 0)
+/// is the document the editor booted with; demo tabs are opened at runtime
+/// via [MonacoController.openDocument].
+class ShowcaseDocTab {
+  ShowcaseDocTab({
+    required this.label,
+    required this.language,
+    required this.doc,
+  });
+
+  String label;
+  MonacoLanguage language;
+  final MonacoDocument doc;
+
+  Uri? get uri => doc.uri;
+}
+
+/// One rendered line in the live event feed: the sealed-union case name plus
+/// a short human summary of its payload.
+class ShowcaseEventEntry {
+  const ShowcaseEventEntry({
+    required this.type,
+    required this.detail,
+    required this.seq,
+  });
+
+  final String type;
+  final String detail;
+  final int seq;
+}
+
 /// Holds all page + playground state and brokers every live change to the
 /// single shared [MonacoController].
 ///
@@ -61,6 +94,9 @@ class ShowcaseController extends ChangeNotifier {
 
   /// Set by the app so feature cards can scroll the page to the playground.
   VoidCallback? onRequestScrollToPlayground;
+
+  /// Set by the app so feature cards can scroll the page to the live diff.
+  VoidCallback? onRequestScrollToDiff;
 
   // --- Editor state mirrors ---
   PlaygroundTheme _playgroundTheme = PlaygroundTheme.dark;
@@ -89,6 +125,41 @@ class ShowcaseController extends ChangeNotifier {
 
   MonacoController? _editor;
   bool get isEditorReady => _editor != null;
+
+  /// The live protocol handshake (Monaco version, protocol version, lsp/diff
+  /// capability flags), populated once the editor is ready.
+  MonacoCapabilities? _capabilities;
+  MonacoCapabilities? get capabilities => _capabilities;
+
+  // --- Multi-document tabs ---
+  final List<ShowcaseDocTab> _tabs = [];
+  List<ShowcaseDocTab> get tabs => List.unmodifiable(_tabs);
+
+  int _activeTab = 0;
+  int get activeTab => _activeTab;
+
+  /// Uri strings of documents with unsaved edits, for the tab dirty dots.
+  /// A separate listenable so per-keystroke updates don't rebuild the page.
+  final ValueNotifier<Set<String>> dirtyDocs = ValueNotifier(const {});
+
+  // --- Live event feed ---
+  /// Newest-first ring buffer of decoded [MonacoEvent]s (capped at
+  /// [_eventLogCap]). A separate listenable for the same reason as
+  /// [dirtyDocs].
+  final ValueNotifier<List<ShowcaseEventEntry>> eventLog = ValueNotifier(
+    const [],
+  );
+  static const int _eventLogCap = 6;
+  int _eventSeq = 0;
+
+  bool _eventFeedOpen = false;
+  bool get eventFeedOpen => _eventFeedOpen;
+
+  StreamSubscription<MonacoEvent>? _eventSub;
+
+  // --- Custom action demo ---
+  int _saveCount = 0;
+  int get saveCount => _saveCount;
 
   /// Owner key for the markers demo's diagnostics.
   static const String _demoMarkerOwner = 'showcase-demo';
@@ -124,11 +195,22 @@ class ShowcaseController extends ChangeNotifier {
     padding: const MonacoPadding(top: 16, bottom: 16),
   );
 
-  /// Called from [MonacoEditor.onReady]: registers the custom theme and
-  /// completion snippets, then syncs the current theme.
+  /// Called from [MonacoEditor.onReady]: registers the custom theme, the
+  /// completion snippets, and the Cmd/Ctrl+S save action, wires the event
+  /// feed, captures the handshake, then syncs the current theme.
   Future<void> attachEditor(MonacoController controller) async {
     _editor = controller;
     _demoDecorations = null; // Any previous set died with its controller.
+    _capabilities = controller.capabilities;
+    _tabs.clear();
+    _activeTab = 0;
+    dirtyDocs.value = const {};
+
+    // Every decoded event is one case of the sealed MonacoEvent union; the
+    // feed panel renders them as they arrive.
+    unawaited(_eventSub?.cancel());
+    _eventSub = controller.events.listen(_logEvent);
+
     try {
       await controller.defineTheme(kMidnightTheme);
       await controller.registerStaticCompletions(
@@ -142,7 +224,32 @@ class ShowcaseController extends ChangeNotifier {
         triggerCharacters: const ['.'],
         items: kDemoCompletions,
       );
+      // Dart-defined editor action with a real keybinding (new in 3.0). It
+      // also shows up in the editor's context menu and command palette.
+      await controller.addAction(
+        MonacoActionDescriptor(
+          id: const MonacoAction('showcase.save'),
+          label: 'Save (showcase demo)',
+          keybindings: const [
+            MonacoKeybinding(key: MonacoKey.keyS, ctrlCmd: true),
+          ],
+          contextMenuGroupId: 'navigation',
+          contextMenuOrder: 1,
+        ),
+        _onSaveAction,
+      );
       await controller.setTheme(_playgroundTheme.monacoTheme);
+      // The document the editor booted with becomes the primary tab.
+      final docs = await controller.listDocuments();
+      if (docs.isNotEmpty) {
+        _tabs.add(
+          ShowcaseDocTab(
+            label: _labelFor(_language),
+            language: _language,
+            doc: docs.first,
+          ),
+        );
+      }
     } catch (e) {
       debugPrint('[ShowcaseController] attachEditor failed: $e');
     }
@@ -203,6 +310,11 @@ class ShowcaseController extends ChangeNotifier {
     if (language == _language) return;
     _language = language;
     _hint = null;
+    if (_tabs.isNotEmpty) {
+      final tab = _tabs[_activeTab];
+      tab.language = language;
+      tab.label = _labelFor(language, stem: tab.label.split('.').first);
+    }
     notifyListeners();
     final editor = _editor;
     if (editor == null) return;
@@ -267,15 +379,74 @@ class ShowcaseController extends ChangeNotifier {
   Future<void> reset() async {
     final editor = _editor;
     _hint = null;
+    _eventFeedOpen = false;
     notifyListeners();
     if (editor == null) return;
     await _clearDemoArtifacts(editor);
+    // Close the demo tabs and return to the primary document.
+    if (_tabs.length > 1) {
+      final primary = _tabs.first;
+      final extras = _tabs.sublist(1);
+      _tabs.removeRange(1, _tabs.length);
+      _activeTab = 0;
+      _language = primary.language;
+      notifyListeners();
+      await editor.activateDocument(primary.doc);
+      for (final tab in extras) {
+        try {
+          await tab.doc.close();
+        } catch (e) {
+          debugPrint('[ShowcaseController] closing ${tab.label} failed: $e');
+        }
+      }
+    }
+    dirtyDocs.value = const {};
     await editor.document.setLanguage(_language);
     await editor.document.setText(sampleFor(_language, metadata: _metadata));
   }
 
   /// Scrolls the page to the playground (used by feature-card "Try it" links).
   void scrollToPlayground() => onRequestScrollToPlayground?.call();
+
+  /// Scrolls the page to the live migration diff.
+  void scrollToDiff() => onRequestScrollToDiff?.call();
+
+  // --- Multi-document tabs ---
+
+  Future<void> activateTab(int index) async {
+    final editor = _editor;
+    if (editor == null || index < 0 || index >= _tabs.length) return;
+    if (index == _activeTab) return;
+    _activeTab = index;
+    final tab = _tabs[index];
+    _language = tab.language;
+    notifyListeners();
+    await editor.activateDocument(tab.doc);
+  }
+
+  /// Closes a demo tab (the primary tab at index 0 cannot be closed).
+  Future<void> closeTab(int index) async {
+    final editor = _editor;
+    if (editor == null || index <= 0 || index >= _tabs.length) return;
+    final tab = _tabs.removeAt(index);
+    if (_activeTab == index) {
+      _activeTab = 0;
+      _language = _tabs.first.language;
+      await editor.activateDocument(_tabs.first.doc);
+    } else if (_activeTab > index) {
+      _activeTab--;
+    }
+    final uri = tab.uri?.toString();
+    if (uri != null) {
+      dirtyDocs.value = {...dirtyDocs.value}..remove(uri);
+    }
+    notifyListeners();
+    try {
+      await tab.doc.close();
+    } catch (e) {
+      debugPrint('[ShowcaseController] closing ${tab.label} failed: $e');
+    }
+  }
 
   // --- Advanced feature demos (all drive the one editor) ---
 
@@ -340,6 +511,184 @@ class ShowcaseController extends ChangeNotifier {
     _setHint('Lines highlighted with a MonacoDecorationSet + injected CSS.');
   }
 
+  /// Custom-action demo: focuses the editor and invites the keypress; the
+  /// registered Dart callback does the rest.
+  Future<void> runCustomActionDemo() async {
+    final editor = _editor;
+    if (editor == null) return;
+    _setHint(
+      'Press Cmd/Ctrl+S inside the editor - the keybinding runs a Dart '
+      'callback registered with controller.addAction (also in the '
+      'right-click menu as "Save (showcase demo)").',
+    );
+    await editor.requestFocus();
+  }
+
+  /// Multi-document demo: opens two more documents and switches to one, so
+  /// the tab strip shows independent MonacoDocument handles.
+  Future<void> runMultiDocumentDemo() async {
+    final editor = _editor;
+    if (editor == null || _tabs.isEmpty) return;
+    if (_tabs.length == 1) {
+      final python = await editor.openDocument(
+        text: sampleFor(MonacoLanguage.python, metadata: _metadata),
+        language: MonacoLanguage.python,
+        uri: Uri.parse('inmemory://showcase/server.py'),
+      );
+      final markdown = await editor.openDocument(
+        text: sampleFor(MonacoLanguage.markdown, metadata: _metadata),
+        language: MonacoLanguage.markdown,
+        uri: Uri.parse('inmemory://showcase/notes.md'),
+      );
+      _tabs.addAll([
+        ShowcaseDocTab(
+          label: 'server.py',
+          language: MonacoLanguage.python,
+          doc: python,
+        ),
+        ShowcaseDocTab(
+          label: 'notes.md',
+          language: MonacoLanguage.markdown,
+          doc: markdown,
+        ),
+      ]);
+      notifyListeners();
+    }
+    await activateTab(1);
+    _setHint(
+      'Each tab is a MonacoDocument opened with controller.openDocument - '
+      'own undo stack, own language, own dirty state. Edit one and watch '
+      'its tab dot.',
+    );
+  }
+
+  /// Event-feed demo: opens the live feed under the editor.
+  Future<void> runEventsDemo() async {
+    _eventFeedOpen = true;
+    _setHint(
+      'Type, select, and click around - every line below is one case of '
+      'the sealed MonacoEvent union from controller.events.',
+    );
+  }
+
+  void closeEventFeed() {
+    _eventFeedOpen = false;
+    notifyListeners();
+  }
+
+  Future<void> _onSaveAction() async {
+    final editor = _editor;
+    if (editor == null) return;
+    _saveCount++;
+    final text = await editor.document.getText();
+    await editor.document.markSaved();
+    if (_tabs.isNotEmpty) {
+      final uri = _tabs[_activeTab].uri?.toString();
+      if (uri != null) {
+        dirtyDocs.value = {...dirtyDocs.value}..remove(uri);
+      }
+    }
+    _setHint(
+      'Saved ${text.length} characters (save #$_saveCount). Cmd/Ctrl+S ran '
+      'Dart code via controller.addAction - no JavaScript involved.',
+    );
+  }
+
+  void _logEvent(MonacoEvent event) {
+    final (type, detail) = switch (event) {
+      MonacoContentChanged(
+        :final isFlush,
+        :final changes,
+        :final truncated,
+        :final documentUri,
+      ) =>
+        (
+          'MonacoContentChanged',
+          isFlush
+              ? 'flush - whole document replaced'
+              : truncated
+              ? 'changes truncated (>64 KB)'
+              : '${changes?.length ?? 0} change range(s)'
+                    '${documentUri != null ? ' in ${_docLabel(documentUri)}' : ''}',
+        ),
+      MonacoSelectionChanged(:final selection) => (
+        'MonacoSelectionChanged',
+        switch (selection) {
+          null => 'selection cleared',
+          Range(:final startLine, :final startColumn)
+              when selection.isCollapsed =>
+            'caret at $startLine:$startColumn',
+          final range =>
+            '${range.startLine}:${range.startColumn} -> '
+                '${range.endLine}:${range.endColumn}',
+        },
+      ),
+      MonacoFocusChanged(:final focused) => (
+        'MonacoFocusChanged',
+        focused ? 'editor focused' : 'editor blurred',
+      ),
+      MonacoScrollHandoffEvent() => (
+        'MonacoScrollHandoffEvent',
+        'edge reached - scroll hands off to the page',
+      ),
+      MonacoUnknownEvent(:final name) => ('MonacoUnknownEvent', name),
+    };
+
+    // Tab dirty dots ride the same stream: real user edits are non-flush.
+    if (event case MonacoContentChanged(
+      isFlush: false,
+      documentUri: final Uri uri,
+    )) {
+      final key = uri.toString();
+      if (!dirtyDocs.value.contains(key)) {
+        dirtyDocs.value = {...dirtyDocs.value, key};
+      }
+    }
+
+    final next = [
+      ShowcaseEventEntry(type: type, detail: detail, seq: _eventSeq++),
+      ...eventLog.value,
+    ];
+    if (next.length > _eventLogCap) {
+      next.removeRange(_eventLogCap, next.length);
+    }
+    eventLog.value = next;
+  }
+
+  /// Human label for a document uri: the tab label when the document is
+  /// open in the tab strip (the boot model's anonymous `inmemory://model/1`
+  /// would otherwise render as "1"), else the uri basename.
+  String _docLabel(Uri uri) {
+    for (final tab in _tabs) {
+      if (tab.uri == uri) return tab.label;
+    }
+    final segments = uri.pathSegments.where((s) => s.isNotEmpty).toList();
+    return segments.isEmpty ? uri.toString() : segments.last;
+  }
+
+  static String _labelFor(MonacoLanguage language, {String? stem}) {
+    final base = stem ?? 'main';
+    final extension = switch (language) {
+      MonacoLanguage.dart => 'dart',
+      MonacoLanguage.typescript => 'ts',
+      MonacoLanguage.javascript => 'js',
+      MonacoLanguage.python => 'py',
+      MonacoLanguage.json => 'json',
+      MonacoLanguage.rust => 'rs',
+      MonacoLanguage.go => 'go',
+      MonacoLanguage.sql => 'sql',
+      MonacoLanguage.yaml => 'yaml',
+      MonacoLanguage.html => 'html',
+      MonacoLanguage.css => 'css',
+      MonacoLanguage.markdown => 'md',
+      MonacoLanguage.java => 'java',
+      MonacoLanguage.kotlin => 'kt',
+      MonacoLanguage.swift => 'swift',
+      _ => 'txt',
+    };
+    return '$base.$extension';
+  }
+
   void _setHint(String message) {
     _hint = message;
     notifyListeners();
@@ -347,6 +696,9 @@ class ShowcaseController extends ChangeNotifier {
 
   @override
   void dispose() {
+    unawaited(_eventSub?.cancel());
+    eventLog.dispose();
+    dirtyDocs.dispose();
     _metadataLoader.dispose();
     super.dispose();
   }

--- a/example/lib/showcase/util/links.dart
+++ b/example/lib/showcase/util/links.dart
@@ -13,6 +13,8 @@ abstract final class Links {
       'https://github.com/omar-hanafy/flutter_monaco/blob/main/CHANGELOG.md';
   static const String license =
       'https://github.com/omar-hanafy/flutter_monaco/blob/main/LICENSE';
+  static const String lspExample =
+      'https://github.com/omar-hanafy/flutter_monaco/blob/main/example/lib/lsp_example.dart';
   static const String portfolio = 'https://omar-hanafy.github.io';
   static const String buyMeACoffee = 'https://www.buymeacoffee.com/omar.hanafy';
 }

--- a/example/lib/showcase/widgets/feature_card.dart
+++ b/example/lib/showcase/widgets/feature_card.dart
@@ -13,6 +13,7 @@ class FeatureCard extends StatefulWidget {
     required this.body,
     this.snippet,
     this.onTry,
+    this.tryLabel = 'Try it',
   });
 
   final IconData icon;
@@ -20,6 +21,7 @@ class FeatureCard extends StatefulWidget {
   final String body;
   final String? snippet;
   final VoidCallback? onTry;
+  final String tryLabel;
 
   @override
   State<FeatureCard> createState() => _FeatureCardState();
@@ -99,7 +101,7 @@ class _FeatureCardState extends State<FeatureCard> {
             ],
             if (widget.onTry != null) ...[
               const SizedBox(height: Insets.md),
-              _TryLink(onTap: widget.onTry!),
+              _TryLink(onTap: widget.onTry!, label: widget.tryLabel),
             ],
           ],
         ),
@@ -109,9 +111,10 @@ class _FeatureCardState extends State<FeatureCard> {
 }
 
 class _TryLink extends StatelessWidget {
-  const _TryLink({required this.onTap});
+  const _TryLink({required this.onTap, required this.label});
 
   final VoidCallback onTap;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
@@ -123,7 +126,7 @@ class _TryLink extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              'Try it',
+              label,
               style: ShowcaseText.small.copyWith(
                 color: ShowcaseColors.accentBlue,
               ),

--- a/example/lib/showcase/widgets/gradient_button.dart
+++ b/example/lib/showcase/widgets/gradient_button.dart
@@ -17,12 +17,17 @@ class GradientButton extends StatefulWidget {
     required this.onPressed,
     this.icon,
     this.variant = GradientButtonVariant.filled,
+    this.dense = false,
   });
 
   final String label;
   final VoidCallback onPressed;
   final IconData? icon;
   final GradientButtonVariant variant;
+
+  /// A tighter size for use inside chrome like the top nav, where the default
+  /// hero-scale button would dominate the row.
+  final bool dense;
 
   @override
   State<GradientButton> createState() => _GradientButtonState();
@@ -43,14 +48,20 @@ class _GradientButtonState extends State<GradientButton> {
         ? c.textPrimary
         : c.textSecondary;
 
+    final dense = widget.dense;
     final content = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         if (widget.icon != null) ...[
-          Icon(widget.icon, size: 18, color: fg),
-          const SizedBox(width: Insets.sm),
+          Icon(widget.icon, size: dense ? 16 : 18, color: fg),
+          SizedBox(width: dense ? Insets.xs : Insets.sm),
         ],
-        Text(widget.label, style: ShowcaseText.button.copyWith(color: fg)),
+        Text(
+          widget.label,
+          style: (dense ? ShowcaseText.small : ShowcaseText.button).copyWith(
+            color: fg,
+          ),
+        ),
       ],
     );
 
@@ -63,11 +74,14 @@ class _GradientButtonState extends State<GradientButton> {
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 160),
           curve: Curves.easeOut,
-          transform: Matrix4.translationValues(0, _hovered ? -2 : 0, 0),
-          padding: const EdgeInsets.symmetric(
-            horizontal: Insets.lg,
-            vertical: 14,
+          transform: Matrix4.translationValues(
+            0,
+            _hovered ? (dense ? -1 : -2) : 0,
+            0,
           ),
+          padding: dense
+              ? const EdgeInsets.symmetric(horizontal: Insets.md, vertical: 8)
+              : const EdgeInsets.symmetric(horizontal: Insets.lg, vertical: 14),
           decoration: BoxDecoration(
             gradient: filled ? accentGradient : null,
             color: filled
@@ -75,14 +89,14 @@ class _GradientButtonState extends State<GradientButton> {
                 : outline
                 ? Colors.transparent
                 : (_hovered ? c.surface : Colors.transparent),
-            borderRadius: BorderRadius.circular(Radii.md),
+            borderRadius: BorderRadius.circular(dense ? Radii.sm : Radii.md),
             border: outline ? Border.all(color: c.border) : null,
             boxShadow: filled && _hovered
                 ? [
                     BoxShadow(
                       color: ShowcaseColors.accentBlue.withValues(alpha: 0.35),
-                      blurRadius: 24,
-                      offset: const Offset(0, 8),
+                      blurRadius: dense ? 16 : 24,
+                      offset: Offset(0, dense ? 5 : 8),
                     ),
                   ]
                 : null,

--- a/example/test/showcase/metadata_test.dart
+++ b/example/test/showcase/metadata_test.dart
@@ -35,7 +35,7 @@ environment:
       expect(metadata.flutterConstraint, '>=3.44.0');
     });
 
-    test('merges latest pub.dev package metadata', () {
+    test('pub.dev merge adds provenance but keeps the bundled build data', () {
       final metadata = parsePubDevPackage({
         'latest': {
           'version': '2.2.0',
@@ -51,14 +51,21 @@ environment:
         },
       });
 
-      expect(metadata.version, '2.2.0');
-      expect(metadata.description, 'Live description');
+      // The page reports the build it actually runs (the bundled pubspec);
+      // pub.dev only contributes provenance and live stats.
+      expect(metadata.version, ShowcaseMetadata.fallback.version);
+      expect(metadata.description, ShowcaseMetadata.fallback.description);
+      expect(metadata.latestPubVersion, '2.2.0');
       expect(metadata.hasLivePubDev, isTrue);
       expect(metadata.publishedAt, isNotNull);
-      expect(metadata.platforms.map((platform) => platform.label), [
-        'Windows',
-        'Web',
-      ]);
+      expect(
+        metadata.publishedLabel,
+        'v2.2.0 on pub.dev · ${formatShortDate(metadata.publishedAt!)}',
+      );
+      expect(
+        metadata.platforms.map((platform) => platform.id),
+        ShowcaseMetadata.fallback.platforms.map((platform) => platform.id),
+      );
     });
   });
 }

--- a/lib/src/diff/diff_controller.dart
+++ b/lib/src/diff/diff_controller.dart
@@ -265,6 +265,38 @@ class MonacoDiffController {
     await _invoke('diff.revealPreviousChange', {});
   }
 
+  /// Unconsumed scroll intents reported by the diff page (edge scroll
+  /// handoff). Emits only while a source is enabled through
+  /// [setScrollHandoffSources]; malformed payloads are dropped silently.
+  ///
+  /// The vertical scroll master is the modified editor (both panes are
+  /// height-aligned), and the wheel region covers both panes. See
+  /// [MonacoScrollHandoffDetails] for the delta conventions.
+  Stream<MonacoScrollHandoffDetails> get onScrollHandoff => _protocol.events
+      .where((event) => event.name == 'scrollHandoff')
+      .map(
+        (event) => MonacoScrollHandoffDetails.tryParse(
+          Map<String, dynamic>.from(event.data),
+        ),
+      )
+      .where((details) => details != null)
+      .cast<MonacoScrollHandoffDetails>();
+
+  /// Enables or disables edge scroll handoff sources inside the diff page.
+  ///
+  /// Identical contract to `MonacoController.setScrollHandoffSources`: an
+  /// enabled source installs the matching DOM listeners and posts
+  /// `scrollHandoff` events (surfaced through [onScrollHandoff]) for deltas
+  /// the diff editor cannot consume; disabling removes the listeners again.
+  /// `MonacoDiffEditor` calls this automatically from its `scrollHandoff`
+  /// configuration.
+  Future<void> setScrollHandoffSources({
+    bool wheel = false,
+    bool touch = false,
+  }) async {
+    await _invoke('page.setScrollHandoff', {'wheel': wheel, 'touch': touch});
+  }
+
   /// Releases the WebView and fails all in-flight commands.
   void dispose() {
     if (_disposed) return;

--- a/lib/src/widgets/monaco_diff_editor.dart
+++ b/lib/src/widgets/monaco_diff_editor.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/widgets/monaco_status_bar.dart';
+import 'package:flutter_monaco/src/widgets/scroll_handoff_driver.dart';
 
 /// A widget that renders a Monaco diff editor (original vs modified).
 ///
@@ -33,6 +34,7 @@ class MonacoDiffEditor extends StatefulWidget {
     this.diffOptions = const MonacoDiffOptions(),
     this.page = const MonacoPageConfig(),
     this.readyTimeout = const Duration(seconds: 20),
+    this.scrollHandoff = const MonacoScrollHandoff.disabled(),
     this.onReady,
     this.onError,
     this.loadingBuilder,
@@ -73,6 +75,17 @@ class MonacoDiffEditor extends StatefulWidget {
   /// widget owns it.
   final MonacoPageConfig page;
 
+  /// How scroll input the diff editor cannot consume is handed to the
+  /// Flutter host. Defaults to [MonacoScrollHandoff.disabled].
+  ///
+  /// When set to [MonacoScrollHandoff.edge], wheel or trackpad input over
+  /// either pane keeps scrolling the diff until it reaches its vertical
+  /// scroll edge; unconsumed deltas are then forwarded to
+  /// [MonacoScrollHandoff.controller] or the nearest enclosing vertical
+  /// scrollable, so the surrounding page continues scrolling. Identical
+  /// semantics to `MonacoEditor.scrollHandoff`.
+  final MonacoScrollHandoff scrollHandoff;
+
   /// The maximum duration to wait for the diff editor to initialize.
   final Duration readyTimeout;
 
@@ -108,6 +121,20 @@ class _MonacoDiffEditorState extends State<MonacoDiffEditor> {
   int _bootstrapSeq = 0;
   MonacoTheme? _appliedResolvedTheme;
   bool _bootstrappedOnce = false;
+
+  /// Applies forwarded scroll deltas to the configured Flutter target
+  /// (shared with `MonacoEditor`).
+  late final ScrollHandoffDriver _scrollHandoffDriver = ScrollHandoffDriver(
+    config: () => widget.scrollHandoff,
+    context: () => context,
+    isMounted: () => mounted,
+  );
+  StreamSubscription<MonacoScrollHandoffDetails>? _scrollHandoffSub;
+
+  /// The handoff sources last pushed to the diff page, so config rebuilds
+  /// only produce bridge traffic when the effective sources change.
+  bool _syncedWheelSource = false;
+  bool _syncedTouchSource = false;
 
   /// The texts/language last pushed to (or booted into) the controller, so
   /// prop changes that land during the connecting window are re-applied at
@@ -151,6 +178,13 @@ class _MonacoDiffEditorState extends State<MonacoDiffEditor> {
       _teardown(disposeOldController: true);
       _bootstrap();
       return;
+    }
+
+    if (widget.scrollHandoff != oldWidget.scrollHandoff) {
+      // Identity compare is enough: the sync method dedupes against the
+      // last pushed source flags, so rebuilds with equivalent configs are
+      // free.
+      _syncScrollHandoffSources();
     }
 
     if (_connectionState != _DiffConnectionState.ready || _controller == null) {
@@ -274,6 +308,9 @@ class _MonacoDiffEditorState extends State<MonacoDiffEditor> {
         }
       }
 
+      _wireScrollHandoff();
+      _syncScrollHandoffSources();
+
       setState(() => _connectionState = _DiffConnectionState.ready);
       // Content props may have changed while the boot was in flight;
       // re-apply the delta now that didUpdateWidget can no longer see it.
@@ -321,6 +358,30 @@ class _MonacoDiffEditorState extends State<MonacoDiffEditor> {
     );
   }
 
+  /// Subscribes the shared driver to the controller's handoff stream.
+  void _wireScrollHandoff() {
+    _scrollHandoffSub?.cancel();
+    _scrollHandoffSub = _controller!.onScrollHandoff.listen(
+      _scrollHandoffDriver.handle,
+    );
+  }
+
+  /// Pushes the desired handoff sources to the diff page when they differ
+  /// from what was last pushed. A disabled config therefore produces no
+  /// bridge traffic at all.
+  void _syncScrollHandoffSources() {
+    final controller = _controller;
+    if (controller == null) return;
+    final wheel = widget.scrollHandoff.wheelSourceEnabled;
+    final touch = widget.scrollHandoff.touchSourceEnabled;
+    if (wheel == _syncedWheelSource && touch == _syncedTouchSource) return;
+    _syncedWheelSource = wheel;
+    _syncedTouchSource = touch;
+    _ignoreAsync(
+      controller.setScrollHandoffSources(wheel: wheel, touch: touch),
+    );
+  }
+
   void _ignoreAsync(Future<void> future) {
     unawaited(
       future.catchError((Object e, StackTrace st) {
@@ -346,8 +407,21 @@ class _MonacoDiffEditorState extends State<MonacoDiffEditor> {
   }
 
   void _teardown({required bool disposeOldController}) {
+    _scrollHandoffSub?.cancel();
+    _scrollHandoffSub = null;
+    final controller = _controller;
+    if (controller != null &&
+        !disposeOldController &&
+        (_syncedWheelSource || _syncedTouchSource)) {
+      // The external controller outlives this widget: stop the page from
+      // posting handoff events nobody consumes.
+      _ignoreAsync(controller.setScrollHandoffSources());
+    }
+    _syncedWheelSource = false;
+    _syncedTouchSource = false;
+    _scrollHandoffDriver.clearPending();
     if (disposeOldController) {
-      _controller?.dispose();
+      controller?.dispose();
     }
     _controller = null;
     _appliedResolvedTheme = null;

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -3,10 +3,10 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/widgets/monaco_status_bar.dart';
+import 'package:flutter_monaco/src/widgets/scroll_handoff_driver.dart';
 
 /// An enumeration representing the connection state of the Monaco Editor.
 enum _ConnectionState {
@@ -276,10 +276,13 @@ class _MonacoEditorState extends State<MonacoEditor> {
   /// native input-ready.
   bool _monacoReportsFocused = false;
 
-  /// Scroll handoff deltas accumulated between frames (wheel semantics:
-  /// positive scrolls down). Applied once per frame to the resolved target.
-  double _pendingScrollHandoffDelta = 0;
-  bool _scrollHandoffFrameScheduled = false;
+  /// Applies forwarded scroll deltas to the configured Flutter target
+  /// (shared with `MonacoDiffEditor`).
+  late final ScrollHandoffDriver _scrollHandoffDriver = ScrollHandoffDriver(
+    config: () => widget.scrollHandoff,
+    context: () => context,
+    isMounted: () => mounted,
+  );
 
   /// The handoff sources last pushed to the editor page, so config rebuilds
   /// only produce bridge traffic when the effective sources change.
@@ -587,7 +590,7 @@ class _MonacoEditorState extends State<MonacoEditor> {
     _streamSubscriptions.add(focusSub);
 
     final scrollHandoffSub = _controller!.onScrollHandoff.listen(
-      _handleScrollHandoff,
+      _scrollHandoffDriver.handle,
     );
     _streamSubscriptions.add(scrollHandoffSub);
 
@@ -635,70 +638,6 @@ class _MonacoEditorState extends State<MonacoEditor> {
     _ignoreAsync(
       controller.setScrollHandoffSources(wheel: wheel, touch: touch),
     );
-  }
-
-  void _handleScrollHandoff(MonacoScrollHandoffDetails details) {
-    final config = widget.scrollHandoff;
-    if (!config.isEnabled) return;
-    final sourceEnabled = switch (details.source) {
-      MonacoScrollHandoffSource.wheel => config.desktopWheel,
-      MonacoScrollHandoffSource.touch => config.mobileTouch,
-    };
-    if (!sourceEnabled) return;
-
-    // The callback sees every raw delta; coalescing below only affects the
-    // built-in parent scrolling.
-    final onHandoff = config.onHandoff;
-    if (onHandoff != null && onHandoff(details)) return;
-
-    if (details.deltaY == 0) return;
-    _pendingScrollHandoffDelta += details.deltaY;
-    _scheduleScrollHandoffFlush();
-  }
-
-  /// Coalesces high-frequency bridge deltas into one scroll application per
-  /// frame so trackpad streams cannot flood the scroll position.
-  void _scheduleScrollHandoffFlush() {
-    if (_scrollHandoffFrameScheduled) return;
-    _scrollHandoffFrameScheduled = true;
-    SchedulerBinding.instance.scheduleFrameCallback((_) {
-      _scrollHandoffFrameScheduled = false;
-      final delta = _pendingScrollHandoffDelta;
-      _pendingScrollHandoffDelta = 0;
-      if (!mounted || delta == 0) return;
-      _applyScrollHandoffDelta(delta);
-    });
-  }
-
-  void _applyScrollHandoffDelta(double delta) {
-    final config = widget.scrollHandoff;
-    if (!config.isEnabled) return;
-    for (final position in _resolveScrollHandoffPositions(config)) {
-      // Mirror Scrollable's own wheel handling: pointerScroll clamps,
-      // fires the correct notifications, and lets NestedScrollView
-      // positions coordinate; reversed axes flip the delta sign.
-      final directional = axisDirectionIsReversed(position.axisDirection)
-          ? -delta
-          : delta;
-      if (directional == 0) continue;
-      position.pointerScroll(directional);
-    }
-  }
-
-  List<ScrollPosition> _resolveScrollHandoffPositions(
-    MonacoScrollHandoff config,
-  ) {
-    final explicit = config.controller;
-    if (explicit != null) {
-      if (!explicit.hasClients) return const [];
-      return explicit.positions
-          .where((position) => position.axis == Axis.vertical)
-          .toList();
-    }
-    if (!config.useNearestScrollable) return const [];
-    final position = Scrollable.maybeOf(context, axis: Axis.vertical)?.position;
-    if (position == null) return const [];
-    return [position];
   }
 
   /// Wires only the content changed listener, allowing it to be updated separately.
@@ -770,7 +709,7 @@ class _MonacoEditorState extends State<MonacoEditor> {
     }
     _syncedWheelSource = false;
     _syncedTouchSource = false;
-    _pendingScrollHandoffDelta = 0;
+    _scrollHandoffDriver.clearPending();
     _appliedResolvedTheme = null;
     if (disposeOldController) {
       controller?.dispose();

--- a/lib/src/widgets/scroll_handoff_driver.dart
+++ b/lib/src/widgets/scroll_handoff_driver.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_monaco/flutter_monaco.dart';
+
+/// Shared edge-scroll-handoff engine for `MonacoEditor` and
+/// `MonacoDiffEditor`.
+///
+/// Owns everything between "a `scrollHandoff` event arrived" and "a Flutter
+/// scroll position moved": the config and source gates, the [MonacoScrollHandoff.onHandoff]
+/// callback, per-frame delta coalescing, and target resolution (explicit
+/// controller, else the nearest enclosing vertical scrollable). The host
+/// `State` stays responsible for stream wiring, source syncing over the
+/// bridge, and calling [clearPending] on teardown.
+class ScrollHandoffDriver {
+  /// Creates a driver bound to its host `State` through callbacks, so it
+  /// always reads the current widget config and context.
+  ScrollHandoffDriver({
+    required this._config,
+    required this._context,
+    required this._isMounted,
+  });
+
+  final MonacoScrollHandoff Function() _config;
+  final BuildContext Function() _context;
+  final bool Function() _isMounted;
+
+  /// Scroll handoff deltas accumulated between frames (wheel semantics:
+  /// positive scrolls down). Applied once per frame to the resolved target.
+  double _pendingDelta = 0;
+  bool _frameScheduled = false;
+
+  /// Handles one forwarded delta from the editor page.
+  void handle(MonacoScrollHandoffDetails details) {
+    final config = _config();
+    if (!config.isEnabled) return;
+    final sourceEnabled = switch (details.source) {
+      MonacoScrollHandoffSource.wheel => config.desktopWheel,
+      MonacoScrollHandoffSource.touch => config.mobileTouch,
+    };
+    if (!sourceEnabled) return;
+
+    // The callback sees every raw delta; coalescing below only affects the
+    // built-in parent scrolling.
+    final onHandoff = config.onHandoff;
+    if (onHandoff != null && onHandoff(details)) return;
+
+    if (details.deltaY == 0) return;
+    _pendingDelta += details.deltaY;
+    _scheduleFlush();
+  }
+
+  /// Drops any accumulated delta; call when the controller goes away so a
+  /// pending flush cannot scroll on behalf of a dead editor.
+  void clearPending() {
+    _pendingDelta = 0;
+  }
+
+  /// Coalesces high-frequency bridge deltas into one scroll application per
+  /// frame so trackpad streams cannot flood the scroll position.
+  void _scheduleFlush() {
+    if (_frameScheduled) return;
+    _frameScheduled = true;
+    SchedulerBinding.instance.scheduleFrameCallback((_) {
+      _frameScheduled = false;
+      final delta = _pendingDelta;
+      _pendingDelta = 0;
+      if (!_isMounted() || delta == 0) return;
+      _applyDelta(delta);
+    });
+  }
+
+  void _applyDelta(double delta) {
+    final config = _config();
+    if (!config.isEnabled) return;
+    for (final position in _resolvePositions(config)) {
+      // Mirror Scrollable's own wheel handling: pointerScroll clamps,
+      // fires the correct notifications, and lets NestedScrollView
+      // positions coordinate; reversed axes flip the delta sign.
+      final directional = axisDirectionIsReversed(position.axisDirection)
+          ? -delta
+          : delta;
+      if (directional == 0) continue;
+      position.pointerScroll(directional);
+    }
+  }
+
+  List<ScrollPosition> _resolvePositions(MonacoScrollHandoff config) {
+    final explicit = config.controller;
+    if (explicit != null) {
+      if (!explicit.hasClients) return const [];
+      return explicit.positions
+          .where((position) => position.axis == Axis.vertical)
+          .toList();
+    }
+    if (!config.useNearestScrollable) return const [];
+    final position = Scrollable.maybeOf(
+      _context(),
+      axis: Axis.vertical,
+    )?.position;
+    if (position == null) return const [];
+    return [position];
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/assets/bridge_files_test.dart
+++ b/test/assets/bridge_files_test.dart
@@ -80,5 +80,35 @@ void main() {
         expect(boot, contains(call), reason: 'boot.js lacks $call');
       }
     });
+
+    test('diff boot wires edge scroll handoff over both panes', () {
+      // The diff path drives the handoff module with the modified editor as
+      // the vertical scroll master and a scope that accepts both panes.
+      final boot = bridgeSource('boot.js');
+      for (final marker in [
+        'diffCtx.bootDiff(params)',
+        'window.diffEditor.getModifiedEditor()',
+        'diffCtx.handoffScope',
+        '.scrollHandoff(diffCtx)',
+      ]) {
+        expect(boot, contains(marker), reason: 'boot.js lacks $marker');
+      }
+
+      final handoff = bridgeSource('scroll-handoff.js');
+      for (final marker in [
+        'ctx.handoffScope || null',
+        'handoffScope.regionRoot',
+        'handoffScope.editorDoms',
+        // Diff pages never run core.js, so the module must create the
+        // legacy namespace before assigning the toggle onto it.
+        'window.flutterMonaco = window.flutterMonaco || {}',
+      ]) {
+        expect(
+          handoff,
+          contains(marker),
+          reason: 'scroll-handoff.js lacks $marker',
+        );
+      }
+    });
   });
 }

--- a/test/core/monaco_diff_controller_scroll_handoff_test.dart
+++ b/test/core/monaco_diff_controller_scroll_handoff_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_monaco/flutter_monaco.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../fakes/fake_platform_webview_controller.dart';
+
+class _Bundle {
+  _Bundle(this.controller, this.webview);
+
+  final MonacoDiffController controller;
+  final FakePlatformWebViewController webview;
+}
+
+Future<_Bundle> _createBundle() async {
+  final webview = FakePlatformWebViewController(widget: const SizedBox());
+  final controller = await MonacoDiffController.createForTesting(
+    webViewController: webview,
+  );
+  return _Bundle(controller, webview);
+}
+
+Map<String, Object?> _payload({
+  Object? source = 'wheel',
+  Object? deltaX = 0,
+  Object? deltaY = 24,
+  bool atTop = false,
+  bool atBottom = true,
+}) {
+  return {
+    'source': ?source,
+    'deltaX': ?deltaX,
+    'deltaY': ?deltaY,
+    'atTop': atTop,
+    'atBottom': atBottom,
+    'atLeft': true,
+    'atRight': true,
+  };
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MonacoDiffController.onScrollHandoff', () {
+    test('emits parsed details for a valid wheel payload', () async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+
+      final events = <MonacoScrollHandoffDetails>[];
+      final sub = bundle.controller.onScrollHandoff.listen(events.add);
+      addTearDown(sub.cancel);
+
+      bundle.webview.emitEvent('scrollHandoff', _payload(deltaY: 44.5));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      expect(events.single.source, MonacoScrollHandoffSource.wheel);
+      expect(events.single.deltaY, 44.5);
+      expect(events.single.atBottom, isTrue);
+    });
+
+    test('drops malformed payloads silently', () async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+
+      final events = <MonacoScrollHandoffDetails>[];
+      final sub = bundle.controller.onScrollHandoff.listen(events.add);
+      addTearDown(sub.cancel);
+
+      bundle.webview.emitEvent('scrollHandoff', _payload(source: 'gamepad'));
+      bundle.webview.emitEvent('scrollHandoff', _payload(source: null));
+      bundle.webview.emitEvent('scrollHandoff', _payload(deltaY: null));
+      bundle.webview.emitEvent('scrollHandoff', _payload(deltaY: 'ten'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, isEmpty);
+    });
+
+    test('ignores unrelated events', () async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+
+      final events = <MonacoScrollHandoffDetails>[];
+      final sub = bundle.controller.onScrollHandoff.listen(events.add);
+      addTearDown(sub.cancel);
+
+      bundle.webview.emitEvent('stats', {'lineCount': 3, 'charCount': 9});
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, isEmpty);
+    });
+
+    test('closes on dispose', () async {
+      final bundle = await _createBundle();
+
+      final done = expectLater(bundle.controller.onScrollHandoff, emitsDone);
+      bundle.controller.dispose();
+      await done;
+    });
+  });
+
+  group('MonacoDiffController.setScrollHandoffSources', () {
+    test('invokes the JS toggle with the requested sources', () async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+
+      await bundle.controller.setScrollHandoffSources(wheel: true);
+
+      final calls = bundle.webview.dispatched
+          .where((d) => d['method'] == 'page.setScrollHandoff')
+          .toList();
+      expect(calls, hasLength(1));
+      final params = calls.single['params']! as Map<String, Object?>;
+      expect(params['wheel'], isTrue);
+      expect(params['touch'], isFalse);
+    });
+
+    test('defaults to disabling both sources', () async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+
+      await bundle.controller.setScrollHandoffSources();
+
+      final calls = bundle.webview.dispatched
+          .where((d) => d['method'] == 'page.setScrollHandoff')
+          .toList();
+      expect(calls, hasLength(1));
+      final params = calls.single['params']! as Map<String, Object?>;
+      expect(params['wheel'], isFalse);
+      expect(params['touch'], isFalse);
+    });
+  });
+}

--- a/test/widgets/monaco_diff_editor_scroll_handoff_test.dart
+++ b/test/widgets/monaco_diff_editor_scroll_handoff_test.dart
@@ -1,0 +1,408 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_monaco/flutter_monaco.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../fakes/fake_platform_webview_controller.dart';
+
+class _Bundle {
+  _Bundle(this.controller, this.webview);
+
+  final MonacoDiffController controller;
+  final FakePlatformWebViewController webview;
+}
+
+Future<_Bundle> _createBundle() async {
+  final webview = FakePlatformWebViewController(
+    widget: const SizedBox(key: Key('webview')),
+  );
+  final controller = await MonacoDiffController.createForTesting(
+    webViewController: webview,
+  );
+  return _Bundle(controller, webview);
+}
+
+void _emitHandoff(
+  FakePlatformWebViewController webview, {
+  String source = 'wheel',
+  double deltaY = 40,
+  bool atTop = false,
+  bool atBottom = true,
+}) {
+  webview.emitEvent('scrollHandoff', {
+    'source': source,
+    'deltaX': 0,
+    'deltaY': deltaY,
+    'atTop': atTop,
+    'atBottom': atBottom,
+    'atLeft': true,
+    'atRight': true,
+  });
+}
+
+/// Delivers pending broadcast-stream events, then runs the coalescing
+/// frame callback.
+Future<void> _settleHandoff(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pump();
+}
+
+Widget _diffInScrollView({
+  required MonacoDiffController controller,
+  required ScrollController scrollController,
+  MonacoScrollHandoff scrollHandoff = const MonacoScrollHandoff.disabled(),
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SingleChildScrollView(
+        controller: scrollController,
+        child: Column(
+          children: [
+            SizedBox(
+              height: 300,
+              child: MonacoDiffEditor(
+                controller: controller,
+                scrollHandoff: scrollHandoff,
+              ),
+            ),
+            const SizedBox(height: 3000, width: 100),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Pumps until the diff editor's async bootstrap (whenReady + post-ready
+/// option pushes) has completed and the handoff wiring is live.
+Future<void> _pumpReady(WidgetTester tester, Widget widget) async {
+  await tester.pumpWidget(widget);
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MonacoDiffEditor scroll handoff', () {
+    testWidgets('wheel handoff scrolls the enclosing scrollable', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await _pumpReady(
+        tester,
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+
+      _emitHandoff(bundle.webview, deltaY: 50);
+      await _settleHandoff(tester);
+
+      expect(scrollController.offset, 50);
+    });
+
+    testWidgets('scrolling clamps to the scrollable extents', (tester) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await _pumpReady(
+        tester,
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+
+      _emitHandoff(bundle.webview, deltaY: 999999);
+      await _settleHandoff(tester);
+      expect(
+        scrollController.offset,
+        scrollController.position.maxScrollExtent,
+      );
+
+      _emitHandoff(bundle.webview, deltaY: -999999, atTop: true);
+      await _settleHandoff(tester);
+      expect(scrollController.offset, 0);
+    });
+
+    testWidgets('disabled config ignores handoff events entirely', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await _pumpReady(
+        tester,
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+        ),
+      );
+
+      _emitHandoff(bundle.webview, deltaY: 50);
+      await _settleHandoff(tester);
+
+      expect(scrollController.offset, 0);
+      bundle.webview.assertNotExecuted('page.setScrollHandoff');
+    });
+
+    testWidgets('touch deltas are ignored unless mobileTouch is enabled', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await _pumpReady(
+        tester,
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+
+      _emitHandoff(bundle.webview, source: 'touch', deltaY: 50);
+      await _settleHandoff(tester);
+      expect(scrollController.offset, 0);
+
+      await tester.pumpWidget(
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(mobileTouch: true),
+        ),
+      );
+      await tester.pump();
+
+      _emitHandoff(bundle.webview, source: 'touch', deltaY: 50);
+      await _settleHandoff(tester);
+      expect(scrollController.offset, 50);
+    });
+
+    testWidgets('an explicit controller wins over the enclosing scrollable', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final enclosingController = ScrollController();
+      addTearDown(enclosingController.dispose);
+      final explicitController = ScrollController();
+      addTearDown(explicitController.dispose);
+
+      await _pumpReady(
+        tester,
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    controller: enclosingController,
+                    child: Column(
+                      children: [
+                        SizedBox(
+                          height: 200,
+                          child: MonacoDiffEditor(
+                            controller: bundle.controller,
+                            scrollHandoff: MonacoScrollHandoff.edge(
+                              controller: explicitController,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 2000, width: 100),
+                      ],
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  height: 100,
+                  child: SingleChildScrollView(
+                    controller: explicitController,
+                    child: const SizedBox(height: 2000, width: 100),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      _emitHandoff(bundle.webview, deltaY: 60);
+      await _settleHandoff(tester);
+
+      expect(explicitController.offset, 60);
+      expect(enclosingController.offset, 0);
+    });
+
+    testWidgets('onHandoff returning true consumes the delta', (tester) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      final seen = <MonacoScrollHandoffDetails>[];
+
+      await _pumpReady(
+        tester,
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: MonacoScrollHandoff.edge(
+            onHandoff: (details) {
+              seen.add(details);
+              return true;
+            },
+          ),
+        ),
+      );
+
+      _emitHandoff(bundle.webview, deltaY: 50);
+      await _settleHandoff(tester);
+
+      expect(seen, hasLength(1));
+      expect(seen.single.deltaY, 50);
+      expect(scrollController.offset, 0);
+    });
+
+    testWidgets('drops deltas silently when no target resolves', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+
+      // No enclosing scrollable and no explicit controller.
+      await _pumpReady(
+        tester,
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              height: 300,
+              child: MonacoDiffEditor(
+                controller: bundle.controller,
+                scrollHandoff: const MonacoScrollHandoff.edge(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      _emitHandoff(bundle.webview, deltaY: 50);
+      await _settleHandoff(tester);
+      // Nothing to assert beyond "no crash": the delta had nowhere to go.
+    });
+
+    testWidgets('same-frame deltas coalesce into one scroll application', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await _pumpReady(
+        tester,
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+
+      var notifications = 0;
+      scrollController.position.addListener(() => notifications++);
+
+      _emitHandoff(bundle.webview, deltaY: 10);
+      _emitHandoff(bundle.webview, deltaY: 15);
+      _emitHandoff(bundle.webview, deltaY: 25);
+      await _settleHandoff(tester);
+
+      expect(scrollController.offset, 50);
+      expect(notifications, 1);
+    });
+
+    testWidgets('syncs JS sources on enable and on rebuild to disabled', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await _pumpReady(
+        tester,
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+
+      var scripts = bundle.webview.scriptsContaining('page.setScrollHandoff');
+      expect(scripts, hasLength(1));
+      expect(scripts.single, contains('"wheel":true'));
+      expect(scripts.single, contains('"touch":false'));
+
+      await tester.pumpWidget(
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+        ),
+      );
+      await tester.pump();
+
+      scripts = bundle.webview.scriptsContaining('page.setScrollHandoff');
+      expect(scripts, hasLength(2));
+      expect(scripts.last, contains('"wheel":false'));
+
+      // Behavioral: after disabling, deltas no longer move the parent.
+      _emitHandoff(bundle.webview, deltaY: 50);
+      await _settleHandoff(tester);
+      expect(scrollController.offset, 0);
+    });
+
+    testWidgets(
+      'removing the diff editor disables sources on an external controller',
+      (tester) async {
+        final bundle = await _createBundle();
+        addTearDown(bundle.controller.dispose);
+        final scrollController = ScrollController();
+        addTearDown(scrollController.dispose);
+
+        await _pumpReady(
+          tester,
+          _diffInScrollView(
+            controller: bundle.controller,
+            scrollController: scrollController,
+            scrollHandoff: const MonacoScrollHandoff.edge(),
+          ),
+        );
+        expect(
+          bundle.webview.scriptsContaining('page.setScrollHandoff'),
+          hasLength(1),
+        );
+
+        await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+        await tester.pump();
+
+        final scripts = bundle.webview.scriptsContaining(
+          'page.setScrollHandoff',
+        );
+        expect(scripts, hasLength(2));
+        expect(scripts.last, contains('"wheel":false'));
+        expect(scripts.last, contains('"touch":false'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What this does

Rebuilds the showcase site around what 3.0 actually shipped, with every claim demonstrated live:

### New section: Rebuilt from the spine out in 3.0
- Six pillar cards (one wire protocol, typed errors, document split, two-phase boot, open typed ids, sparse options).
- The proof: the 2.x -> 3.0 API migration rendered as a **live MonacoDiffEditor** with side-by-side/inline toggle, change navigation, and a live change-region count from `getLineChangeCount()`. The diff follows the page brightness via D27 (null theme).

### Playground upgrades (all live demos)
- **Document tabs** via `openDocument`/`activateDocument` with per-tab dirty dots driven by `MonacoContentChanged.documentUri`.
- **Cmd/Ctrl+S save hook** registered through `controller.addAction` with a real keybinding (also in the context menu).
- **Event feed** showing the sealed `MonacoEvent` union streaming from `controller.events`.
- Status bar shows the **live protocol handshake** (`controller.capabilities`: Monaco version + protocol v3).
- **Edge scroll handoff** enabled, so the page never traps the wheel.

### Dynamic data instead of static
- Version/description/constraints come from the bundled pubspec (what the page actually runs); pub.dev now contributes provenance and live stats only (new `latestPubVersion`, honest 'vX on pub.dev' chip while the page runs a newer build). Stale 2.0.0 fallback bumped.
- Monaco version, language/theme counts, platform list all sourced from the package.

### Package fix (found by the new demos)
`boot.js` now creates the boot document explicitly instead of via the `value`/`language` create options: Monaco's standalone editor *owns* an implicitly created model and **disposes it on the first `setModel`**, which killed the boot document as soon as a second document was activated.

## Verification
- `dart format` clean, `flutter analyze` clean (package + example), **533 package tests + 14 example tests green**.
- Web release build (wasm) driven end-to-end in headless Chrome via CDP: boot handshake clean (protocol 3, lsp+diff capabilities), multi-document round-trip, Cmd+S action, event feed, diff toggle/navigation, light/dark flips (including live diff re-theme), all screenshot-verified with zero console errors.

---

## Update: diff edge scroll handoff + 3.1.0 (`ae5c66e`)

Omar hit "nested scroll does not work" on the showcase. Root cause (verified numerically with a CDP probe): the single-editor handoff worked as designed - the trap was **`MonacoDiffEditor`, which had no scroll handoff at all**, so the wheel died over the migration diff.

- **JS**: the handoff module takes an optional scope (region root + accepted editor DOMs); diff boot wires it to cover **both panes**, with the modified editor as the vertical scroll master. Single-editor behavior is unchanged (no scope = old region rule).
- **Dart**: `MonacoDiffEditor.scrollHandoff` + `MonacoDiffController.onScrollHandoff`/`setScrollHandoffSources`; the per-frame delta engine is extracted to a driver shared by both widgets.
- **Showcase**: the migration diff enables `MonacoScrollHandoff.edge()`.
- **Tests**: 550 package (+17: diff widget suite, diff controller suite, bridge markers) + 14 example, analyzers clean.
- **Browser-verified** on the wasm build: playground both directions; diff side-by-side (original AND modified panes) both directions; inline mode; a continuous gesture over the pinned diff carries the page through the section; zero console errors.
- **Version: 3.1.0** (new public API) with the boot-model ownership fix recorded in the changelog. Note: **merging this PR auto-releases 3.1.0 to pub.dev** via the pubspec-change chain that shipped 3.0.0 - desirable, since pub.dev's 3.0.0 carries the multi-document boot-model bug.
