### PR TITLE
feat: scroll handoff boundary lock - gesture ownership stops momentum leakage (3.4.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: node --check every bridge script
         run: find assets/monaco/bridge -name '*.js' -print -exec node --check {} +
       - name: Execute the real bridge against the Monaco stub
-        run: node --test tool/bridge_tests/editor_api_test.mjs
+        run: node --test tool/bridge_tests/*_test.mjs
 
   pana:
     name: Pana

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.4.0] - 2026-07-10
-
-Edge scroll handoff gains native nested-scroll boundary behavior: the gesture that reaches the editor's scroll edge stops there instead of jerking the surrounding page.
-
-### Changed
-- **Edge scroll handoff absorbs a gesture's remaining momentum at the editor's scroll boundary.** A wheel/trackpad gesture that starts inside the editor now stops dead at the edge, inertial tail included; the host page scrolls only when a physically distinct gesture starts while the editor is already at its edge. Reversing direction still hands input back to the editor immediately. This is the new default (`MonacoScrollBoundaryPolicy.newGestureOnly`); restore the previous unconsumed-delta chaining with `MonacoScrollHandoff.edge(policy: MonacoScrollBoundaryPolicy.continuous)` or the `policy` parameter of `setScrollHandoffSources`.
-- Experimental touch forwarding under the default policy decides ownership once per drag: a drag that starts over scrollable editor content belongs to the editor for its whole lifetime (contained at the edge), and only a drag that starts at an outward edge scrolls the host.
-
-### Added
-- `MonacoScrollBoundaryPolicy` (`newGestureOnly` | `continuous`) on `MonacoScrollHandoff.edge` and on `setScrollHandoffSources` of both controllers.
-- Host-owned handoff gestures arrive sessionized: `MonacoScrollHandoffDetails` gains `phase` (`begin`/`update`/`end`/`cancel` via `MonacoScrollHandoffPhase`), `gestureId`, and `momentum`. The built-in scrolling applies updates only for the gesture it saw begin, so stale deltas can never move the host; custom `onScrollHandoff` consumers can enforce the same rule. Payloads without session fields keep working unchanged.
-
 ## [3.3.0] - 2026-07-10
 
-Correctness release driven by an external architecture audit of v3: two release-blocking fixes (dirty tracking, boot-error propagation), a set of lifecycle repairs, and small API additions. No public API is removed.
+Two independent improvements in one release. Correctness fixes driven by an external architecture audit of v3: two release-blocking fixes (dirty tracking, boot-error propagation), a set of lifecycle repairs, and small API additions; no public API is removed. And edge scroll handoff gains native nested-scroll boundary behavior: the gesture that reaches the editor's scroll edge stops there instead of jerking the surrounding page.
 
 ### Fixed
 - **Dirty tracking no longer misses the first edit.** Dirty baselines were created lazily on the first `isDirty()` query, so querying after the first edit recorded the already-edited version as "clean" and returned `false` - the exact pattern of updating a dirty marker from `onContentChanged`. Every document (the boot document and each `openDocument`) is now baselined at creation.
@@ -40,12 +28,16 @@ Correctness release driven by an external architecture audit of v3: two release-
 - **`MonacoViewState` is now truly value-typed:** `toJson()` returns an independent deep copy and equality/hashCode are deep over nested payloads.
 
 ### Changed
+- **Edge scroll handoff absorbs a gesture's remaining momentum at the editor's scroll boundary.** A wheel/trackpad gesture that starts inside the editor now stops dead at the edge, inertial tail included; the host page scrolls only when a physically distinct gesture starts while the editor is already at its edge. Reversing direction still hands input back to the editor immediately. This is the new default (`MonacoScrollBoundaryPolicy.newGestureOnly`); restore the previous unconsumed-delta chaining with `MonacoScrollHandoff.edge(policy: MonacoScrollBoundaryPolicy.continuous)` or the `policy` parameter of `setScrollHandoffSources`.
+- Experimental touch forwarding under the default policy decides ownership once per drag: a drag that starts over scrollable editor content belongs to the editor for its whole lifetime (contained at the edge), and only a drag that starts at an outward edge scrolls the host.
 - **`MonacoDiffController.getLineChangeCount` is loud about an uncomputed diff:** when Monaco has not finished computing (throttled/offscreen views) it throws `MonacoTimeoutError` instead of silently returning `0`, so zero always means a real "no changes" result. `diff.getState` reports the pending state as a `null` count.
 - **`MonacoDocument.lineAt` is strict:** reading a line beyond the end of the document now throws instead of silently clamping to the last line. The ranged `getLines` keeps its documented clamping.
 - **Content-change events also truncate on change count:** deltas are omitted (with `truncated: true`) for events carrying more than 1000 individual changes, not only for 64 KiB of inserted text - multi-cursor edit storms previously shipped unbounded envelopes.
 - **`LanguageServerConnection.disconnect()` now completes only after a bridged transport's `onClose` finished** - for `LspServerProcess`, that means the local server process has exited.
 
 ### Added
+- `MonacoScrollBoundaryPolicy` (`newGestureOnly` | `continuous`) on `MonacoScrollHandoff.edge` and on `setScrollHandoffSources` of both controllers.
+- Host-owned handoff gestures arrive sessionized: `MonacoScrollHandoffDetails` gains `phase` (`begin`/`update`/`end`/`cancel` via `MonacoScrollHandoffPhase`), `gestureId`, and `momentum`. The built-in scrolling applies updates only for the gesture it saw begin, so stale deltas can never move the host; custom `onScrollHandoff` consumers can enforce the same rule. Payloads without session fields keep working unchanged.
 - **`MonacoCapabilities.raw` and `supports(String)`**: the verbatim capability strings from the page handshake, so apps can feature-gate capabilities this package version has no typed field for.
 - **`FindOptions.searchOnlyEditableRange` and `limitResultCount` are now honored** by `findMatches`/`replaceMatches` (they previously serialized but had no effect); `limitResultCount` composes with the `limit` parameter as the smaller cap.
 - **`MonacoPageConfig.stableCacheKey()`**: a process-stable digest of the page configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-07-10
+
+Edge scroll handoff gains native nested-scroll boundary behavior: the gesture that reaches the editor's scroll edge stops there instead of jerking the surrounding page.
+
+### Changed
+- **Edge scroll handoff absorbs a gesture's remaining momentum at the editor's scroll boundary.** A wheel/trackpad gesture that starts inside the editor now stops dead at the edge, inertial tail included; the host page scrolls only when a physically distinct gesture starts while the editor is already at its edge. Reversing direction still hands input back to the editor immediately. This is the new default (`MonacoScrollBoundaryPolicy.newGestureOnly`); restore the previous unconsumed-delta chaining with `MonacoScrollHandoff.edge(policy: MonacoScrollBoundaryPolicy.continuous)` or the `policy` parameter of `setScrollHandoffSources`.
+- Experimental touch forwarding under the default policy decides ownership once per drag: a drag that starts over scrollable editor content belongs to the editor for its whole lifetime (contained at the edge), and only a drag that starts at an outward edge scrolls the host.
+
+### Added
+- `MonacoScrollBoundaryPolicy` (`newGestureOnly` | `continuous`) on `MonacoScrollHandoff.edge` and on `setScrollHandoffSources` of both controllers.
+- Host-owned handoff gestures arrive sessionized: `MonacoScrollHandoffDetails` gains `phase` (`begin`/`update`/`end`/`cancel` via `MonacoScrollHandoffPhase`), `gestureId`, and `momentum`. The built-in scrolling applies updates only for the gesture it saw begin, so stale deltas can never move the host; custom `onScrollHandoff` consumers can enforce the same rule. Payloads without session fields keep working unchanged.
+
 ## [3.3.0] - 2026-07-10
 
 Correctness release driven by an external architecture audit of v3: two release-blocking fixes (dirty tracking, boot-error propagation), a set of lifecycle repairs, and small API additions. No public API is removed.

--- a/README.md
+++ b/README.md
@@ -506,12 +506,20 @@ SingleChildScrollView(
 
 Behavior with `MonacoScrollHandoff.edge()`:
 
-- A scrollable editor consumes the wheel until its top/bottom edge, then the page continues scrolling; reversing direction immediately returns the wheel to the editor.
-- A non-scrollable editor (short snippet) hands everything off, so the page scrolls straight through it.
+- A scrollable editor consumes the wheel until its top/bottom edge. The gesture that reaches the edge **stops there**: its remaining input, trackpad momentum included, is absorbed like a native nested scroll "wall" and never jerks the page. To scroll the page, stop and start a new gesture while the editor is at its edge; reversing direction immediately returns the wheel to the editor.
+- A non-scrollable editor (short snippet) hands new gestures straight to the page, so the page scrolls through it.
 - The delta goes to the explicit `controller` if provided, otherwise to the nearest enclosing vertical `Scrollable` (`useNearestScrollable: true` by default). Provide `onHandoff` and return `true` to consume deltas yourself.
 - Ctrl/meta wheel (editor `mouseWheelZoom`, browser zoom, macOS pinch) is never handed off, and Monaco-owned scrollable overlays (suggest list, hover docs, menus, peek editors) keep their own wheel handling.
 - `scrollBeyondLastLine` blank space counts as editor-scrollable; set it to `false` in `EditorOptions` if you want handoff to begin at the real last line.
 - Multiple editors route independently: each editor forwards only to its own configured target.
+
+The boundary behavior is a policy. `MonacoScrollBoundaryPolicy.newGestureOnly` (the default since 3.4.0) gives the native wall feel described above; `MonacoScrollBoundaryPolicy.continuous` restores the pre-3.4 behavior where every unconsumed delta chains to the page immediately, mid-gesture:
+
+```dart
+MonacoScrollHandoff.edge(
+  policy: MonacoScrollBoundaryPolicy.continuous, // opt out of the wall
+)
+```
 
 Headless / custom-widget integrations can skip the widget wiring and consume the stream directly:
 
@@ -526,7 +534,7 @@ controller.onScrollHandoff.listen((details) {
 
 This is **edge scroll handoff, not native nested scrolling**. Monaco lives inside a WebView/iframe, so the platform gesture itself never enters Flutter's gesture arena; the package forwards the unconsumed scroll intent across the bridge instead. Wheel and trackpad input is the stable, supported source on macOS, Windows, and desktop web (plus external mice on mobile where the WebView reports wheel events).
 
-Touch forwarding is a separate, **experimental** opt-in (`mobileTouch: true`). It is observation-only: it never blocks Monaco's own touch handling, never opens the keyboard, and yields to text selection, but there is no native momentum or fling transfer, and iOS Safari on Flutter Web remains best-effort.
+Touch forwarding is a separate, **experimental** opt-in (`mobileTouch: true`). It is observation-only: it never blocks Monaco's own touch handling, never opens the keyboard, and yields to text selection, but there is no native momentum or fling transfer, and iOS Safari on Flutter Web remains best-effort. Under the default boundary policy a drag that starts over scrollable editor content belongs to the editor for its whole lifetime (it is contained at the edge); only a drag that starts while the editor is already at the edge scrolls the page.
 
 See `example/lib/scroll_handoff_example.dart` for a full page with short, long, and handoff-disabled editors.
 

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Behavior with `MonacoScrollHandoff.edge()`:
 - `scrollBeyondLastLine` blank space counts as editor-scrollable; set it to `false` in `EditorOptions` if you want handoff to begin at the real last line.
 - Multiple editors route independently: each editor forwards only to its own configured target.
 
-The boundary behavior is a policy. `MonacoScrollBoundaryPolicy.newGestureOnly` (the default since 3.4.0) gives the native wall feel described above; `MonacoScrollBoundaryPolicy.continuous` restores the pre-3.4 behavior where every unconsumed delta chains to the page immediately, mid-gesture:
+The boundary behavior is a policy. `MonacoScrollBoundaryPolicy.newGestureOnly` (the default since 3.3.0) gives the native wall feel described above; `MonacoScrollBoundaryPolicy.continuous` restores the pre-3.3 behavior where every unconsumed delta chains to the page immediately, mid-gesture:
 
 ```dart
 MonacoScrollHandoff.edge(

--- a/assets/monaco/bridge/boot.js
+++ b/assets/monaco/bridge/boot.js
@@ -80,6 +80,9 @@ window.__FMB = window.__FMB || {};
                   window.flutterMonaco.setScrollHandoff({
                     wheel: !!diffScrollHandoff.wheel,
                     touch: !!diffScrollHandoff.touch,
+                    policy: typeof diffScrollHandoff.policy === 'string'
+                      ? diffScrollHandoff.policy
+                      : undefined,
                   });
                 }
                 window.FlutterMonaco.lifecycle('ready');
@@ -150,6 +153,9 @@ window.__FMB = window.__FMB || {};
                 window.flutterMonaco.setScrollHandoff({
                   wheel: !!bootScrollHandoff.wheel,
                   touch: !!bootScrollHandoff.touch,
+                  policy: typeof bootScrollHandoff.policy === 'string'
+                    ? bootScrollHandoff.policy
+                    : undefined,
                 });
               }
 

--- a/assets/monaco/bridge/scroll-handoff.js
+++ b/assets/monaco/bridge/scroll-handoff.js
@@ -2,7 +2,7 @@
 // plumbing here are extracted verbatim from the 2.3.0 generated page
 // (lib/src/core/monaco_assets.dart generateIndexHtml); see upcoming/v3.md
 // Section 14 (verbatim-port inventory). The gesture-ownership arbitration
-// ("boundary lock", 3.4.0) intentionally diverges from the 2.3.0 forwarding
+// ("boundary lock", 3.3.0) intentionally diverges from the 2.3.0 forwarding
 // behavior; the 2.3.0 semantics remain available as the 'continuous' policy.
 /* eslint-disable */
 'use strict';

--- a/assets/monaco/bridge/scroll-handoff.js
+++ b/assets/monaco/bridge/scroll-handoff.js
@@ -1,30 +1,61 @@
-// flutter_monaco bridge - extracted verbatim from the 2.3.0 generated page
-// (lib/src/core/monaco_assets.dart generateIndexHtml). Do not reformat the
-// ported bodies; see upcoming/v3.md Section 14 (verbatim-port inventory).
+// flutter_monaco bridge - the scroll metrics, region filtering, and listener
+// plumbing here are extracted verbatim from the 2.3.0 generated page
+// (lib/src/core/monaco_assets.dart generateIndexHtml); see upcoming/v3.md
+// Section 14 (verbatim-port inventory). The gesture-ownership arbitration
+// ("boundary lock", 3.4.0) intentionally diverges from the 2.3.0 forwarding
+// behavior; the 2.3.0 semantics remain available as the 'continuous' policy.
 /* eslint-disable */
 'use strict';
 window.__FMB = window.__FMB || {};
 
-// Edge scroll handoff module. VERBATIM PORT, extended for diff pages:
+// Edge scroll handoff module, extended for diff pages:
 // ctx.handoffScope (optional) widens the accepted wheel region to a set of
 // editor DOM nodes under one region root, while ctx.E stays the vertical
 // scroll master whose metrics gate the handoff. Without a scope the region
-// is exactly the single editor, byte-for-byte the 2.3.0 behavior.
+// is exactly the single editor.
 window.__FMB.scrollHandoff = function (ctx) {
   const { E, post } = ctx;
   const handoffScope = ctx.handoffScope || null;
-                // Edge scroll handoff (opt-in): forward scroll deltas the
-                // editor cannot consume to Flutter, which applies them to a
+                // Edge scroll handoff (opt-in): forward scroll intent the
+                // editor cannot consume to Flutter, which applies it to a
                 // host scrollable. Sources are toggled from Dart through
                 // flutterMonaco.setScrollHandoff; while disabled this module
                 // installs no DOM listeners and adds no per-event work, so
                 // the default editor behavior is untouched.
+                //
+                // Ownership model (policy 'newGestureOnly', the default):
+                // the component that owns a scroll transaction when it
+                // begins keeps it until that transaction ends. A gesture
+                // that starts while the editor can scroll belongs to the
+                // editor; when it reaches the scroll edge, its remaining
+                // input - the whole inertial tail included - is absorbed at
+                // the wall and never forwarded. Flutter receives only
+                // transactions that START at the edge, as begin/update/end
+                // sessions keyed by gestureId. Policy 'continuous' keeps
+                // the 2.3.0 chaining: any delta the editor cannot consume
+                // is forwarded immediately, with the legacy payload shape.
                 (function () {
                   const EDGE_EPSILON = 1;
                   const TOUCH_SLOP = 8;
+                  // Wheel events carry no transaction boundaries (beyond
+                  // the Pointer Events level 4 'momentum' flag where a
+                  // browser ships it), so gesture ends fall back to quiet
+                  // periods: an editor-owned transaction expires after
+                  // WHEEL_NORMAL_IDLE_MS without events; once a transaction
+                  // has touched the boundary, the parent can be acquired
+                  // only after WHEEL_BOUNDARY_QUIET_MS of silence. The
+                  // re-arm window is the conservative one because a false
+                  // "same gesture" merely delays host scrolling by about a
+                  // quarter second, while a false "new gesture" jerks the
+                  // host page - the exact bug this arbiter exists to stop.
+                  const WHEEL_NORMAL_IDLE_MS = 120;
+                  const WHEEL_BOUNDARY_QUIET_MS = 260;
+
                   const handoffState = {
                     wheel: false,
                     touch: false,
+                    policy: 'newGestureOnly',
+                    gestureSeq: 0,
                     touchGesture: null,
                     touchSelectionWatch: null,
                   };
@@ -104,6 +135,21 @@ window.__FMB.scrollHandoff = function (ctx) {
                     return true;
                   };
 
+                  // Whether the editor itself can scroll in the requested
+                  // vertical direction (wheel semantics: wantsDown scrolls
+                  // the content down).
+                  const canChildConsume = (ed, metrics, wantsDown) =>
+                    !editorWheelDisabled(ed) &&
+                    metrics.maxTop > EDGE_EPSILON &&
+                    (wantsDown ? !metrics.atBottom : !metrics.atTop);
+
+                  const blockLocal = (event) => {
+                    if (event.cancelable !== false) event.preventDefault();
+                    event.stopPropagation();
+                  };
+
+                  // Legacy payload, byte-compatible with 2.3.0: emitted only
+                  // under policy 'continuous'.
                   const postHandoff = (source, deltaX, deltaY, metrics) => {
                     post('scrollHandoff', {
                       source: source,
@@ -114,6 +160,195 @@ window.__FMB.scrollHandoff = function (ctx) {
                       atLeft: metrics.atLeft,
                       atRight: metrics.atRight,
                     });
+                  };
+
+                  // Sessionized payload for policy 'newGestureOnly'. The
+                  // Dart driver applies updates only for the gestureId it
+                  // saw begin, so stale or superseded deltas can never move
+                  // the host.
+                  const postSession = (source, phase, gestureId, deltaX, deltaY, metrics, momentum) => {
+                    post('scrollHandoff', {
+                      source: source,
+                      phase: phase,
+                      gestureId: gestureId,
+                      momentum: !!momentum,
+                      deltaX: deltaX,
+                      deltaY: deltaY,
+                      atTop: metrics.atTop,
+                      atBottom: metrics.atBottom,
+                      atLeft: metrics.atLeft,
+                      atRight: metrics.atRight,
+                    });
+                  };
+                  const NO_METRICS = Object.freeze({
+                    atTop: false, atBottom: false, atLeft: false, atRight: false,
+                  });
+
+                  // ---- wheel transaction arbiter (policy newGestureOnly) --
+                  // States: 'idle' (no transaction), 'child' (the editor
+                  // owns it), 'locked' (an editor-owned transaction reached
+                  // the wall; residual input is absorbed), 'parent' (it
+                  // started at the wall; Flutter owns it, inertia included).
+                  const wheelSession = {
+                    owner: 'idle',
+                    gestureId: 0,
+                    direction: 0,
+                    lastEventAt: -Infinity,
+                    // Survives idle on purpose: the freshest editor-owned
+                    // activity, used to keep the sparse end of an inertial
+                    // tail from acquiring the parent after a boundary hit.
+                    lastChildLikeAt: -Infinity,
+                    lastChildLikeDir: 0,
+                    sawMomentum: false,
+                    lastMetrics: NO_METRICS,
+                    endTimer: 0,
+                  };
+
+                  const noteChildLike = (now, dir) => {
+                    wheelSession.lastChildLikeAt = now;
+                    wheelSession.lastChildLikeDir = dir;
+                  };
+
+                  const finishWheelSession = (phase) => {
+                    if (wheelSession.endTimer) {
+                      clearTimeout(wheelSession.endTimer);
+                      wheelSession.endTimer = 0;
+                    }
+                    if (wheelSession.owner === 'parent') {
+                      postSession('wheel', phase, wheelSession.gestureId,
+                        0, 0, wheelSession.lastMetrics, false);
+                    }
+                    wheelSession.owner = 'idle';
+                    wheelSession.direction = 0;
+                    wheelSession.sawMomentum = false;
+                  };
+
+                  const scheduleWheelFinish = () => {
+                    if (wheelSession.endTimer) clearTimeout(wheelSession.endTimer);
+                    const delay = wheelSession.owner === 'child'
+                      ? WHEEL_NORMAL_IDLE_MS
+                      : WHEEL_BOUNDARY_QUIET_MS;
+                    wheelSession.endTimer = setTimeout(function () {
+                      wheelSession.endTimer = 0;
+                      finishWheelSession('end');
+                    }, delay);
+                  };
+
+                  const arbitrateWheel = (event, ed, metrics, deltaX, deltaY) => {
+                    const now = event.timeStamp;
+                    const dir = deltaY > 0 ? 1 : -1;
+                    const consumable = canChildConsume(ed, metrics, dir > 0);
+                    const momentumKnown = 'momentum' in event;
+                    const isMomentum = momentumKnown && event.momentum === true;
+                    // With momentum metadata, the first direct event after
+                    // an inertial tail is a new physical gesture even when
+                    // it arrives with no time gap (fingers back on the pad).
+                    const directAfterMomentum =
+                      momentumKnown && wheelSession.sawMomentum && !isMomentum;
+                    const sessionGapMs = wheelSession.owner === 'child'
+                      ? WHEEL_NORMAL_IDLE_MS
+                      : WHEEL_BOUNDARY_QUIET_MS;
+                    const fresh =
+                      wheelSession.owner === 'idle' ||
+                      now - wheelSession.lastEventAt > sessionGapMs ||
+                      directAfterMomentum;
+                    wheelSession.lastEventAt = now;
+                    wheelSession.lastMetrics = metrics;
+
+                    if (fresh) {
+                      finishWheelSession('end');
+                      handoffState.gestureSeq += 1;
+                      wheelSession.gestureId = handoffState.gestureSeq;
+                      wheelSession.direction = dir;
+                      wheelSession.sawMomentum = isMomentum;
+                      if (consumable) {
+                        // The editor can scroll: this transaction belongs to
+                        // it. Monaco receives the event untouched (that
+                        // includes a momentum tail resuming after a lull).
+                        wheelSession.owner = 'child';
+                        noteChildLike(now, dir);
+                        scheduleWheelFinish();
+                        return;
+                      }
+                      const recentlyChildLike =
+                        !directAfterMomentum &&
+                        dir === wheelSession.lastChildLikeDir &&
+                        now - wheelSession.lastChildLikeAt < WHEEL_BOUNDARY_QUIET_MS;
+                      if (isMomentum || recentlyChildLike) {
+                        // Leftover kinetic energy: a tagged momentum event,
+                        // or the detached tail of recent editor-owned
+                        // activity in the same direction. Absorb it at the
+                        // wall; it may never acquire the parent.
+                        wheelSession.owner = 'locked';
+                        noteChildLike(now, dir);
+                        blockLocal(event);
+                        scheduleWheelFinish();
+                        return;
+                      }
+                      // A genuinely new gesture starting at the edge: the
+                      // parent owns it until it ends or reverses back into
+                      // the editor, its inertia included.
+                      wheelSession.owner = 'parent';
+                      blockLocal(event);
+                      postSession('wheel', 'begin', wheelSession.gestureId,
+                        deltaX, deltaY, metrics, isMomentum);
+                      scheduleWheelFinish();
+                      return;
+                    }
+
+                    // Continuing the active transaction.
+                    wheelSession.sawMomentum = wheelSession.sawMomentum || isMomentum;
+                    switch (wheelSession.owner) {
+                      case 'child':
+                        if (consumable) {
+                          wheelSession.direction = dir;
+                          noteChildLike(now, dir);
+                          scheduleWheelFinish();
+                          return; // Monaco consumes it, reversals included.
+                        }
+                        // The transaction began in the editor and just hit
+                        // the wall: everything it has left is absorbed.
+                        wheelSession.owner = 'locked';
+                        wheelSession.direction = dir;
+                        noteChildLike(now, dir);
+                        blockLocal(event);
+                        scheduleWheelFinish();
+                        return;
+                      case 'locked':
+                        if (consumable) {
+                          // Deliberate reversal back into content: the
+                          // editor takes the transaction again.
+                          wheelSession.owner = 'child';
+                          wheelSession.direction = dir;
+                          noteChildLike(now, dir);
+                          scheduleWheelFinish();
+                          return;
+                        }
+                        noteChildLike(now, dir);
+                        blockLocal(event);
+                        scheduleWheelFinish();
+                        return;
+                      case 'parent':
+                        if (dir !== wheelSession.direction && consumable) {
+                          // Reversal back into the editor never leaks: close
+                          // the parent session, Monaco consumes this event.
+                          finishWheelSession('end');
+                          wheelSession.owner = 'child';
+                          wheelSession.direction = dir;
+                          wheelSession.sawMomentum = isMomentum;
+                          noteChildLike(now, dir);
+                          scheduleWheelFinish();
+                          return;
+                        }
+                        wheelSession.direction = dir;
+                        blockLocal(event);
+                        postSession('wheel', 'update', wheelSession.gestureId,
+                          deltaX, deltaY, metrics, isMomentum);
+                        scheduleWheelFinish();
+                        return;
+                      default:
+                        return;
+                    }
                   };
 
                   const onHandoffWheel = (event) => {
@@ -140,16 +375,15 @@ window.__FMB.scrollHandoff = function (ctx) {
                       // input stays with the editor.
                       if (deltaY === 0 || Math.abs(deltaY) <= Math.abs(deltaX)) return;
 
-                      const wantsDown = deltaY > 0;
-                      const editorCannotConsume =
-                        editorWheelDisabled(ed) ||
-                        metrics.maxTop <= EDGE_EPSILON ||
-                        (wantsDown ? metrics.atBottom : metrics.atTop);
-                      if (!editorCannotConsume) return;
-
-                      event.preventDefault();
-                      event.stopPropagation();
-                      postHandoff('wheel', deltaX, deltaY, metrics);
+                      if (handoffState.policy === 'continuous') {
+                        // 2.3.0 chaining: forward whatever the editor cannot
+                        // consume, immediately and unsessionized.
+                        if (canChildConsume(ed, metrics, deltaY > 0)) return;
+                        blockLocal(event);
+                        postHandoff('wheel', deltaX, deltaY, metrics);
+                        return;
+                      }
+                      arbitrateWheel(event, ed, metrics, deltaX, deltaY);
                     } catch (_) {}
                   };
 
@@ -157,7 +391,12 @@ window.__FMB.scrollHandoff = function (ctx) {
                   // that never block, refocus, or select, so Monaco's touch
                   // handling and the mobile focus guards keep working exactly
                   // as before. Worst case is an extra parent scroll, never a
-                  // broken editor gesture.
+                  // broken editor gesture. Under policy 'newGestureOnly' the
+                  // owner is decided once per touch gesture (its boundaries
+                  // are explicit): a drag that starts over scrollable editor
+                  // content is the editor's for its whole lifetime and is
+                  // contained at the wall; only a drag that starts at an
+                  // outward edge is forwarded, as one session.
                   const gestureTouch = (event) => {
                     const gesture = handoffState.touchGesture;
                     if (!gesture) return null;
@@ -167,9 +406,19 @@ window.__FMB.scrollHandoff = function (ctx) {
                     }
                     return null;
                   };
+                  const finishTouchSession = (gesture, phase) => {
+                    if (!gesture || gesture.owner !== 'parent' ||
+                        !gesture.began || gesture.sessionClosed) {
+                      return;
+                    }
+                    gesture.sessionClosed = true;
+                    postSession('touch', phase, gesture.gestureId,
+                      0, 0, gesture.lastMetrics || NO_METRICS, false);
+                  };
                   const onHandoffTouchStart = (event) => {
                     try {
                       if (event.touches && event.touches.length > 1) {
+                        finishTouchSession(handoffState.touchGesture, 'cancel');
                         handoffState.touchGesture = null;
                         return;
                       }
@@ -178,6 +427,7 @@ window.__FMB.scrollHandoff = function (ctx) {
                       if (!touchPoint) return;
                       const ed = E();
                       if (!ed || !isMainScrollRegion(ed, event.target)) {
+                        finishTouchSession(handoffState.touchGesture, 'cancel');
                         handoffState.touchGesture = null;
                         return;
                       }
@@ -188,6 +438,13 @@ window.__FMB.scrollHandoff = function (ctx) {
                         lastY: touchPoint.clientY,
                         moved: false,
                         cancelled: false,
+                        // Ownership (policy newGestureOnly) is decided at
+                        // the first vertical movement past the slop.
+                        owner: null,
+                        gestureId: 0,
+                        began: false,
+                        sessionClosed: false,
+                        lastMetrics: null,
                       };
                     } catch (_) {}
                   };
@@ -217,13 +474,48 @@ window.__FMB.scrollHandoff = function (ctx) {
                       const editorCannotConsume =
                         metrics.maxTop <= EDGE_EPSILON ||
                         (wantsDown ? metrics.atBottom : metrics.atTop);
+
+                      if (handoffState.policy === 'continuous') {
+                        // 2.3.0 behavior: forward the moves the editor
+                        // cannot consume, regardless of gesture history.
+                        if (!editorCannotConsume) return;
+                        postHandoff('touch', 0, deltaY, metrics);
+                        return;
+                      }
+
+                      if (gesture.owner === null) {
+                        // Direct-manipulation gestures never migrate between
+                        // scrollables mid-flight: whoever can consume the
+                        // first movement owns the whole drag.
+                        gesture.owner = editorCannotConsume ? 'parent' : 'child';
+                      }
+                      // Containment: an editor-owned drag reaching the wall
+                      // is absorbed (Monaco simply stops), never forwarded.
+                      if (gesture.owner === 'child') return;
+                      // Parent-owned: forward only what the editor cannot
+                      // consume. This listener is passive, so a consumable
+                      // reversal is Monaco's to apply; forwarding it too
+                      // would scroll both surfaces at once.
                       if (!editorCannotConsume) return;
-                      postHandoff('touch', 0, deltaY, metrics);
+                      gesture.lastMetrics = metrics;
+                      if (!gesture.began) {
+                        gesture.began = true;
+                        handoffState.gestureSeq += 1;
+                        gesture.gestureId = handoffState.gestureSeq;
+                        postSession('touch', 'begin', gesture.gestureId,
+                          0, deltaY, metrics, false);
+                        return;
+                      }
+                      postSession('touch', 'update', gesture.gestureId,
+                        0, deltaY, metrics, false);
                     } catch (_) {}
                   };
                   const onHandoffTouchEnd = (event) => {
                     try {
-                      if (gestureTouch(event)) handoffState.touchGesture = null;
+                      if (gestureTouch(event)) {
+                        finishTouchSession(handoffState.touchGesture, 'end');
+                        handoffState.touchGesture = null;
+                      }
                     } catch (_) {}
                   };
 
@@ -244,10 +536,15 @@ window.__FMB.scrollHandoff = function (ctx) {
                       const ed = E();
                       if (ed && ed.onDidChangeCursorSelection && !handoffState.touchSelectionWatch) {
                         // Text selection wins: a selection change during a
-                        // moved gesture stops forwarding for that gesture.
+                        // moved gesture stops forwarding for that gesture
+                        // (and cancels its parent-owned session, so pending
+                        // deltas are dropped host-side).
                         handoffState.touchSelectionWatch = ed.onDidChangeCursorSelection(() => {
                           const gesture = handoffState.touchGesture;
-                          if (gesture && gesture.moved) gesture.cancelled = true;
+                          if (gesture && gesture.moved && !gesture.cancelled) {
+                            gesture.cancelled = true;
+                            finishTouchSession(gesture, 'cancel');
+                          }
                         });
                       }
                     } catch (_) {}
@@ -262,6 +559,7 @@ window.__FMB.scrollHandoff = function (ctx) {
                     if (watch && watch.dispose) {
                       try { watch.dispose(); } catch (_) {}
                     }
+                    finishTouchSession(handoffState.touchGesture, 'cancel');
                     handoffState.touchGesture = null;
                   };
 
@@ -271,10 +569,28 @@ window.__FMB.scrollHandoff = function (ctx) {
                   window.flutterMonaco.setScrollHandoff = function (cfg) {
                     const wheel = !!(cfg && cfg.wheel);
                     const touch = !!(cfg && cfg.touch);
+                    if (cfg && typeof cfg.policy === 'string') {
+                      // Only an explicit policy changes it; unknown names
+                      // fall back to the default so a newer Dart side can
+                      // never strand the page on 'continuous'.
+                      const policy = cfg.policy === 'continuous'
+                        ? 'continuous'
+                        : 'newGestureOnly';
+                      if (policy !== handoffState.policy) {
+                        handoffState.policy = policy;
+                        // Open sessions do not survive a semantics change.
+                        finishWheelSession('cancel');
+                        finishTouchSession(handoffState.touchGesture, 'cancel');
+                        handoffState.touchGesture = null;
+                      }
+                    }
                     if (wheel !== handoffState.wheel) {
                       handoffState.wheel = wheel;
                       if (wheel) { installScrollHandoffWheel(); }
-                      else { removeScrollHandoffWheel(); }
+                      else {
+                        removeScrollHandoffWheel();
+                        finishWheelSession('cancel');
+                      }
                     }
                     if (touch !== handoffState.touch) {
                       handoffState.touch = touch;
@@ -287,5 +603,9 @@ window.__FMB.scrollHandoff = function (ctx) {
 
                 // ---- protocol v3 command registry ----
                 window.FlutterMonaco.register('page.setScrollHandoff', (p) =>
-                  window.flutterMonaco.setScrollHandoff({ wheel: !!p.wheel, touch: !!p.touch }));
+                  window.flutterMonaco.setScrollHandoff({
+                    wheel: !!p.wheel,
+                    touch: !!p.touch,
+                    policy: typeof p.policy === 'string' ? p.policy : undefined,
+                  }));
 };

--- a/example/lib/scroll_handoff_example.dart
+++ b/example/lib/scroll_handoff_example.dart
@@ -166,7 +166,7 @@ class _ScrollHandoffExamplePageState extends State<ScrollHandoffExamplePage> {
                         'there, momentum included. Start a new gesture at '
                         'the edge to continue into the page (or enable '
                         'continuous chaining to spill mid-gesture, the '
-                        'pre-3.4 behavior). Reversing direction gives the '
+                        'pre-3.3 behavior). Reversing direction gives the '
                         'wheel back to the editor. Ctrl/meta wheel (zoom) '
                         'and Monaco popups are never handed off.',
                   ),

--- a/example/lib/scroll_handoff_example.dart
+++ b/example/lib/scroll_handoff_example.dart
@@ -53,6 +53,7 @@ class _ScrollHandoffExamplePageState extends State<ScrollHandoffExamplePage> {
   bool _handoffEnabled = true;
   bool _mobileTouch = false;
   bool _scrollBeyondLastLine = true;
+  bool _continuousChaining = false;
   MonacoScrollHandoffDetails? _lastHandoff;
 
   static final String _shortSnippet = [
@@ -83,6 +84,11 @@ class _ScrollHandoffExamplePageState extends State<ScrollHandoffExamplePage> {
     return MonacoScrollHandoff.edge(
       controller: _pageScrollController,
       mobileTouch: _mobileTouch,
+      // newGestureOnly (default) absorbs a gesture's momentum at the
+      // editor edge; continuous lets it spill into the page mid-gesture.
+      policy: _continuousChaining
+          ? MonacoScrollBoundaryPolicy.continuous
+          : MonacoScrollBoundaryPolicy.newGestureOnly,
       onHandoff: (details) {
         // Observe only: returning false keeps the built-in page scrolling.
         if (_lastHandoff != details) {
@@ -125,6 +131,13 @@ class _ScrollHandoffExamplePageState extends State<ScrollHandoffExamplePage> {
                 : null,
           ),
           _ToggleAction(
+            label: 'Continuous chaining',
+            value: _continuousChaining,
+            onChanged: _handoffEnabled
+                ? (value) => setState(() => _continuousChaining = value)
+                : null,
+          ),
+          _ToggleAction(
             label: 'scrollBeyondLastLine',
             value: _scrollBeyondLastLine,
             onChanged: (value) => setState(() => _scrollBeyondLastLine = value),
@@ -149,10 +162,13 @@ class _ScrollHandoffExamplePageState extends State<ScrollHandoffExamplePage> {
                         'Scroll this page with the wheel or trackpad. With '
                         'handoff enabled, the pointer can stay over an '
                         'editor: Monaco scrolls while it has somewhere to '
-                        'go and the page continues once the editor hits '
-                        'its edge. Reversing direction gives the wheel '
-                        'back to the editor. Ctrl/meta wheel (zoom) and '
-                        'Monaco popups are never handed off.',
+                        'go, and the gesture that reaches its edge stops '
+                        'there, momentum included. Start a new gesture at '
+                        'the edge to continue into the page (or enable '
+                        'continuous chaining to spill mid-gesture, the '
+                        'pre-3.4 behavior). Reversing direction gives the '
+                        'wheel back to the editor. Ctrl/meta wheel (zoom) '
+                        'and Monaco popups are never handed off.',
                   ),
                   const SizedBox(height: 16),
                   _EditorCard(

--- a/lib/flutter_monaco.dart
+++ b/lib/flutter_monaco.dart
@@ -151,9 +151,11 @@ export 'src/types/markers.dart'
     show MarkerData, MarkerSeverity, RelatedInformation;
 export 'src/types/scroll_handoff.dart'
     show
+        MonacoScrollBoundaryPolicy,
         MonacoScrollHandoff,
         MonacoScrollHandoffDetails,
         MonacoScrollHandoffMode,
+        MonacoScrollHandoffPhase,
         MonacoScrollHandoffSource;
 export 'src/types/stats.dart' show EditorState, MonacoLiveStats;
 export 'src/types/text.dart'

--- a/lib/src/diff/diff_controller.dart
+++ b/lib/src/diff/diff_controller.dart
@@ -339,15 +339,22 @@ class MonacoDiffController {
   ///
   /// Identical contract to `MonacoController.setScrollHandoffSources`: an
   /// enabled source installs the matching DOM listeners and posts
-  /// `scrollHandoff` events (surfaced through [onScrollHandoff]) for deltas
-  /// the diff editor cannot consume; disabling removes the listeners again.
-  /// `MonacoDiffEditor` calls this automatically from its `scrollHandoff`
-  /// configuration.
+  /// `scrollHandoff` events (surfaced through [onScrollHandoff]) for scroll
+  /// gestures the diff editor cannot consume, arbitrated by [policy] (the
+  /// momentum-absorbing [MonacoScrollBoundaryPolicy.newGestureOnly] by
+  /// default); disabling removes the listeners again. `MonacoDiffEditor`
+  /// calls this automatically from its `scrollHandoff` configuration.
   Future<void> setScrollHandoffSources({
     bool wheel = false,
     bool touch = false,
+    MonacoScrollBoundaryPolicy policy =
+        MonacoScrollBoundaryPolicy.newGestureOnly,
   }) async {
-    await _invoke('page.setScrollHandoff', {'wheel': wheel, 'touch': touch});
+    await _invoke('page.setScrollHandoff', {
+      'wheel': wheel,
+      'touch': touch,
+      'policy': policy.name,
+    });
   }
 
   /// Releases the WebView and fails all in-flight commands.

--- a/lib/src/editor/controller.dart
+++ b/lib/src/editor/controller.dart
@@ -718,9 +718,12 @@ class MonacoController {
   ///
   /// When a source is enabled, the page installs the matching DOM listeners
   /// and posts `scrollHandoff` events (surfaced through [onScrollHandoff])
-  /// for deltas the editor cannot consume. Disabling a source removes its
-  /// listeners again, so both sources disabled restores the exact
-  /// pre-feature behavior. Waits for the editor to be ready.
+  /// for scroll gestures the editor cannot consume, arbitrated by [policy]
+  /// (the momentum-absorbing [MonacoScrollBoundaryPolicy.newGestureOnly] by
+  /// default). Changing the policy cancels any handoff gesture in flight.
+  /// Disabling a source removes its listeners again, so both sources
+  /// disabled restores the exact pre-feature behavior. Waits for the editor
+  /// to be ready.
   ///
   /// `MonacoEditor` calls this automatically from its `scrollHandoff`
   /// configuration; call it directly only for headless or custom-widget
@@ -728,8 +731,14 @@ class MonacoController {
   Future<void> setScrollHandoffSources({
     bool wheel = false,
     bool touch = false,
+    MonacoScrollBoundaryPolicy policy =
+        MonacoScrollBoundaryPolicy.newGestureOnly,
   }) async {
-    await _invoke('page.setScrollHandoff', {'wheel': wheel, 'touch': touch});
+    await _invoke('page.setScrollHandoff', {
+      'wheel': wheel,
+      'touch': touch,
+      'policy': policy.name,
+    });
   }
 
   // --- EVENT HANDLING ---

--- a/lib/src/types/scroll_handoff.dart
+++ b/lib/src/types/scroll_handoff.dart
@@ -27,6 +27,61 @@ enum MonacoScrollHandoffSource {
   touch,
 }
 
+/// How gesture ownership is resolved when a scroll gesture meets the
+/// editor's scroll boundary.
+///
+/// The policy decides one thing: whether the *remainder* of a gesture that
+/// started inside the editor may spill into the Flutter host once the editor
+/// runs out of scroll range. It is applied inside the editor page, before
+/// any delta crosses the bridge, so the host never has to guess whether a
+/// delta was leftover inertia.
+enum MonacoScrollBoundaryPolicy {
+  /// Unconsumed deltas chain to the host immediately (the 2.3.0 behavior).
+  ///
+  /// Fast wheels and trackpad momentum spill into the surrounding page the
+  /// instant the editor hits its edge, mid-gesture. Use this only when the
+  /// embedding wants Android-style continuous nested-scroll chaining.
+  continuous,
+
+  /// The editor keeps every gesture it started; the host gets new gestures
+  /// that start at the boundary (the default).
+  ///
+  /// A gesture (and its whole inertial tail) that reaches the editor's edge
+  /// is absorbed there, like a native macOS/iOS nested scroll "wall". To
+  /// scroll the surrounding page, the user stops and starts a physically
+  /// distinct gesture while the editor is already at its edge; reversing
+  /// direction hands the input back to the editor immediately. Forwarded
+  /// gestures arrive as begin/update/end sessions (see
+  /// [MonacoScrollHandoffDetails.phase]).
+  newGestureOnly,
+}
+
+/// The position of one [MonacoScrollHandoffDetails] message within a
+/// host-owned scroll gesture.
+///
+/// Only gestures the editor page decided the host owns are sessionized;
+/// under [MonacoScrollBoundaryPolicy.continuous] every delta arrives as a
+/// standalone [update] with [MonacoScrollHandoffDetails.gestureId] `0`.
+enum MonacoScrollHandoffPhase {
+  /// The first delta of a host-owned gesture. Carries a payload delta and
+  /// resets any pending state from earlier gestures.
+  begin,
+
+  /// A continuation delta of the gesture announced by [begin] with the same
+  /// [MonacoScrollHandoffDetails.gestureId].
+  update,
+
+  /// The gesture ended (quiet period elapsed, direction reversed back into
+  /// the editor, or it was superseded). Carries zero deltas; already
+  /// accumulated deltas still apply.
+  end,
+
+  /// The gesture was cancelled (handoff disabled, policy changed, or touch
+  /// forwarding yielded to text selection). Carries zero deltas; the host
+  /// drops any deltas of this gesture it has not applied yet.
+  cancel,
+}
+
 /// One unconsumed scroll intent reported by the editor page.
 ///
 /// Deltas use wheel semantics normalized to pixels: positive [deltaY] means
@@ -44,10 +99,38 @@ class MonacoScrollHandoffDetails {
     required this.atBottom,
     required this.atLeft,
     required this.atRight,
+    this.phase = MonacoScrollHandoffPhase.update,
+    this.gestureId = 0,
+    this.momentum = false,
   });
 
   /// The input source that produced this delta.
   final MonacoScrollHandoffSource source;
+
+  /// Where this message sits in its gesture's lifecycle.
+  ///
+  /// Payload deltas arrive as [MonacoScrollHandoffPhase.begin] or
+  /// [MonacoScrollHandoffPhase.update]; [MonacoScrollHandoffPhase.end] and
+  /// [MonacoScrollHandoffPhase.cancel] close a gesture and carry zero
+  /// deltas. Under [MonacoScrollBoundaryPolicy.continuous] every message is
+  /// an [MonacoScrollHandoffPhase.update].
+  final MonacoScrollHandoffPhase phase;
+
+  /// The page-unique id of the host-owned gesture this message belongs to.
+  ///
+  /// `0` marks an unsessionized message ([MonacoScrollBoundaryPolicy
+  /// .continuous]); sessionized gestures count up from `1`. The built-in
+  /// handoff applies an [MonacoScrollHandoffPhase.update] only while its
+  /// gesture is the active one, so a stale delta can never move the host.
+  final int gestureId;
+
+  /// Whether the editor page identified this delta as scroll inertia
+  /// rather than direct input.
+  ///
+  /// Only populated where the browser exposes momentum metadata on wheel
+  /// events; `false` otherwise. Informational: ownership was already decided
+  /// on the editor side.
+  final bool momentum;
 
   /// Horizontal delta in pixels. Reported for completeness; the built-in
   /// handoff applies only [deltaY] in this release.
@@ -72,8 +155,11 @@ class MonacoScrollHandoffDetails {
   /// Parses a `scrollHandoff` bridge payload.
   ///
   /// Returns `null` for malformed payloads instead of throwing: an unknown
-  /// [source], or a missing, non-numeric, or non-finite delta. Absent or
-  /// non-boolean edge flags default to `false`.
+  /// [source], an unknown [phase], or a missing, non-numeric, or non-finite
+  /// delta. Absent or non-boolean edge flags default to `false`. Legacy
+  /// payloads without session fields parse as
+  /// [MonacoScrollHandoffPhase.update] with [gestureId] `0` and no
+  /// [momentum], and a malformed [gestureId] also falls back to `0`.
   static MonacoScrollHandoffDetails? tryParse(Map<String, dynamic> json) {
     final source = switch (json['source']) {
       'wheel' => MonacoScrollHandoffSource.wheel,
@@ -82,12 +168,25 @@ class MonacoScrollHandoffDetails {
     };
     if (source == null) return null;
 
+    final phase = switch (json['phase']) {
+      null => MonacoScrollHandoffPhase.update,
+      'begin' => MonacoScrollHandoffPhase.begin,
+      'update' => MonacoScrollHandoffPhase.update,
+      'end' => MonacoScrollHandoffPhase.end,
+      'cancel' => MonacoScrollHandoffPhase.cancel,
+      _ => null,
+    };
+    if (phase == null) return null;
+
     final deltaX = _finiteDouble(json['deltaX']);
     final deltaY = _finiteDouble(json['deltaY']);
     if (deltaX == null || deltaY == null) return null;
 
     return MonacoScrollHandoffDetails(
       source: source,
+      phase: phase,
+      gestureId: _gestureId(json['gestureId']),
+      momentum: json['momentum'] == true,
       deltaX: deltaX,
       deltaY: deltaY,
       atTop: json['atTop'] == true,
@@ -103,10 +202,22 @@ class MonacoScrollHandoffDetails {
     return result.isFinite ? result : null;
   }
 
+  /// A malformed gesture id degrades to the legacy id `0` (always applied)
+  /// rather than dropping the whole payload: losing session tracking is
+  /// recoverable, losing scroll deltas is user-visible.
+  static int _gestureId(Object? value) {
+    if (value is! num || !value.isFinite) return 0;
+    final id = value.toInt();
+    return id < 0 ? 0 : id;
+  }
+
   @override
   bool operator ==(Object other) {
     return other is MonacoScrollHandoffDetails &&
         other.source == source &&
+        other.phase == phase &&
+        other.gestureId == gestureId &&
+        other.momentum == momentum &&
         other.deltaX == deltaX &&
         other.deltaY == deltaY &&
         other.atTop == atTop &&
@@ -116,13 +227,25 @@ class MonacoScrollHandoffDetails {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(source, deltaX, deltaY, atTop, atBottom, atLeft, atRight);
+  int get hashCode => Object.hash(
+    source,
+    phase,
+    gestureId,
+    momentum,
+    deltaX,
+    deltaY,
+    atTop,
+    atBottom,
+    atLeft,
+    atRight,
+  );
 
   @override
   String toString() {
     return 'MonacoScrollHandoffDetails('
         'source: ${source.name}, '
+        'phase: ${phase.name}, gestureId: $gestureId, '
+        'momentum: $momentum, '
         'deltaX: $deltaX, deltaY: $deltaY, '
         'atTop: $atTop, atBottom: $atBottom, '
         'atLeft: $atLeft, atRight: $atRight)';
@@ -133,9 +256,18 @@ class MonacoScrollHandoffDetails {
 ///
 /// Disabled by default. When enabled with [MonacoScrollHandoff.edge], wheel
 /// or trackpad input over the editor keeps scrolling Monaco until the editor
-/// reaches its scroll edge; deltas the editor cannot consume are forwarded
-/// to a Flutter scroll target so the surrounding page continues scrolling.
-/// Reversing direction hands the input back to Monaco immediately.
+/// reaches its scroll edge; scroll gestures the editor cannot consume are
+/// forwarded to a Flutter scroll target so the surrounding page continues
+/// scrolling. Reversing direction hands the input back to Monaco
+/// immediately.
+///
+/// What happens to the gesture that *reaches* the edge is governed by
+/// [policy]. Under the default [MonacoScrollBoundaryPolicy.newGestureOnly],
+/// that gesture (and its trackpad momentum) stops dead at the boundary like
+/// a native nested scroll view; the host page scrolls only when a new
+/// gesture starts while the editor is already at its edge. Under
+/// [MonacoScrollBoundaryPolicy.continuous] every unconsumed delta chains to
+/// the host immediately, which lets fast scrolls jerk the page.
 ///
 /// The forwarded delta is applied to the first available target:
 ///
@@ -168,24 +300,37 @@ class MonacoScrollHandoff {
       useNearestScrollable = true,
       desktopWheel = true,
       mobileTouch = false,
+      policy = MonacoScrollBoundaryPolicy.newGestureOnly,
       onHandoff = null;
 
   /// Enables edge handoff.
   ///
   /// [desktopWheel] controls the wheel/trackpad source (on by default).
   /// [mobileTouch] additionally opts in to experimental touch forwarding.
-  /// See the class docs for how the scroll target is resolved from
-  /// [onHandoff], [controller], and [useNearestScrollable].
+  /// [policy] selects the boundary behavior (momentum-absorbing
+  /// [MonacoScrollBoundaryPolicy.newGestureOnly] by default). See the class
+  /// docs for how the scroll target is resolved from [onHandoff],
+  /// [controller], and [useNearestScrollable].
   const MonacoScrollHandoff.edge({
     this.controller,
     this.useNearestScrollable = true,
     this.desktopWheel = true,
     this.mobileTouch = false,
+    this.policy = MonacoScrollBoundaryPolicy.newGestureOnly,
     this.onHandoff,
   }) : mode = MonacoScrollHandoffMode.edge;
 
   /// The active handoff mode.
   final MonacoScrollHandoffMode mode;
+
+  /// How gestures that meet the editor's scroll boundary are owned.
+  ///
+  /// Defaults to [MonacoScrollBoundaryPolicy.newGestureOnly]: a gesture that
+  /// starts inside the editor is absorbed at the edge, momentum included,
+  /// and the host scrolls only on a subsequent gesture that starts at the
+  /// edge. Set [MonacoScrollBoundaryPolicy.continuous] to restore the 2.3.0
+  /// unconsumed-delta chaining.
+  final MonacoScrollBoundaryPolicy policy;
 
   /// Explicit scroll target. Wins over [useNearestScrollable]. Only its
   /// vertical positions receive deltas; horizontal positions are ignored.

--- a/lib/src/widgets/monaco_diff_editor.dart
+++ b/lib/src/widgets/monaco_diff_editor.dart
@@ -137,10 +137,13 @@ class _MonacoDiffEditorState extends State<MonacoDiffEditor> {
   );
   StreamSubscription<MonacoScrollHandoffDetails>? _scrollHandoffSub;
 
-  /// The handoff sources last pushed to the diff page, so config rebuilds
-  /// only produce bridge traffic when the effective sources change.
+  /// The handoff sources and boundary policy last pushed to the diff page,
+  /// so config rebuilds only produce bridge traffic when the effective
+  /// configuration changes.
   bool _syncedWheelSource = false;
   bool _syncedTouchSource = false;
+  MonacoScrollBoundaryPolicy _syncedPolicy =
+      MonacoScrollBoundaryPolicy.newGestureOnly;
 
   /// The texts/language last pushed to (or booted into) the controller, so
   /// prop changes that land during the connecting window are re-applied at
@@ -422,19 +425,29 @@ class _MonacoDiffEditorState extends State<MonacoDiffEditor> {
     );
   }
 
-  /// Pushes the desired handoff sources to the diff page when they differ
-  /// from what was last pushed. A disabled config therefore produces no
-  /// bridge traffic at all.
+  /// Pushes the desired handoff sources and boundary policy to the diff
+  /// page when they differ from what was last pushed. A disabled config
+  /// therefore produces no bridge traffic at all.
   void _syncScrollHandoffSources() {
     final controller = _controller;
     if (controller == null) return;
     final wheel = widget.scrollHandoff.wheelSourceEnabled;
     final touch = widget.scrollHandoff.touchSourceEnabled;
-    if (wheel == _syncedWheelSource && touch == _syncedTouchSource) return;
+    final policy = widget.scrollHandoff.policy;
+    if (wheel == _syncedWheelSource &&
+        touch == _syncedTouchSource &&
+        policy == _syncedPolicy) {
+      return;
+    }
     _syncedWheelSource = wheel;
     _syncedTouchSource = touch;
+    _syncedPolicy = policy;
     _ignoreAsync(
-      controller.setScrollHandoffSources(wheel: wheel, touch: touch),
+      controller.setScrollHandoffSources(
+        wheel: wheel,
+        touch: touch,
+        policy: policy,
+      ),
     );
   }
 
@@ -475,6 +488,7 @@ class _MonacoDiffEditorState extends State<MonacoDiffEditor> {
     }
     _syncedWheelSource = false;
     _syncedTouchSource = false;
+    _syncedPolicy = MonacoScrollBoundaryPolicy.newGestureOnly;
     _scrollHandoffDriver.clearPending();
     if (disposeOldController) {
       controller?.dispose();

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -292,10 +292,13 @@ class _MonacoEditorState extends State<MonacoEditor> {
     isMounted: () => mounted,
   );
 
-  /// The handoff sources last pushed to the editor page, so config rebuilds
-  /// only produce bridge traffic when the effective sources change.
+  /// The handoff sources and boundary policy last pushed to the editor
+  /// page, so config rebuilds only produce bridge traffic when the
+  /// effective configuration changes.
   bool _syncedWheelSource = false;
   bool _syncedTouchSource = false;
+  MonacoScrollBoundaryPolicy _syncedPolicy =
+      MonacoScrollBoundaryPolicy.newGestureOnly;
 
   /// The theme most recently pushed to the editor, so ambient brightness
   /// changes (D27) only produce bridge traffic when the resolved theme
@@ -699,19 +702,29 @@ class _MonacoEditorState extends State<MonacoEditor> {
     );
   }
 
-  /// Pushes the desired handoff sources to the editor page when they differ
-  /// from what was last pushed. A disabled config therefore produces no
-  /// bridge traffic at all.
+  /// Pushes the desired handoff sources and boundary policy to the editor
+  /// page when they differ from what was last pushed. A disabled config
+  /// therefore produces no bridge traffic at all.
   void _syncScrollHandoffSources() {
     final controller = _controller;
     if (controller == null) return;
     final wheel = widget.scrollHandoff.wheelSourceEnabled;
     final touch = widget.scrollHandoff.touchSourceEnabled;
-    if (wheel == _syncedWheelSource && touch == _syncedTouchSource) return;
+    final policy = widget.scrollHandoff.policy;
+    if (wheel == _syncedWheelSource &&
+        touch == _syncedTouchSource &&
+        policy == _syncedPolicy) {
+      return;
+    }
     _syncedWheelSource = wheel;
     _syncedTouchSource = touch;
+    _syncedPolicy = policy;
     _ignoreAsync(
-      controller.setScrollHandoffSources(wheel: wheel, touch: touch),
+      controller.setScrollHandoffSources(
+        wheel: wheel,
+        touch: touch,
+        policy: policy,
+      ),
     );
   }
 
@@ -791,6 +804,7 @@ class _MonacoEditorState extends State<MonacoEditor> {
     }
     _syncedWheelSource = false;
     _syncedTouchSource = false;
+    _syncedPolicy = MonacoScrollBoundaryPolicy.newGestureOnly;
     _scrollHandoffDriver.clearPending();
     _appliedResolvedTheme = null;
     if (disposeOldController) {

--- a/lib/src/widgets/scroll_handoff_driver.dart
+++ b/lib/src/widgets/scroll_handoff_driver.dart
@@ -31,7 +31,7 @@ class ScrollHandoffDriver {
 
   /// The gestureId whose deltas may move the host, or `null` when no
   /// sessionized gesture is active. The legacy id `0` (continuous policy or
-  /// a pre-3.4 page) bypasses the gate entirely.
+  /// a pre-3.3 page) bypasses the gate entirely.
   int? _activeGestureId;
 
   /// Handles one forwarded handoff message from the editor page.

--- a/lib/src/widgets/scroll_handoff_driver.dart
+++ b/lib/src/widgets/scroll_handoff_driver.dart
@@ -29,7 +29,16 @@ class ScrollHandoffDriver {
   double _pendingDelta = 0;
   bool _frameScheduled = false;
 
-  /// Handles one forwarded delta from the editor page.
+  /// The gestureId whose deltas may move the host, or `null` when no
+  /// sessionized gesture is active. The legacy id `0` (continuous policy or
+  /// a pre-3.4 page) bypasses the gate entirely.
+  int? _activeGestureId;
+
+  /// Handles one forwarded handoff message from the editor page.
+  ///
+  /// Session bookkeeping happens for every message; only payload-bearing
+  /// phases (begin/update) can reach [MonacoScrollHandoff.onHandoff] and the
+  /// built-in scrolling.
   void handle(MonacoScrollHandoffDetails details) {
     final config = _config();
     if (!config.isEnabled) return;
@@ -39,8 +48,32 @@ class ScrollHandoffDriver {
     };
     if (!sourceEnabled) return;
 
-    // The callback sees every raw delta; coalescing below only affects the
-    // built-in parent scrolling.
+    switch (details.phase) {
+      case MonacoScrollHandoffPhase.begin:
+        // A new host-owned gesture supersedes whatever came before it,
+        // including deltas of the old gesture still waiting for a frame.
+        _activeGestureId = details.gestureId;
+        _pendingDelta = 0;
+      case MonacoScrollHandoffPhase.update:
+        // Only the active gesture may move the host. Id 0 is the
+        // unsessionized legacy stream and is always live.
+        final stale =
+            details.gestureId != 0 && details.gestureId != _activeGestureId;
+        if (stale) return;
+      case MonacoScrollHandoffPhase.end:
+        // The gesture is over; deltas it already accumulated still apply.
+        if (details.gestureId == _activeGestureId) _activeGestureId = null;
+        return;
+      case MonacoScrollHandoffPhase.cancel:
+        if (details.gestureId == _activeGestureId) {
+          _activeGestureId = null;
+          _pendingDelta = 0;
+        }
+        return;
+    }
+
+    // The callback sees every payload delta; coalescing below only affects
+    // the built-in parent scrolling.
     final onHandoff = config.onHandoff;
     if (onHandoff != null && onHandoff(details)) return;
 
@@ -49,10 +82,12 @@ class ScrollHandoffDriver {
     _scheduleFlush();
   }
 
-  /// Drops any accumulated delta; call when the controller goes away so a
-  /// pending flush cannot scroll on behalf of a dead editor.
+  /// Drops any accumulated delta and forgets the active gesture; call when
+  /// the controller goes away so a pending flush cannot scroll on behalf of
+  /// a dead editor.
   void clearPending() {
     _pendingDelta = 0;
+    _activeGestureId = null;
   }
 
   /// Coalesces high-frequency bridge deltas into one scroll application per

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 3.3.0
+version: 3.4.0
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 3.4.0
+version: 3.3.0
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/core/monaco_controller_scroll_handoff_test.dart
+++ b/test/core/monaco_controller_scroll_handoff_test.dart
@@ -155,5 +155,25 @@ void main() {
       expect(params['wheel'], isFalse);
       expect(params['touch'], isFalse);
     });
+
+    test('sends the boundary policy, newGestureOnly by default', () async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+
+      await bundle.controller.setScrollHandoffSources(wheel: true);
+      await bundle.controller.setScrollHandoffSources(
+        wheel: true,
+        policy: MonacoScrollBoundaryPolicy.continuous,
+      );
+
+      final calls = bundle.webview.dispatched
+          .where((d) => d['method'] == 'page.setScrollHandoff')
+          .toList();
+      expect(calls, hasLength(2));
+      final first = calls.first['params']! as Map<String, Object?>;
+      final second = calls.last['params']! as Map<String, Object?>;
+      expect(first['policy'], 'newGestureOnly');
+      expect(second['policy'], 'continuous');
+    });
   });
 }

--- a/test/core/monaco_diff_controller_scroll_handoff_test.dart
+++ b/test/core/monaco_diff_controller_scroll_handoff_test.dart
@@ -128,5 +128,25 @@ void main() {
       expect(params['wheel'], isFalse);
       expect(params['touch'], isFalse);
     });
+
+    test('sends the boundary policy, newGestureOnly by default', () async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+
+      await bundle.controller.setScrollHandoffSources(wheel: true);
+      await bundle.controller.setScrollHandoffSources(
+        wheel: true,
+        policy: MonacoScrollBoundaryPolicy.continuous,
+      );
+
+      final calls = bundle.webview.dispatched
+          .where((d) => d['method'] == 'page.setScrollHandoff')
+          .toList();
+      expect(calls, hasLength(2));
+      final first = calls.first['params']! as Map<String, Object?>;
+      final second = calls.last['params']! as Map<String, Object?>;
+      expect(first['policy'], 'newGestureOnly');
+      expect(second['policy'], 'continuous');
+    });
   });
 }

--- a/test/models/monaco_scroll_handoff_test.dart
+++ b/test/models/monaco_scroll_handoff_test.dart
@@ -118,6 +118,92 @@ void main() {
       expect(details.atRight, isFalse);
     });
 
+    test('parses a sessionized payload', () {
+      final details = MonacoScrollHandoffDetails.tryParse({
+        'source': 'wheel',
+        'phase': 'begin',
+        'gestureId': 17,
+        'momentum': true,
+        'deltaX': 0,
+        'deltaY': 44.5,
+        'atTop': false,
+        'atBottom': true,
+        'atLeft': true,
+        'atRight': true,
+      });
+
+      expect(details, isNotNull);
+      expect(details!.phase, MonacoScrollHandoffPhase.begin);
+      expect(details.gestureId, 17);
+      expect(details.momentum, isTrue);
+    });
+
+    test('parses every phase name', () {
+      MonacoScrollHandoffPhase? phaseOf(String name) {
+        return MonacoScrollHandoffDetails.tryParse({
+          'source': 'wheel',
+          'phase': name,
+          'deltaX': 0,
+          'deltaY': 1,
+        })?.phase;
+      }
+
+      expect(phaseOf('begin'), MonacoScrollHandoffPhase.begin);
+      expect(phaseOf('update'), MonacoScrollHandoffPhase.update);
+      expect(phaseOf('end'), MonacoScrollHandoffPhase.end);
+      expect(phaseOf('cancel'), MonacoScrollHandoffPhase.cancel);
+    });
+
+    test('legacy payloads default to update/0/no-momentum', () {
+      final details = MonacoScrollHandoffDetails.tryParse({
+        'source': 'wheel',
+        'deltaX': 0,
+        'deltaY': 44.5,
+      });
+
+      expect(details, isNotNull);
+      expect(details!.phase, MonacoScrollHandoffPhase.update);
+      expect(details.gestureId, 0);
+      expect(details.momentum, isFalse);
+    });
+
+    test('drops payloads with an unknown phase', () {
+      expect(
+        MonacoScrollHandoffDetails.tryParse({
+          'source': 'wheel',
+          'phase': 'flick',
+          'deltaX': 0,
+          'deltaY': 1,
+        }),
+        isNull,
+      );
+      expect(
+        MonacoScrollHandoffDetails.tryParse({
+          'source': 'wheel',
+          'phase': 7,
+          'deltaX': 0,
+          'deltaY': 1,
+        }),
+        isNull,
+      );
+    });
+
+    test('malformed gesture ids fall back to the legacy id 0', () {
+      int? idOf(Object? raw) {
+        return MonacoScrollHandoffDetails.tryParse({
+          'source': 'wheel',
+          if (raw != null) 'gestureId': raw,
+          'deltaX': 0,
+          'deltaY': 1,
+        })?.gestureId;
+      }
+
+      expect(idOf('seventeen'), 0);
+      expect(idOf(-4), 0);
+      expect(idOf(double.nan), 0);
+      expect(idOf(3.0), 3);
+    });
+
     test('supports value equality', () {
       const a = MonacoScrollHandoffDetails(
         source: MonacoScrollHandoffSource.wheel,
@@ -151,6 +237,44 @@ void main() {
       expect(a.hashCode, b.hashCode);
       expect(a, isNot(equals(c)));
       expect(a.toString(), contains('wheel'));
+    });
+
+    test('equality covers the session fields', () {
+      const base = MonacoScrollHandoffDetails(
+        source: MonacoScrollHandoffSource.wheel,
+        deltaX: 0,
+        deltaY: 10,
+        atTop: false,
+        atBottom: true,
+        atLeft: true,
+        atRight: true,
+      );
+      const sameSession = MonacoScrollHandoffDetails(
+        source: MonacoScrollHandoffSource.wheel,
+        deltaX: 0,
+        deltaY: 10,
+        atTop: false,
+        atBottom: true,
+        atLeft: true,
+        atRight: true,
+      );
+      const otherGesture = MonacoScrollHandoffDetails(
+        source: MonacoScrollHandoffSource.wheel,
+        phase: MonacoScrollHandoffPhase.begin,
+        gestureId: 2,
+        momentum: true,
+        deltaX: 0,
+        deltaY: 10,
+        atTop: false,
+        atBottom: true,
+        atLeft: true,
+        atRight: true,
+      );
+
+      expect(base, equals(sameSession));
+      expect(base, isNot(equals(otherGesture)));
+      expect(otherGesture.toString(), contains('begin'));
+      expect(otherGesture.toString(), contains('2'));
     });
   });
 
@@ -197,6 +321,18 @@ void main() {
       expect(config.controller, same(controller));
       expect(config.useNearestScrollable, isFalse);
       expect(config.onHandoff, same(handler));
+    });
+
+    test('boundary policy defaults to newGestureOnly and is configurable', () {
+      const disabled = MonacoScrollHandoff.disabled();
+      const edge = MonacoScrollHandoff.edge();
+      const chaining = MonacoScrollHandoff.edge(
+        policy: MonacoScrollBoundaryPolicy.continuous,
+      );
+
+      expect(disabled.policy, MonacoScrollBoundaryPolicy.newGestureOnly);
+      expect(edge.policy, MonacoScrollBoundaryPolicy.newGestureOnly);
+      expect(chaining.policy, MonacoScrollBoundaryPolicy.continuous);
     });
   });
 }

--- a/test/models/monaco_scroll_handoff_test.dart
+++ b/test/models/monaco_scroll_handoff_test.dart
@@ -192,7 +192,7 @@ void main() {
       int? idOf(Object? raw) {
         return MonacoScrollHandoffDetails.tryParse({
           'source': 'wheel',
-          if (raw != null) 'gestureId': raw,
+          'gestureId': ?raw,
           'deltaX': 0,
           'deltaY': 1,
         })?.gestureId;

--- a/test/widgets/monaco_diff_editor_scroll_handoff_test.dart
+++ b/test/widgets/monaco_diff_editor_scroll_handoff_test.dart
@@ -353,6 +353,26 @@ void main() {
       expect(scripts, hasLength(1));
       expect(scripts.single, contains('"wheel":true'));
       expect(scripts.single, contains('"touch":false'));
+      expect(scripts.single, contains('"policy":"newGestureOnly"'));
+
+      await tester.pumpWidget(
+        _diffInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(
+            policy: MonacoScrollBoundaryPolicy.continuous,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      scripts = bundle.webview.scriptsContaining('page.setScrollHandoff');
+      expect(
+        scripts,
+        hasLength(2),
+        reason: 'a policy change alone must re-sync the page',
+      );
+      expect(scripts.last, contains('"policy":"continuous"'));
 
       await tester.pumpWidget(
         _diffInScrollView(
@@ -363,7 +383,7 @@ void main() {
       await tester.pump();
 
       scripts = bundle.webview.scriptsContaining('page.setScrollHandoff');
-      expect(scripts, hasLength(2));
+      expect(scripts, hasLength(3));
       expect(scripts.last, contains('"wheel":false'));
 
       // Behavioral: after disabling, deltas no longer move the parent.

--- a/test/widgets/monaco_editor_scroll_handoff_test.dart
+++ b/test/widgets/monaco_editor_scroll_handoff_test.dart
@@ -445,6 +445,26 @@ void main() {
       expect(scripts, hasLength(1));
       expect(scripts.single, contains('"wheel":true'));
       expect(scripts.single, contains('"touch":false'));
+      expect(scripts.single, contains('"policy":"newGestureOnly"'));
+
+      await tester.pumpWidget(
+        _editorInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(
+            policy: MonacoScrollBoundaryPolicy.continuous,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      scripts = bundle.webview.scriptsContaining('page.setScrollHandoff');
+      expect(
+        scripts,
+        hasLength(2),
+        reason: 'a policy change alone must re-sync the page',
+      );
+      expect(scripts.last, contains('"policy":"continuous"'));
 
       await tester.pumpWidget(
         _editorInScrollView(
@@ -455,7 +475,7 @@ void main() {
       await tester.pump();
 
       scripts = bundle.webview.scriptsContaining('page.setScrollHandoff');
-      expect(scripts, hasLength(2));
+      expect(scripts, hasLength(3));
       expect(scripts.last, contains('"wheel":false'));
 
       // Behavioral: after disabling, deltas no longer move the parent.

--- a/test/widgets/monaco_editor_scroll_handoff_test.dart
+++ b/test/widgets/monaco_editor_scroll_handoff_test.dart
@@ -39,6 +39,27 @@ void _emitHandoff(
   });
 }
 
+void _emitSessionHandoff(
+  FakePlatformWebViewController webview, {
+  required String phase,
+  required int gestureId,
+  double deltaY = 0,
+  bool momentum = false,
+}) {
+  webview.emitEvent('scrollHandoff', {
+    'source': 'wheel',
+    'phase': phase,
+    'gestureId': gestureId,
+    'momentum': momentum,
+    'deltaX': 0,
+    'deltaY': deltaY,
+    'atTop': false,
+    'atBottom': true,
+    'atLeft': true,
+    'atRight': true,
+  });
+}
+
 /// Delivers pending broadcast-stream events, then runs the coalescing
 /// frame callback.
 Future<void> _settleHandoff(WidgetTester tester) async {
@@ -475,6 +496,240 @@ void main() {
 
       _emitHandoff(bundle.webview, deltaY: 50);
       await _settleHandoff(tester);
+      expect(scrollController.offset, 50);
+    });
+
+    testWidgets('sessionized begin and update deltas accumulate and scroll', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(
+        _editorInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+      await tester.pump();
+
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'begin',
+        gestureId: 7,
+        deltaY: 20,
+      );
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'update',
+        gestureId: 7,
+        deltaY: 30,
+      );
+      await _settleHandoff(tester);
+
+      expect(scrollController.offset, 50);
+    });
+
+    testWidgets('updates from a stale or unknown gesture never scroll', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(
+        _editorInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+      await tester.pump();
+
+      // No begin was ever seen for gesture 3.
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'update',
+        gestureId: 3,
+        deltaY: 50,
+      );
+      await _settleHandoff(tester);
+      expect(scrollController.offset, 0);
+
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'begin',
+        gestureId: 7,
+        deltaY: 20,
+      );
+      await _settleHandoff(tester);
+      expect(scrollController.offset, 20);
+
+      // Gesture 3 is stale now too: only 7 may move the host.
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'update',
+        gestureId: 3,
+        deltaY: 40,
+      );
+      await _settleHandoff(tester);
+      expect(scrollController.offset, 20);
+    });
+
+    testWidgets('cancel drops deltas that have not been applied yet', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(
+        _editorInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+      await tester.pump();
+
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'begin',
+        gestureId: 7,
+        deltaY: 40,
+      );
+      _emitSessionHandoff(bundle.webview, phase: 'cancel', gestureId: 7);
+      await _settleHandoff(tester);
+
+      expect(scrollController.offset, 0);
+    });
+
+    testWidgets('end keeps deltas that were already accumulated', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(
+        _editorInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+      await tester.pump();
+
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'begin',
+        gestureId: 7,
+        deltaY: 40,
+      );
+      _emitSessionHandoff(bundle.webview, phase: 'end', gestureId: 7);
+      await _settleHandoff(tester);
+
+      expect(scrollController.offset, 40);
+    });
+
+    testWidgets('a new begin supersedes the previous session', (tester) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+
+      await tester.pumpWidget(
+        _editorInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: const MonacoScrollHandoff.edge(),
+        ),
+      );
+      await tester.pump();
+
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'begin',
+        gestureId: 7,
+        deltaY: 40,
+      );
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'begin',
+        gestureId: 8,
+        deltaY: 10,
+      );
+      await _settleHandoff(tester);
+      expect(
+        scrollController.offset,
+        10,
+        reason: 'unapplied deltas of gesture 7 die with it',
+      );
+
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'update',
+        gestureId: 7,
+        deltaY: 100,
+      );
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'update',
+        gestureId: 8,
+        deltaY: 5,
+      );
+      await _settleHandoff(tester);
+      expect(scrollController.offset, 15);
+    });
+
+    testWidgets('onHandoff sees payload phases but not lifecycle phases', (
+      tester,
+    ) async {
+      final bundle = await _createBundle();
+      addTearDown(bundle.controller.dispose);
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      final phases = <MonacoScrollHandoffPhase>[];
+
+      await tester.pumpWidget(
+        _editorInScrollView(
+          controller: bundle.controller,
+          scrollController: scrollController,
+          scrollHandoff: MonacoScrollHandoff.edge(
+            onHandoff: (details) {
+              phases.add(details.phase);
+              return false;
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'begin',
+        gestureId: 7,
+        deltaY: 20,
+      );
+      _emitSessionHandoff(
+        bundle.webview,
+        phase: 'update',
+        gestureId: 7,
+        deltaY: 30,
+      );
+      _emitSessionHandoff(bundle.webview, phase: 'end', gestureId: 7);
+      await _settleHandoff(tester);
+
+      expect(phases, [
+        MonacoScrollHandoffPhase.begin,
+        MonacoScrollHandoffPhase.update,
+      ]);
       expect(scrollController.offset, 50);
     });
 

--- a/tool/bridge_tests/scroll_handoff_test.mjs
+++ b/tool/bridge_tests/scroll_handoff_test.mjs
@@ -1,0 +1,497 @@
+// Executes the REAL scroll-handoff.js against a scripted wheel/touch event
+// stream and a fake editor with live scroll metrics. These tests pin the
+// gesture-ownership contract (boundary lock): a gesture that starts inside
+// the editor is absorbed at the scroll edge, and only a physically new
+// gesture that starts at the edge acquires the Flutter parent.
+//
+// Run: node --test tool/bridge_tests/scroll_handoff_test.mjs
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { createPage, dispatch, eventsNamed } from './harness.mjs';
+
+/**
+ * Builds an isolated page with scroll-handoff.js installed over a fake
+ * editor. Wheel events are dispatched to the module's real listener; events
+ * the module does not preventDefault are consumed by the fake editor the way
+ * Monaco would (clamped to the scroll range).
+ */
+function createScrollPage({
+  scrollTop = 0,
+  scrollHeight = 1000,
+  viewportHeight = 300,
+  policy,
+  touch = false,
+} = {}) {
+  const page = createPage();
+  const { sandbox } = page;
+
+  const listeners = new Map();
+  sandbox.addEventListener = (type, fn) => {
+    if (!listeners.has(type)) listeners.set(type, new Set());
+    listeners.get(type).add(fn);
+  };
+  sandbox.removeEventListener = (type, fn) => {
+    listeners.get(type)?.delete(fn);
+  };
+
+  // Deterministic timers: the arbiter's session-end timer never fires unless
+  // a test explicitly elapses the quiet period.
+  const timers = new Map();
+  let timerSeq = 0;
+  sandbox.setTimeout = (cb, delay) => {
+    timerSeq += 1;
+    timers.set(timerSeq, { cb, delay });
+    return timerSeq;
+  };
+  sandbox.clearTimeout = (id) => {
+    timers.delete(id);
+  };
+
+  // Just the EditorOption ids scroll-handoff.js reads.
+  sandbox.monaco = {
+    editor: { EditorOption: { lineHeight: 66, scrollbar: 102 } },
+  };
+
+  const editorState = {
+    scrollTop,
+    scrollHeight,
+    viewportHeight,
+    wheelDisabled: false,
+  };
+  const selectionHandlers = [];
+  const scrollableEl = {
+    classList: { contains: (name) => name === 'editor-scrollable' },
+  };
+  const editorDom = {
+    nodeType: 1,
+    contains: (el) => Boolean(el && el._insideEditor),
+  };
+  const editor = {
+    getLayoutInfo: () => ({
+      height: editorState.viewportHeight,
+      width: 500,
+    }),
+    getScrollTop: () => editorState.scrollTop,
+    getScrollLeft: () => 0,
+    getScrollHeight: () => editorState.scrollHeight,
+    getScrollWidth: () => 500,
+    getDomNode: () => editorDom,
+    getOption: (id) => {
+      if (id === 66) return 20;
+      if (id === 102) return { handleMouseWheel: !editorState.wheelDisabled };
+      return undefined;
+    },
+    onDidChangeCursorSelection: (fn) => {
+      selectionHandlers.push(fn);
+      return { dispose() {} };
+    },
+  };
+  const target = {
+    nodeType: 1,
+    _insideEditor: true,
+    closest: (selector) => {
+      if (selector === '.monaco-editor') return editorDom;
+      if (selector === '.monaco-scrollable-element') return scrollableEl;
+      return null;
+    },
+  };
+
+  page.load('assets/monaco/bridge/scroll-handoff.js');
+  const ctx = {
+    E: () => editor,
+    post: (name, data) => sandbox.FlutterMonaco.emit(name, data),
+  };
+  sandbox.__FMB.scrollHandoff(ctx);
+  const cfg = { wheel: true, touch };
+  if (policy !== undefined) cfg.policy = policy;
+  sandbox.flutterMonaco.setScrollHandoff(cfg);
+
+  const maxTop = () =>
+    Math.max(0, editorState.scrollHeight - editorState.viewportHeight);
+
+  let clock = 0;
+  const dispatchTo = (type, ev) => {
+    for (const fn of [...(listeners.get(type) || [])]) fn(ev);
+    return ev;
+  };
+  const makeEvent = (type, { at, gap, cancelable = true, ...rest }) => {
+    clock = at !== undefined ? at : clock + (gap !== undefined ? gap : 16);
+    return {
+      type,
+      timeStamp: clock,
+      cancelable,
+      defaultPrevented: false,
+      target,
+      prevented: false,
+      stopped: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+        this.prevented = true;
+      },
+      stopPropagation() {
+        this.stopped = true;
+      },
+      ...rest,
+    };
+  };
+
+  /** Dispatches one wheel event; unblocked events scroll the fake editor. */
+  const wheel = ({
+    deltaY,
+    deltaX = 0,
+    at,
+    gap,
+    momentum,
+    ctrlKey = false,
+    metaKey = false,
+  }) => {
+    const ev = makeEvent('wheel', {
+      at,
+      gap,
+      deltaX,
+      deltaY,
+      deltaMode: 0,
+      ctrlKey,
+      metaKey,
+    });
+    if (momentum !== undefined) ev.momentum = momentum;
+    dispatchTo('wheel', ev);
+    if (!ev.prevented && !ctrlKey && !metaKey && !editorState.wheelDisabled) {
+      editorState.scrollTop = Math.min(
+        maxTop(),
+        Math.max(0, editorState.scrollTop + deltaY),
+      );
+    }
+    return ev;
+  };
+
+  const touchPoint = (id, clientY) => ({ identifier: id, clientX: 40, clientY });
+  const touchStart = ({ y, id = 1, at, gap }) => {
+    editorState._lastTouchY = y;
+    return dispatchTo(
+      'touchstart',
+      makeEvent('touchstart', {
+        at,
+        gap,
+        touches: [touchPoint(id, y)],
+        changedTouches: [touchPoint(id, y)],
+      }),
+    );
+  };
+  /** One touch move; Monaco-style consumption for unforwarded drags. */
+  const touchMove = ({ y, id = 1, at, gap, consume = true }) => {
+    const ev = dispatchTo(
+      'touchmove',
+      makeEvent('touchmove', {
+        at,
+        gap,
+        touches: [touchPoint(id, y)],
+        changedTouches: [touchPoint(id, y)],
+      }),
+    );
+    if (consume) {
+      const dy = y - (editorState._lastTouchY ?? y);
+      editorState.scrollTop = Math.min(
+        maxTop(),
+        Math.max(0, editorState.scrollTop - dy),
+      );
+    }
+    editorState._lastTouchY = y;
+    return ev;
+  };
+  const touchEnd = ({ id = 1, at, gap } = {}) => {
+    editorState._lastTouchY = undefined;
+    return dispatchTo(
+      'touchend',
+      makeEvent('touchend', {
+        at,
+        gap,
+        touches: [],
+        changedTouches: [touchPoint(id, 0)],
+      }),
+    );
+  };
+
+  const firePendingTimers = () => {
+    const pending = [...timers.values()];
+    timers.clear();
+    for (const t of pending) t.cb();
+  };
+  const events = () => eventsNamed(page, 'scrollHandoff').map((m) => m.data);
+
+  return {
+    page,
+    sandbox,
+    editorState,
+    selectionHandlers,
+    wheel,
+    touchStart,
+    touchMove,
+    touchEnd,
+    firePendingTimers,
+    events,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Wheel: boundary lock (policy default = newGestureOnly)
+// ---------------------------------------------------------------------------
+
+test('a gesture that starts inside the editor is absorbed at the edge', () => {
+  const p = createScrollPage({ scrollTop: 400 }); // maxTop = 700
+  const inMotion = [
+    p.wheel({ deltaY: 120, at: 0 }),
+    p.wheel({ deltaY: 120 }),
+    p.wheel({ deltaY: 120 }), // crosses the edge: Monaco clamps, no spill
+  ];
+  const tail = [
+    p.wheel({ deltaY: 120 }),
+    p.wheel({ deltaY: 110 }),
+    p.wheel({ deltaY: 90 }),
+    p.wheel({ deltaY: 40 }),
+  ];
+
+  assert.equal(p.editorState.scrollTop, 700);
+  for (const ev of inMotion) assert.equal(ev.prevented, false);
+  // The wall: every residual event is cancelled and dropped.
+  for (const ev of tail) assert.equal(ev.prevented, true);
+  assert.deepEqual(p.events(), []);
+});
+
+test('a fresh gesture starting at the edge acquires the parent immediately', () => {
+  const p = createScrollPage({ scrollTop: 700 });
+  const first = p.wheel({ deltaY: 100, at: 1000 });
+  const second = p.wheel({ deltaY: 90 });
+
+  assert.equal(first.prevented, true);
+  assert.equal(second.prevented, true);
+  const posted = p.events();
+  assert.equal(posted.length, 2);
+  assert.equal(posted[0].phase, 'begin');
+  assert.equal(posted[0].source, 'wheel');
+  assert.equal(posted[0].deltaY, 100);
+  assert.equal(posted[0].momentum, false);
+  assert.equal(posted[0].atBottom, true);
+  assert.equal(posted[1].phase, 'update');
+  assert.equal(posted[1].deltaY, 90);
+  assert.ok(posted[0].gestureId >= 1);
+  assert.equal(posted[1].gestureId, posted[0].gestureId);
+});
+
+test('same-direction input shortly after a child tail stays absorbed; a distinct later gesture acquires the parent', () => {
+  const p = createScrollPage({ scrollTop: 640 });
+  p.wheel({ deltaY: 120, at: 0 }); // child, reaches 700
+  p.wheel({ deltaY: 120, at: 16 }); // wall -> locked
+  p.wheel({ deltaY: 120, at: 200 }); // 184ms gap: still the same transaction
+  p.wheel({ deltaY: 120, at: 400 }); // 200ms gap: still absorbed
+  assert.deepEqual(p.events(), []);
+
+  const distinct = p.wheel({ deltaY: 120, at: 700 }); // 300ms of silence
+  assert.equal(distinct.prevented, true);
+  const posted = p.events();
+  assert.equal(posted.length, 1);
+  assert.equal(posted[0].phase, 'begin');
+});
+
+test('reversal while locked hands the event back to the editor', () => {
+  const p = createScrollPage({ scrollTop: 640 });
+  p.wheel({ deltaY: 120, at: 0 }); // child -> 700
+  p.wheel({ deltaY: 120, at: 16 }); // locked
+  const reversal = p.wheel({ deltaY: -120, at: 32 });
+
+  assert.equal(reversal.prevented, false);
+  assert.equal(p.editorState.scrollTop, 580);
+  assert.deepEqual(p.events(), []);
+});
+
+test('a parent session ends after the quiet period', () => {
+  const p = createScrollPage({ scrollTop: 700 });
+  p.wheel({ deltaY: 100, at: 0 });
+  p.firePendingTimers();
+
+  const posted = p.events();
+  assert.equal(posted.length, 2);
+  assert.equal(posted[1].phase, 'end');
+  assert.equal(posted[1].gestureId, posted[0].gestureId);
+  assert.equal(posted[1].deltaY, 0);
+});
+
+test('parent reversal into consumable content ends the session and scrolls the editor', () => {
+  const p = createScrollPage({ scrollTop: 700 });
+  p.wheel({ deltaY: 100, at: 0 });
+  const reversal = p.wheel({ deltaY: -100, at: 16 });
+
+  assert.equal(reversal.prevented, false);
+  assert.equal(p.editorState.scrollTop, 600);
+  const posted = p.events();
+  assert.equal(posted.length, 2);
+  assert.equal(posted[0].phase, 'begin');
+  assert.equal(posted[1].phase, 'end');
+});
+
+test('momentum metadata: inertia never acquires the parent, direct input after a tail does instantly', () => {
+  const p = createScrollPage({ scrollTop: 640 });
+  p.wheel({ deltaY: 120, at: 0, momentum: false }); // child -> 700
+  p.wheel({ deltaY: 120, at: 16, momentum: true }); // wall inside the tail
+  p.wheel({ deltaY: 120, at: 32, momentum: true }); // absorbed
+  assert.deepEqual(p.events(), []);
+
+  // Fingers back on the trackpad while the old tail still streams: a direct
+  // event is a new physical gesture and may take the parent with no wait.
+  const direct = p.wheel({ deltaY: 120, at: 48, momentum: false });
+  assert.equal(direct.prevented, true);
+  const posted = p.events();
+  assert.equal(posted.length, 1);
+  assert.equal(posted[0].phase, 'begin');
+});
+
+test('an isolated momentum event at the edge is absorbed, never forwarded', () => {
+  const p = createScrollPage({ scrollTop: 700 });
+  const ev = p.wheel({ deltaY: 80, at: 0, momentum: true });
+
+  assert.equal(ev.prevented, true);
+  assert.deepEqual(p.events(), []);
+});
+
+test('non-scrollable document: fresh direct gestures go to the parent, isolated momentum does not', () => {
+  const p = createScrollPage({ scrollHeight: 200 }); // maxTop = 0
+  const direct = p.wheel({ deltaY: 50, at: 0 });
+  assert.equal(direct.prevented, true);
+  assert.equal(p.events().length, 1);
+  assert.equal(p.events()[0].phase, 'begin');
+
+  const q = createScrollPage({ scrollHeight: 200 });
+  const inertial = q.wheel({ deltaY: 50, at: 0, momentum: true });
+  assert.equal(inertial.prevented, true);
+  assert.deepEqual(q.events(), []);
+});
+
+test('continuous policy keeps 2.3.0 chaining and the legacy payload shape', () => {
+  const p = createScrollPage({ scrollTop: 640, policy: 'continuous' });
+  const consumed = p.wheel({ deltaY: 120, at: 0 }); // editor scrolls to 700
+  const spill1 = p.wheel({ deltaY: 120, at: 16 });
+  const spill2 = p.wheel({ deltaY: 120, at: 32 }); // same-gesture inertia leaks
+
+  assert.equal(consumed.prevented, false);
+  assert.equal(spill1.prevented, true);
+  assert.equal(spill2.prevented, true);
+  const posted = p.events();
+  assert.equal(posted.length, 2);
+  for (const payload of posted) {
+    assert.equal(payload.source, 'wheel');
+    assert.equal(payload.deltaY, 120);
+    assert.equal('phase' in payload, false);
+    assert.equal('gestureId' in payload, false);
+    assert.equal('momentum' in payload, false);
+  }
+});
+
+test('the policy also arrives through the page.setScrollHandoff command', async () => {
+  const p = createScrollPage({ scrollTop: 640 });
+  await dispatch(p.page, 'page.setScrollHandoff', {
+    wheel: true,
+    touch: false,
+    policy: 'continuous',
+  });
+  p.wheel({ deltaY: 120, at: 0 }); // child consumes to the edge
+  p.wheel({ deltaY: 120, at: 16 }); // continuous: spills immediately
+
+  const posted = p.events();
+  assert.equal(posted.length, 1);
+  assert.equal('phase' in posted[0], false);
+});
+
+test('disabling the wheel source mid-parent-session cancels it', () => {
+  const p = createScrollPage({ scrollTop: 700 });
+  p.wheel({ deltaY: 100, at: 0 });
+  p.sandbox.flutterMonaco.setScrollHandoff({ wheel: false });
+
+  const posted = p.events();
+  assert.equal(posted.length, 2);
+  assert.equal(posted[1].phase, 'cancel');
+  assert.equal(posted[1].gestureId, posted[0].gestureId);
+
+  const after = p.wheel({ deltaY: 100, at: 16 });
+  assert.equal(after.prevented, false);
+  assert.equal(p.events().length, 2);
+});
+
+test('ctrl/meta wheel input is never arbitrated', () => {
+  const p = createScrollPage({ scrollTop: 700 });
+  const zoom = p.wheel({ deltaY: 100, at: 0, ctrlKey: true });
+
+  assert.equal(zoom.prevented, false);
+  assert.deepEqual(p.events(), []);
+});
+
+// ---------------------------------------------------------------------------
+// Touch ownership (policy default = newGestureOnly)
+// ---------------------------------------------------------------------------
+
+test('touch: a drag that starts over scrollable content never forwards, even past the edge', () => {
+  const p = createScrollPage({ scrollTop: 600, touch: true });
+  p.touchStart({ y: 300, at: 0 });
+  p.touchMove({ y: 280, at: 16 }); // slop exceeded, editor scrolls (owner: child)
+  p.touchMove({ y: 200, at: 32 }); // editor reaches 700
+  p.touchMove({ y: 120, at: 48 }); // at the wall: absorbed, not forwarded
+  p.touchMove({ y: 60, at: 64 });
+  p.touchEnd({ at: 80 });
+
+  assert.equal(p.editorState.scrollTop, 700);
+  assert.deepEqual(p.events(), []);
+});
+
+test('touch: a drag that starts at the edge is parent-owned for its whole lifetime', () => {
+  const p = createScrollPage({ scrollTop: 700, touch: true });
+  p.touchStart({ y: 300, at: 0 });
+  p.touchMove({ y: 280, at: 16, consume: false }); // outward at the edge
+  p.touchMove({ y: 240, at: 32, consume: false });
+  p.touchEnd({ at: 48 });
+
+  const posted = p.events();
+  assert.equal(posted.length, 3);
+  assert.equal(posted[0].phase, 'begin');
+  assert.equal(posted[0].source, 'touch');
+  assert.equal(posted[0].deltaY, 20);
+  assert.equal(posted[1].phase, 'update');
+  assert.equal(posted[1].deltaY, 40);
+  assert.equal(posted[2].phase, 'end');
+  assert.equal(
+    new Set(posted.map((payload) => payload.gestureId)).size,
+    1,
+  );
+});
+
+test('touch: a selection change cancels a parent-owned drag', () => {
+  const p = createScrollPage({ scrollTop: 700, touch: true });
+  p.touchStart({ y: 300, at: 0 });
+  p.touchMove({ y: 280, at: 16, consume: false });
+  for (const fn of p.selectionHandlers) fn();
+  p.touchMove({ y: 240, at: 32, consume: false });
+  p.touchEnd({ at: 48 });
+
+  const posted = p.events();
+  assert.equal(posted.length, 2);
+  assert.equal(posted[0].phase, 'begin');
+  assert.equal(posted[1].phase, 'cancel');
+});
+
+test('touch: continuous policy keeps the per-move legacy behavior', () => {
+  const p = createScrollPage({
+    scrollTop: 600,
+    touch: true,
+    policy: 'continuous',
+  });
+  p.touchStart({ y: 300, at: 0 });
+  p.touchMove({ y: 280, at: 16 }); // consumable: not forwarded
+  p.touchMove({ y: 180, at: 32 }); // editor clamps at 700
+  p.touchMove({ y: 100, at: 48 }); // at the edge: legacy spill
+  p.touchEnd({ at: 64 });
+
+  const posted = p.events();
+  assert.equal(posted.length, 1);
+  assert.equal(posted[0].source, 'touch');
+  assert.equal(posted[0].deltaY, 80);
+  assert.equal('phase' in posted[0], false);
+});


### PR DESCRIPTION
## Problem

Edge scroll handoff forwards every delta the editor cannot consume. A fast wheel or trackpad fling that reaches the editor's scroll edge therefore spills its remaining kinetic energy into the host page and jerks it, when the user only wanted to reach the end of the code block.

## Fix: gesture ownership ("boundary lock")

scroll-handoff.js now arbitrates every wheel event through an exclusive ownership state machine (idle / child / locked / parent) before Monaco sees it:

- A transaction that starts while the editor can scroll belongs to the editor. When it hits the edge it enters `locked` and every residual event - the whole inertial tail - is cancelled and dropped. Nothing crosses the bridge.
- Only a transaction that STARTS at the edge is parent-owned. It is forwarded as a begin/update/end session keyed by `gestureId`, its own inertia included.
- Reversing direction into the editor hands input back instantly, from any state.
- Transaction boundaries come from quiet periods (120ms in-editor idle; 260ms boundary re-arm, chosen so a false "same gesture" costs a quarter second of delay while a false "new gesture" would jerk the page) plus the Pointer Events level 4 `momentum` flag where the browser ships it (feature-detected: a momentum event can never acquire the parent; a direct event right after a tail is a new gesture with zero wait).
- Touch (experimental source) decides ownership once per drag at the first vertical movement: editor-owned drags are contained at the wall for their whole lifetime.

Dart side: `ScrollHandoffDriver` applies updates only for the gesture it saw begin, so stale or superseded deltas can never move the host. `MonacoScrollHandoffDetails` gains `phase` / `gestureId` / `momentum`; legacy payloads keep working unchanged.

The behavior is public API: `MonacoScrollBoundaryPolicy.newGestureOnly` (new default) vs `continuous` (byte-compatible 2.3.0 chaining, legacy payload shape) on `MonacoScrollHandoff.edge` and `setScrollHandoffSources` of both controllers.

## Testing

- 17 new Node bridge tests execute the real scroll-handoff.js against a scripted event stream: containment at the wall, edge acquisition, the 260ms re-arm window, reversal handback, session end/cancel, momentum semantics, non-scrollable documents, continuous-policy byte compatibility, and touch ownership. 32 bridge tests total; the CI step now runs `tool/bridge_tests/*_test.mjs`.
- 15 new Dart tests: sessionized payload parsing, driver session gating (stale updates, cancel, supersede), and policy plumbing through controllers and both widgets. Full suite: 604 package + 14 example tests green, analyzer and formatter clean.
- E2E on a real browser: built the example web app and drove headless Chrome via CDP into the "Long editor with edge handoff". A ~150-event fling past the bottom edge left the page pixel-still while the editor bottomed out (old behavior leaked from the first at-edge event); a distinct gesture 450ms later scrolled the page 360px; an immediate reversal scrolled the editor back with the page still.

## Merge order (important)

Stacked on #33 (3.3.0). **Merge #33 first**; GitHub then retargets this PR to main, and merging it releases 3.4.0 through the usual pubspec auto-release chain. If you would rather ship one combined release instead, fold the [3.4.0] CHANGELOG section into [3.3.0] before merging so no phantom version appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)