### PR TITLE
fix(showcase): white specks in hero gradient headline on web

### DIFF
--- a/example/lib/showcase/sections/hero_section.dart
+++ b/example/lib/showcase/sections/hero_section.dart
@@ -51,17 +51,11 @@ class HeroSection extends StatelessWidget {
                             : headlineTop)
                         .copyWith(color: c.textPrimary),
               ),
-              ShaderMask(
-                shaderCallback: (bounds) => accentGradient.createShader(bounds),
-                blendMode: BlendMode.srcIn,
-                child: Text(
-                  'inside your Flutter app.',
-                  style:
-                      (headlineSize != null
-                              ? headlineTop.copyWith(fontSize: headlineSize)
-                              : headlineTop)
-                          .copyWith(color: Colors.white),
-                ),
+              _GradientHeadline(
+                text: 'inside your Flutter app.',
+                style: headlineSize != null
+                    ? headlineTop.copyWith(fontSize: headlineSize)
+                    : headlineTop,
               ),
               const SizedBox(height: Insets.lg),
               ConstrainedBox(
@@ -211,6 +205,45 @@ class _EyebrowPill extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Paints [text] with [accentGradient] applied directly to the glyphs.
+///
+/// This intentionally avoids a [ShaderMask] with [BlendMode.srcIn]: on the
+/// CanvasKit web renderer that composite leaks the masked (white) child
+/// through at anti-aliased glyph edges, showing white specks inside the
+/// gradient text. A `foreground` shader has no separate child layer to leak,
+/// so the artifact cannot occur. The gradient is mapped across the text's
+/// measured bounds so it stays consistent whether the headline renders on one
+/// line or wraps.
+class _GradientHeadline extends StatelessWidget {
+  const _GradientHeadline({required this.text, required this.style});
+
+  final String text;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    final textScaler = MediaQuery.textScalerOf(context);
+    final direction = Directionality.of(context);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final painter = TextPainter(
+          text: TextSpan(text: text, style: style),
+          textDirection: direction,
+          textScaler: textScaler,
+        )..layout(maxWidth: constraints.maxWidth);
+        final rect = Offset.zero & painter.size;
+        return Text(
+          text,
+          textScaler: textScaler,
+          style: style.copyWith(
+            foreground: Paint()..shader = accentGradient.createShader(rect),
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Problem

The showcase hero headline **"inside your Flutter app."** rendered with white specks bleeding through the gradient text on the deployed web build — visible at anti-aliased glyph edges (under the descenders of "app." and around the "inside your" gap).

## Root cause

The headline used `ShaderMask(blendMode: BlendMode.srcIn)` over a white `Text`. On the **CanvasKit** web renderer, the `srcIn` composite leaks the masked white child through at anti-aliased glyph edges. (Ruled out the gradient itself: `accentGradient` has no white stop, and the same gradient used as a `BoxDecoration` fill elsewhere shows no artifact — the bug is unique to `ShaderMask` + `srcIn` over text.)

## Fix

Paint the gradient **directly as the glyph fill** via `TextStyle.foreground = Paint()..shader`, in a new `_GradientHeadline` widget. With no separate masked layer, white cannot leak — the artifact is eliminated by construction rather than patched. The shader `Rect` is measured with a `TextPainter` inside a `LayoutBuilder` so the diagonal gradient maps across the text whether it renders on one line (desktop) or wraps (mobile).

Safe because `ShowcaseText` styles are color-agnostic (`color == null`), so adding `foreground` does not trip the `color`+`foreground` assertion.

## Verification

Built `--wasm --release` and verified in headless Chrome (CanvasKit) against a local server: the gradient headline renders clean with no specks, one line or wrapped, no console exceptions.

Example-only change — no package/pubspec change, so no pub.dev release.