### PR TITLE
fix(web): raise the default boot readyTimeout to 90s on web (3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2026-07-07
+
+### Fixed
+- **Web: flaky "Monaco Editor did not report ready in 20 seconds" on cold-cache first loads.** The default `readyTimeout` was a fixed 20 seconds on every platform, but on web the first (uncached) visit must download the multi-megabyte Monaco bundle over the network - a bandwidth-bound wait, not a hang - so slow connections and just-deployed sites (invalidated CDN caches) tripped the deadline mid-download; a retry then succeeded from the warm browser cache. The default is now platform-aware via `MonacoDefaults.readyTimeout` (20s on native, 90s on web). Hard failures (missing assets, script errors) still surface immediately on every platform; the deadline only backstops silent stalls. The web timeout message now also explains the slow-connection case. Explicitly passed `readyTimeout` values behave exactly as before.
+
 ## [3.1.0] - 2026-07-07
 
 ### Added

--- a/lib/src/common/defaults.dart
+++ b/lib/src/common/defaults.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_monaco/src/options/editor_options.dart';
 import 'package:flutter_monaco/src/options/language.dart';
 import 'package:flutter_monaco/src/options/option_enums.dart';
@@ -31,6 +32,19 @@ abstract final class MonacoDefaults {
     cursorStyle: CursorStyle.line,
     padding: MonacoPadding(top: 10),
   );
+
+  /// Boot deadline applied when the caller leaves `readyTimeout` unset.
+  ///
+  /// Native platforms load Monaco from local files, so 20 seconds only
+  /// trips on a genuinely hung boot. On web the first (cold-cache) visit
+  /// must download the multi-megabyte editor bundle over the network -
+  /// bandwidth-bound, not hang-bound - so the backstop is far more
+  /// generous there. Hard failures (missing assets, script errors) are
+  /// reported immediately through the page's error handlers on every
+  /// platform; this deadline only catches silent stalls.
+  static const Duration readyTimeout = kIsWeb
+      ? Duration(seconds: 90)
+      : Duration(seconds: 20);
 
   /// Document language used when none is configured.
   static const MonacoLanguage language = MonacoLanguage.markdown;

--- a/lib/src/diff/diff_controller.dart
+++ b/lib/src/diff/diff_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/platform/platform_webview.dart';
@@ -54,6 +55,11 @@ class MonacoDiffController {
   /// ...), [diff] the diff-specific behavior (side-by-side vs inline,
   /// ...). [original]/[modified]/[language] seed the two models so the
   /// first painted frame already shows the requested diff.
+  ///
+  /// [readyTimeout] bounds the whole boot; it defaults to
+  /// [MonacoDefaults.readyTimeout] (20s on native, 90s on web where the
+  /// cold-cache first load must download the editor bundle over the
+  /// network).
   static Future<MonacoDiffController> create({
     EditorOptions? options,
     MonacoDiffOptions diff = const MonacoDiffOptions(),
@@ -61,7 +67,7 @@ class MonacoDiffController {
     String modified = '',
     MonacoLanguage language = MonacoLanguage.plaintext,
     MonacoPageConfig page = const MonacoPageConfig(),
-    Duration readyTimeout = const Duration(seconds: 20),
+    Duration readyTimeout = MonacoDefaults.readyTimeout,
   }) async {
     await MonacoAssets.ensureReady();
 
@@ -132,7 +138,10 @@ class MonacoDiffController {
           onTimeout: () => throw MonacoTimeoutError(
             message:
                 'Monaco diff editor did not report ready in '
-                '${readyTimeout.inSeconds} seconds.',
+                '${readyTimeout.inSeconds} seconds.'
+                '${kIsWeb ? ' On web the first load downloads the editor '
+                          'bundle; a slow connection can exceed this deadline. '
+                          'Retrying resumes from the browser cache.' : ''}',
             timeout: readyTimeout,
             operation: 'boot',
           ),

--- a/lib/src/editor/controller.dart
+++ b/lib/src/editor/controller.dart
@@ -148,12 +148,14 @@ class MonacoController {
   ///   [MonacoPageConfig]; changing these requires a new controller.
   /// * [readyTimeout]: Upper bound for the whole boot (asset extraction
   ///   excluded); on expiry [whenReady] completes with a
-  ///   [MonacoTimeoutError].
+  ///   [MonacoTimeoutError]. Defaults to [MonacoDefaults.readyTimeout]
+  ///   (20s on native, 90s on web where the cold-cache first load must
+  ///   download the editor bundle over the network).
   static Future<MonacoController> create({
     EditorOptions? options,
     String? initialText,
     MonacoPageConfig page = const MonacoPageConfig(),
-    Duration readyTimeout = const Duration(seconds: 20),
+    Duration readyTimeout = MonacoDefaults.readyTimeout,
   }) async {
     // Ensure Monaco assets are ready
     await MonacoAssets.ensureReady();
@@ -239,7 +241,10 @@ class MonacoController {
           onTimeout: () => throw MonacoTimeoutError(
             message:
                 'Monaco Editor did not report ready in '
-                '${readyTimeout.inSeconds} seconds.',
+                '${readyTimeout.inSeconds} seconds.'
+                '${kIsWeb ? ' On web the first load downloads the editor '
+                          'bundle; a slow connection can exceed this deadline. '
+                          'Retrying resumes from the browser cache.' : ''}',
             timeout: readyTimeout,
             operation: 'boot',
           ),

--- a/lib/src/widgets/monaco_diff_editor.dart
+++ b/lib/src/widgets/monaco_diff_editor.dart
@@ -33,7 +33,7 @@ class MonacoDiffEditor extends StatefulWidget {
     this.options = const EditorOptions(),
     this.diffOptions = const MonacoDiffOptions(),
     this.page = const MonacoPageConfig(),
-    this.readyTimeout = const Duration(seconds: 20),
+    this.readyTimeout = MonacoDefaults.readyTimeout,
     this.scrollHandoff = const MonacoScrollHandoff.disabled(),
     this.onReady,
     this.onError,
@@ -87,6 +87,12 @@ class MonacoDiffEditor extends StatefulWidget {
   final MonacoScrollHandoff scrollHandoff;
 
   /// The maximum duration to wait for the diff editor to initialize.
+  ///
+  /// Defaults to [MonacoDefaults.readyTimeout]: 20s on native platforms
+  /// (local assets, so expiry means a hung boot) and 90s on web, where the
+  /// cold-cache first load must download the multi-megabyte editor bundle
+  /// and is bound by bandwidth, not by a hang. Hard failures surface
+  /// immediately regardless of this deadline.
   final Duration readyTimeout;
 
   /// Callback invoked when the diff editor is ready.

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -84,7 +84,7 @@ class MonacoEditor extends StatefulWidget {
     this.initialSelection,
     this.autofocus = false,
     this.page = const MonacoPageConfig(),
-    this.readyTimeout = const Duration(seconds: 20),
+    this.readyTimeout = MonacoDefaults.readyTimeout,
     this.onReady,
     this.onError,
     this.onContentChanged,
@@ -141,7 +141,14 @@ class MonacoEditor extends StatefulWidget {
   /// triggers a full reload of the editor.
   final MonacoPageConfig page;
 
-  /// The maximum duration to wait for the editor to initialize before showing an error.
+  /// The maximum duration to wait for the editor to initialize before
+  /// showing an error.
+  ///
+  /// Defaults to [MonacoDefaults.readyTimeout]: 20s on native platforms
+  /// (local assets, so expiry means a hung boot) and 90s on web, where the
+  /// cold-cache first load must download the multi-megabyte editor bundle
+  /// and is bound by bandwidth, not by a hang. Hard failures surface
+  /// immediately regardless of this deadline.
   final Duration readyTimeout;
 
   /// Callback invoked when the editor is fully initialized and ready.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 3.1.0
+version: 3.1.1
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues


### PR DESCRIPTION
## Problem

The deployed showcase (and any flutter_monaco web app) sometimes fails to boot with:

> **Failed to Initialize Editor** - `MonacoTimeoutError(boot): Monaco Editor did not report ready in 20 seconds.`

It is flaky - mostly the first load after a deploy - and pressing **Retry** always fixes it.

## Root cause (reproduced deterministically)

The default `readyTimeout` was a fixed `Duration(seconds: 20)` on every platform. On native platforms Monaco loads from local files, so 20s only trips on a genuinely hung boot. On web, however, the deadline also covers downloading the Monaco bundle over the network - `loader.js` + bridge scripts + the **3.6 MB `editor.api` chunk** (+ css/fonts) - per editor iframe. That wait is **bandwidth-bound, not hang-bound**:

- First load after a deploy invalidates the GitHub Pages CDN cache and the browser cache is cold → the full download races the 20s deadline and loses on anything but a fast connection.
- The showcase mounts **two** editors at startup (playground + migration diff), and the two iframes each fetch the 3.6 MB chunk (no cross-document request dedup), doubling the payload.
- **Retry** always works because the second attempt resumes from the now-warm browser/CDN cache.

Reproduced against the live site with a cold cache at 2 Mbps (headless Chrome, CDP `emulateNetworkConditions`): the exact error panel appears, and the network log shows the widget's 20s deadline **aborting the still-streaming `editor.api` download** (`net::ERR_ABORTED`). Hard failures were ruled out: the page's `loader.js onerror` / `require` error handlers report real load errors immediately and none fired.

## Fix

`kIsWeb` is a compile-time constant, so the default becomes platform-aware with **zero API shape change**:

- New `MonacoDefaults.readyTimeout`: `20s` on native, `90s` on web; it is now the default for `MonacoEditor`, `MonacoDiffEditor`, `MonacoController.create`, and `MonacoDiffController.create`.
- Explicitly passed `readyTimeout` values behave exactly as before.
- Hard failures (missing assets, script errors) still surface immediately on every platform - the deadline only backstops silent stalls, which is all it was ever able to detect.
- The web timeout message now explains the slow-connection case and that Retry resumes from the browser cache.

## Verification

- `dart analyze`: no issues; `flutter test`: 550/550 pass.
- Rebuilt the showcase and re-ran the same cold-cache 2 Mbps probe against the fixed build (served uncompressed locally - harsher than production): the playground rides out the slow download and comes up ready; no error panel.

## Release

Bumps `3.1.0 → 3.1.1` (patch: behavioral default change only). Merging auto-releases to pub.dev via the pubspec-change chain.

## Possible follow-ups (out of scope)

- Dedup/stagger concurrent first boots on web so N editors don't download the bundle N times.
- Preload the Monaco bundle from the host page to overlap it with the Flutter engine download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
