### PR TITLE
perf(web): MonacoAssets.precache() + host-page warmup for the Monaco bundle (3.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-07-07
+
+### Added
+- **`MonacoAssets.precache()`: warm Monaco before the first editor mounts.** On web it fetches the AMD loader, `editor.main.js`/`.css`, and the hash-named editor chunk (~3.6MB, discovered from `editor.main.js` at runtime so it survives Monaco upgrades) into the browser's HTTP cache; the first editor boot is then served from cache instead of starting a multi-megabyte download at mount time. Best-effort and boot-path-untouched: a failed warmup just means the editor downloads the files itself as before. On native platforms it is equivalent to `ensureReady()` (asset extraction). Fire-and-forget from `main()` is the intended use. The README's new "Web performance" section also documents an `index.html` snippet (used by the live demo) that starts the warmup in parallel with the Flutter engine download itself.
+
+### Notes
+- Investigated the suspected duplicate bundle download when several editors boot at once on web: with the HTTP cache enabled, browsers coalesce the concurrent identical requests (verified in Chromium - the second iframe's request completes with zero bytes on the wire), so no boot-path serialization was added. Precaching additionally guarantees single-download behavior on any browser.
+
 ## [3.1.1] - 2026-07-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -906,6 +906,64 @@ print('${info.fileCount} files, ${info.totalSizeMB.toStringAsFixed(1)} MB');
 await MonacoAssets.clearCache();
 ```
 
+### Web performance: precache the Monaco bundle
+
+Web platform only; on native `precache()` is simply `ensureReady()`.
+
+On Flutter Web the first (cold-cache) editor boot downloads Monaco over the
+network - dominated by one hash-named ~3.6MB chunk - and that download only
+starts when the first editor mounts. Warm the browser's HTTP cache ahead of
+time and every editor (including several mounting at once) boots from cache:
+
+```dart
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  unawaited(MonacoAssets.precache()); // fire-and-forget
+  runApp(const MyApp());
+}
+```
+
+The warmup is best-effort: if any fetch fails, the editor downloads the
+files itself exactly as before.
+
+To start the warmup even earlier - in parallel with the Flutter engine
+download itself - add this snippet to your `web/index.html` (this is what
+the [live demo](https://omar-hanafy.github.io/flutter-monaco/) ships):
+
+```html
+<script>
+  // Warm the HTTP cache with Monaco's files while the Flutter engine
+  // downloads. The hashed chunk name changes per Monaco release, so it is
+  // recovered from editor.main.js instead of hard-coded.
+  (function () {
+    'use strict';
+    var vs = 'assets/packages/flutter_monaco/assets/monaco/min/vs/';
+    function warm(file) {
+      return fetch(vs + file, { priority: 'low' })
+        .then(function (r) { return r.ok ? r.arrayBuffer() : null; })
+        .catch(function () {});
+    }
+    warm('loader.js');
+    warm('editor/editor.main.css');
+    fetch(vs + 'editor/editor.main.js', { priority: 'low' })
+      .then(function (r) { return r.ok ? r.text() : ''; })
+      .then(function (src) {
+        var seen = {};
+        var re = /\.\.\/(editor\.api-[A-Za-z0-9_-]+)/g;
+        var m;
+        while ((m = re.exec(src || '')) !== null) {
+          if (!seen[m[1]]) { seen[m[1]] = true; warm(m[1] + '.js'); }
+        }
+      })
+      .catch(function () {});
+  })();
+</script>
+```
+
+If you deploy with a non-root `--base-href`, keep the snippet's URLs
+relative (as above) so they resolve against `<base href>` like every other
+Flutter asset.
+
 ### Web: Handling Overlays
 
 Web platform only. This does not affect native platforms.

--- a/README.md
+++ b/README.md
@@ -964,6 +964,18 @@ If you deploy with a non-root `--base-href`, keep the snippet's URLs
 relative (as above) so they resolve against `<base href>` like every other
 Flutter asset.
 
+What to expect: warming moves the download earlier, it does not add
+bandwidth - on a connection fully saturated by the initial load the total
+time until an editor is interactive stays the same. The win is that the
+editor is served from cache the moment it mounts (no multi-megabyte fetch
+racing `readyTimeout` after first frame), which is a strict improvement
+whenever your first editor appears after startup - behind navigation, a
+tab, or below the fold. The `{ priority: 'low' }` hint keeps the warmup
+behind the engine download on HTTP/2 servers; on plain HTTP/1.1 the two
+share connections, which can delay first paint on slow links - if your
+very first screen is an editor and your users are bandwidth-constrained,
+prefer `MonacoAssets.precache()` over the `index.html` snippet.
+
 ### Web: Handling Overlays
 
 Web platform only. This does not affect native platforms.

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -90,6 +90,38 @@
     <div class="spinner"></div>
   </div>
   <script>
+    // Warm the browser HTTP cache with Monaco's files while the Flutter
+    // engine downloads, so the editor iframes boot from cache instead of
+    // starting a multi-megabyte download after first frame. Best-effort:
+    // any failure just means the editor downloads the files itself.
+    // low-priority fetches keep the engine download in front. The hashed
+    // editor chunk name changes with every Monaco release, so it is
+    // recovered from editor.main.js instead of hard-coded. Bodies are read
+    // to completion because the cache only commits consumed responses.
+    (function () {
+      'use strict';
+      var vs = 'assets/packages/flutter_monaco/assets/monaco/min/vs/';
+      function warm(file) {
+        return fetch(vs + file, { priority: 'low' })
+          .then(function (r) { return r.ok ? r.arrayBuffer() : null; })
+          .catch(function () {});
+      }
+      warm('loader.js');
+      warm('editor/editor.main.css');
+      fetch(vs + 'editor/editor.main.js', { priority: 'low' })
+        .then(function (r) { return r.ok ? r.text() : ''; })
+        .then(function (src) {
+          var seen = {};
+          var re = /\.\.\/(editor\.api-[A-Za-z0-9_-]+)/g;
+          var m;
+          while ((m = re.exec(src || '')) !== null) {
+            if (!seen[m[1]]) { seen[m[1]] = true; warm(m[1] + '.js'); }
+          }
+        })
+        .catch(function () {});
+    })();
+  </script>
+  <script>
     window.addEventListener('flutter-first-frame', function () {
       var el = document.getElementById('loading');
       if (!el) return;

--- a/lib/src/assets/monaco_assets.dart
+++ b/lib/src/assets/monaco_assets.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_monaco/src/assets/asset_diagnostics.dart';
 import 'package:flutter_monaco/src/assets/asset_storage.dart';
+import 'package:flutter_monaco/src/assets/web_precache_stub.dart'
+    if (dart.library.js_interop) 'package:flutter_monaco/src/assets/web_precache_web.dart';
 
 /// The Flutter asset path where Monaco Editor files are bundled.
 ///
@@ -135,6 +137,42 @@ class MonacoAssets {
     }
 
     return completer.future;
+  }
+
+  /// Prepares this platform so the first editor boots as fast as possible.
+  ///
+  /// On **native** platforms this is [ensureReady]: Monaco's files are
+  /// extracted from the app bundle to local storage (and any extraction
+  /// error propagates, exactly as from [ensureReady]).
+  ///
+  /// On **web** it additionally warms the browser's HTTP cache with the
+  /// files the boot will request - the AMD loader, `editor.main.js`/`.css`,
+  /// and the hash-named editor chunk (~3.6MB) that dominates a cold first
+  /// load. The warmup is best-effort and never throws: if any fetch fails,
+  /// the boot simply downloads those files itself as usual. When several
+  /// editors boot at once they all hit the warmed cache, so the bundle is
+  /// downloaded once no matter how many editors mount.
+  ///
+  /// Call it early - fire-and-forget from `main()` is the intended use, so
+  /// the download overlaps app startup instead of starting when the first
+  /// editor mounts:
+  ///
+  /// ```dart
+  /// void main() {
+  ///   WidgetsFlutterBinding.ensureInitialized();
+  ///   unawaited(MonacoAssets.precache());
+  ///   runApp(const MyApp());
+  /// }
+  /// ```
+  ///
+  /// For web apps that want the warmup to start even before the Flutter
+  /// engine downloads, see the "Web performance" section of the README for
+  /// an equivalent `index.html` snippet.
+  static Future<void> precache() async {
+    await ensureReady();
+    if (kIsWeb) {
+      await precacheMonacoWebAssets();
+    }
   }
 
   /// Returns typed diagnostics about the extracted Monaco assets.

--- a/lib/src/assets/warmup_manifest.dart
+++ b/lib/src/assets/warmup_manifest.dart
@@ -1,0 +1,34 @@
+/// Which Monaco files are worth warming into the browser's HTTP cache
+/// before the first editor boots on web.
+///
+/// Internal: consumed by the web precache implementation and its tests; not
+/// exported by the barrel.
+library;
+
+/// Files (relative to `min/vs/`) that every boot loads and whose names are
+/// stable across Monaco releases.
+///
+/// The list is ordered smallest-first so the boot-critical loader is cached
+/// even if warmup is interrupted early.
+const List<String> monacoWarmupStaticFiles = [
+  'loader.js',
+  'editor/editor.main.js',
+  'editor/editor.main.css',
+];
+
+/// Extracts the hash-named editor chunks that `editor.main.js` declares as
+/// AMD dependencies, as paths relative to `min/vs/`.
+///
+/// Monaco 0.55+ ships the bulk of the editor (~3.6MB) in a content-hashed
+/// sibling chunk that `min/vs/editor/editor.main.js` requires as
+/// `"../editor.api-<hash>"`. The hash changes with every Monaco release, so
+/// it cannot be hard-coded; it is recovered from the entry module's source
+/// instead. Returns an empty list when no chunk reference is found (older
+/// or restructured Monaco builds) - warmup then simply covers the static
+/// files and the boot fetches the rest as usual.
+List<String> extractMonacoWarmupChunks(String editorMainSource) {
+  final chunkRef = RegExp(r'\.\./(editor\.api-[A-Za-z0-9_-]+)');
+  return {
+    for (final match in chunkRef.allMatches(editorMainSource)) '${match[1]}.js',
+  }.toList();
+}

--- a/lib/src/assets/web_precache_stub.dart
+++ b/lib/src/assets/web_precache_stub.dart
@@ -1,0 +1,6 @@
+/// Native stand-in for the web precache implementation.
+///
+/// `MonacoAssets.precache` only calls this behind a `kIsWeb` check; on
+/// native platforms asset readiness is handled by extraction in
+/// `MonacoAssets.ensureReady`, so there is nothing to warm here.
+Future<void> precacheMonacoWebAssets() async {}

--- a/lib/src/assets/web_precache_web.dart
+++ b/lib/src/assets/web_precache_web.dart
@@ -1,0 +1,64 @@
+import 'dart:js_interop';
+import 'dart:ui_web' as ui_web;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_monaco/src/assets/monaco_assets.dart';
+import 'package:flutter_monaco/src/assets/warmup_manifest.dart';
+import 'package:flutter_monaco/src/platform/web_asset_resolver.dart';
+import 'package:web/web.dart' as web;
+
+/// Warms the browser's HTTP cache with the Monaco files the first editor
+/// boot will request, so the boot inside the editor iframe is served from
+/// cache instead of the network.
+///
+/// The whole routine is best-effort: every fetch failure is swallowed and
+/// the boot path is completely untouched - a failed warmup just means the
+/// iframe downloads the files itself, exactly as it does today. Responses
+/// are read to completion because the browser only commits a fetch to the
+/// HTTP cache once its body has been consumed.
+Future<void> precacheMonacoWebAssets() async {
+  try {
+    final vsBase = resolveWebAssetUrl(
+      web.document.baseURI,
+      ui_web.assetManager.getAssetUrl('$monacoAssetBaseDir/min/vs'),
+    );
+
+    // The hash-named bulk chunk (~3.6MB) is discovered from editor.main.js,
+    // so that fetch gates the chunk warms; the other static files warm
+    // concurrently.
+    final concurrent = <Future<void>>[
+      for (final file in monacoWarmupStaticFiles)
+        if (file != 'editor/editor.main.js') _fetchAndDiscard('$vsBase/$file'),
+    ];
+
+    final editorMainSource = await _fetchText('$vsBase/editor/editor.main.js');
+    if (editorMainSource != null) {
+      for (final chunk in extractMonacoWarmupChunks(editorMainSource)) {
+        concurrent.add(_fetchAndDiscard('$vsBase/$chunk'));
+      }
+    }
+
+    await Future.wait(concurrent);
+    debugPrint('[MonacoAssets] Web warmup finished for $vsBase');
+  } catch (e) {
+    debugPrint('[MonacoAssets] Web warmup skipped: $e');
+  }
+}
+
+Future<String?> _fetchText(String url) async {
+  try {
+    final response = await web.window.fetch(url.toJS).toDart;
+    if (!response.ok) return null;
+    return (await response.text().toDart).toDart;
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<void> _fetchAndDiscard(String url) async {
+  try {
+    final response = await web.window.fetch(url.toJS).toDart;
+    if (!response.ok) return;
+    await response.arrayBuffer().toDart;
+  } catch (_) {}
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 3.1.1
+version: 3.2.0
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/assets/warmup_manifest_test.dart
+++ b/test/assets/warmup_manifest_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter_monaco/src/assets/warmup_manifest.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The web warmup discovers Monaco's hash-named bulk chunk from
+/// `editor.main.js` at runtime. These tests pin the parsing rules and guard
+/// against a Monaco upgrade silently changing the chunk-reference format
+/// (which would degrade warmup to the static files only).
+void main() {
+  group('extractMonacoWarmupChunks', () {
+    test('finds the hashed editor.api chunk in an AMD dependency list', () {
+      const source =
+          'define(["require","exports","./nls.messages-loader.js!",'
+          '"../monaco.contribution-D2OdxNBt","../editor.api-CalNCsUg",'
+          '"../workers-DcJshg-q"],(function(a,b){}))';
+      expect(extractMonacoWarmupChunks(source), ['editor.api-CalNCsUg.js']);
+    });
+
+    test('deduplicates repeated references', () {
+      const source = '"../editor.api-AbCd_123" "../editor.api-AbCd_123"';
+      expect(extractMonacoWarmupChunks(source), ['editor.api-AbCd_123.js']);
+    });
+
+    test('returns empty for sources without a chunk reference', () {
+      expect(extractMonacoWarmupChunks('define([],function(){})'), isEmpty);
+      expect(extractMonacoWarmupChunks(''), isEmpty);
+    });
+
+    test('bundled editor.main.js yields exactly one chunk', () {
+      final source = File(
+        'assets/monaco/min/vs/editor/editor.main.js',
+      ).readAsStringSync();
+      final chunks = extractMonacoWarmupChunks(source);
+      expect(
+        chunks,
+        hasLength(1),
+        reason:
+            'Monaco changed how editor.main.js references its bulk chunk; '
+            'update extractMonacoWarmupChunks so web warmup keeps covering '
+            'the multi-megabyte download.',
+      );
+      expect(
+        chunks.single,
+        matches(RegExp(r'^editor\.api-[A-Za-z0-9_-]+\.js$')),
+      );
+      final chunkFile = File('assets/monaco/min/vs/${chunks.single}');
+      expect(
+        chunkFile.existsSync(),
+        isTrue,
+        reason: 'referenced chunk ${chunks.single} is not in the bundle',
+      );
+      expect(
+        chunkFile.lengthSync(),
+        greaterThan(1024 * 1024),
+        reason: 'the discovered chunk should be the multi-megabyte editor bulk',
+      );
+    });
+
+    test('static warmup files exist in the bundle', () {
+      for (final file in monacoWarmupStaticFiles) {
+        expect(
+          File('assets/monaco/min/vs/$file').existsSync(),
+          isTrue,
+          reason: '$file is missing from the Monaco bundle',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds `MonacoAssets.precache()` - a public API that warms Monaco before the first editor mounts - and ships an equivalent `index.html` warmup snippet in the showcase. Bumps to **3.2.0** (new public API).

- **Web:** fetches the AMD loader, `editor.main.js`/`.css`, and the hash-named bulk chunk (~3.6MB) into the browser's HTTP cache. The chunk name changes every Monaco release, so it is discovered from `editor.main.js` at runtime (`extractMonacoWarmupChunks`, unit-tested against the bundled asset so a Monaco upgrade that changes the reference format fails CI instead of silently degrading warmup).
- **Native:** equivalent to `ensureReady()` (asset extraction).
- Best-effort by design: the boot path is untouched; any warmup failure just means the editor downloads the files itself exactly as before.
- Showcase `web/index.html` ships the same warmup as a plain JS snippet so it starts in parallel with the Flutter engine download itself; README documents both and their tradeoffs.

## Why (follow-ups from #31)

Two follow-ups were noted in #31: dedup the suspected duplicate bundle download when two editors boot at once, and preload the bundle from the host page.

**Dedup - investigated, no code needed.** The "7.2MB double download" seen while reproducing #31 was an artifact of probing with the HTTP cache disabled. With the cache enabled (real browsers), Chromium coalesces the two iframes' concurrent identical requests: the second `editor.api` request completes with **0 bytes on the wire** at the same instant as the first. No boot-path serialization was added; precaching additionally guarantees single-download behavior on any browser.

**Preload - shipped, with honest expectations.** Warming moves the download earlier; it does not add bandwidth. Measured A/B (cold cache, throttled CDP probes):

| | live before | live after (snippet) |
|---|---|---|
| editor iframes mount | 4.8s | 5.6s |
| bulk chunk fully cached | 7.6s | **3.8s** |
| editors ready | 7.8s | 7.5s |

(8Mbps, GH Pages h2 + brotli - the chunk is ~938KB on the wire there.) On a fully saturated pipe total time-to-editor is physics-bound and unchanged; the win is that the editor boots from cache the moment it mounts - no multi-megabyte fetch racing `readyTimeout` after first frame - which is a strict improvement whenever the first editor appears after startup (navigation, tab, below the fold).

## Verification

- `dart analyze` clean; **555/555 tests pass** (5 new for the warmup manifest).
- Runtime smoke of the Dart path: temporary `precache()` call in the basic example, built for web - the parent page fetched all four files, discovered the hashed chunk, and the editor iframe's requests all hit the disk cache (`0KB, cache=true`).
- Showcase snippet verified live post-deploy (table above); iframe boots served entirely from cache.

Merging auto-releases **3.2.0** to pub.dev.
