### PR TITLE
Release 3.4.0: page reload recovery + web blob lifetime fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-07-11
+
+The editor now survives page reloads it never caused. On Flutter web the engine can detach and re-insert the editor's iframe during platform-view re-composition (closing/opening in-app tabs, route transitions), and re-inserting an iframe makes the browser reload it; native WebView processes can likewise recover from a crash. Both cases previously left a dead editor behind.
+
+### Fixed
+- **Web: the editor pane no longer turns into the browser's "It may have been moved, edited, or deleted." error page.** The Monaco page's blob URL was revoked as soon as the page first reported ready, so any later engine-driven iframe re-insertion reloaded a dead URL. The blob URL now lives exactly as long as the iframe and is released on `dispose()`.
+
+### Added
+- **Automatic page-reload recovery.** When the page document reloads under a live controller, `MonacoController` and `MonacoDiffController` detect it, re-boot the editor with their original boot payload (options, text, language, theme), and re-register every live `registerCompletions` provider and `addAction` action - existing registration handles stay valid. `MonacoEditor` additionally re-applies its widget-owned options, resolved theme, background color, and scroll-handoff sources.
+- **`onPageReloaded` stream on `MonacoController` and `MonacoDiffController`.** Fires after a recovery completes, once the editor accepts commands again. Listen to restore what the package cannot know: document content and models opened with `openDocument` (stale pinned handles throw), post-boot configuration (`updateOptions`, `setTheme`, `defineTheme`, markers, decorations, view states), and LSP connections (reconnect them). A failed recovery surfaces as an error event on the stream.
+- **`MonacoPageReloadedError`.** Commands in flight when the page reloads now fail immediately with this typed, retryable error instead of hanging until their timeout. Note for exhaustive `switch`es over the sealed `MonacoException`: this adds a new member.
+
 ## [3.3.0] - 2026-07-10
 
 Two independent improvements in one release. Correctness fixes driven by an external architecture audit of v3: two release-blocking fixes (dirty tracking, boot-error propagation), a set of lifecycle repairs, and small API additions; no public API is removed. And edge scroll handoff gains native nested-scroll boundary behavior: the gesture that reaches the editor's scroll edge stops there instead of jerking the surrounding page.

--- a/lib/flutter_monaco.dart
+++ b/lib/flutter_monaco.dart
@@ -64,6 +64,7 @@ export 'src/common/exceptions.dart'
         MonacoDisposedError,
         MonacoException,
         MonacoJavaScriptError,
+        MonacoPageReloadedError,
         MonacoProtocolError,
         MonacoTimeoutError;
 export 'src/assets/asset_diagnostics.dart' show MonacoAssetDiagnostics;

--- a/lib/src/common/exceptions.dart
+++ b/lib/src/common/exceptions.dart
@@ -10,6 +10,9 @@ import 'dart:async';
 /// * [MonacoTimeoutError] - no response arrived in time.
 /// * [MonacoDisposedError] - the controller/protocol was used after dispose,
 ///   or disposed while work was in flight.
+/// * [MonacoPageReloadedError] - the page document reloaded while the
+///   command was in flight; the command can be retried once the editor
+///   recovers (`MonacoController.onPageReloaded`).
 ///
 /// Every read and write on `MonacoController` throws on failure; nothing is
 /// silently defaulted.
@@ -125,5 +128,22 @@ final class MonacoTimeoutError extends MonacoException
 final class MonacoDisposedError extends MonacoException {
   /// Creates a use-after-dispose error.
   const MonacoDisposedError({required String message, String? operation})
+    : super(message, operation: operation);
+}
+
+/// The page document reloaded while the command was in flight, so the
+/// command can never be answered: every page-side object (models,
+/// registrations, pending responses) was discarded with the old document.
+///
+/// Page reloads happen outside the app's control - the Flutter web engine
+/// re-inserted the editor's iframe during platform-view re-composition, a
+/// native WebView process recovered, or the page was refreshed. Unlike
+/// [MonacoDisposedError] this is transient: the controller re-boots the
+/// fresh page automatically and announces recovery through
+/// `MonacoController.onPageReloaded`, after which the command can be
+/// retried.
+final class MonacoPageReloadedError extends MonacoException {
+  /// Creates a reload-interrupted-command error.
+  const MonacoPageReloadedError({required String message, String? operation})
     : super(message, operation: operation);
 }

--- a/lib/src/diff/diff_controller.dart
+++ b/lib/src/diff/diff_controller.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_monaco/flutter_monaco.dart';
 import 'package:flutter_monaco/src/platform/platform_webview.dart';
@@ -29,13 +29,23 @@ import 'package:flutter_monaco/src/protocol/protocol.dart';
 /// Prefer the `MonacoDiffEditor` widget, which renders loading/error chrome
 /// and manages this controller's lifecycle.
 class MonacoDiffController {
-  MonacoDiffController._(this._protocol, this._webViewController);
+  MonacoDiffController._(this._protocol, this._webViewController) {
+    _reloadSubscription = _protocol.pageReloads.listen((reload) {
+      unawaited(_recoverFromPageReload(reload));
+    });
+  }
 
   final MonacoProtocol _protocol;
   final PlatformWebViewController _webViewController;
   final Completer<void> _onReady = Completer<void>();
   bool _readyCompletedOk = false;
   bool _disposed = false;
+
+  /// The exact `page.boot` payload of the first boot, replayed verbatim
+  /// when the page document reloads (see [onPageReloaded]).
+  Map<String, Object?>? _bootPayload;
+  final _pageReloaded = StreamController<void>.broadcast();
+  StreamSubscription<MonacoPageReload>? _reloadSubscription;
 
   /// Completes when the diff editor is fully initialized and ready to
   /// accept commands. Completes with the boot error if initialization
@@ -44,6 +54,47 @@ class MonacoDiffController {
 
   /// Returns `true` if the diff editor finished initializing successfully.
   bool get isReady => _onReady.isCompleted && _readyCompletedOk;
+
+  /// Fires after the controller recovered from a page reload.
+  ///
+  /// Same contract as `MonacoController.onPageReloaded`: the page document
+  /// reloaded outside the app's control (Flutter web re-inserted the
+  /// iframe, a WebView process recovered, or the page was refreshed), the
+  /// controller re-booted the diff editor with its ORIGINAL boot payload
+  /// (original/modified text, language, options, theme), and the editor
+  /// accepts commands again. Content and configuration applied after
+  /// [create] must be restored by the app from this stream; commands that
+  /// were in flight failed with [MonacoPageReloadedError]. A failed
+  /// recovery surfaces as an error event on this stream.
+  Stream<void> get onPageReloaded => _pageReloaded.stream;
+
+  /// Converges a freshly reloaded diff page back to a booted editor. See
+  /// [onPageReloaded].
+  Future<void> _recoverFromPageReload(MonacoPageReload reload) async {
+    if (_disposed) return;
+    final bootPayload = _bootPayload;
+    if (bootPayload == null) {
+      debugPrint(
+        '[MonacoDiffController] Page reloaded before boot completed; '
+        'leaving recovery to the boot flow.',
+      );
+      return;
+    }
+    debugPrint('[MonacoDiffController] Page reloaded; re-booting the editor.');
+    try {
+      await _protocol.invoke('page.boot', bootPayload, timeout: null);
+      await reload.editorReady;
+      if (_disposed) return;
+      _pageReloaded.add(null);
+    } on MonacoPageReloadedError {
+      // Superseded by an even newer reload; its recovery takes over.
+    } on MonacoDisposedError {
+      // Disposed mid-recovery; nothing to announce.
+    } catch (e, st) {
+      debugPrint('[MonacoDiffController] Page reload recovery failed: $e');
+      if (!_disposed) _pageReloaded.addError(e, st);
+    }
+  }
 
   /// The platform-specific WebView widget hosting the diff editor.
   Widget get webViewWidget => _webViewController.widget;
@@ -124,7 +175,8 @@ class MonacoDiffController {
         await () async {
           await _webViewController.load(page: page);
           await _protocol.pageReady;
-          await _protocol.invoke('page.boot', {
+          // Kept for page-reload recovery (onPageReloaded).
+          final bootPayload = <String, Object?>{
             'mode': 'diff',
             'options': bootOptions.toMonacoOptions(),
             'diffOptions': diff.toMonacoOptions(),
@@ -132,7 +184,9 @@ class MonacoDiffController {
             'modified': modified,
             'language': language.id,
             'theme': bootTheme.id,
-          }, timeout: null);
+          };
+          _bootPayload = bootPayload;
+          await _protocol.invoke('page.boot', bootPayload, timeout: null);
           await _protocol.editorReady;
         }().timeout(
           readyTimeout,
@@ -361,6 +415,8 @@ class MonacoDiffController {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _reloadSubscription?.cancel();
+    _pageReloaded.close();
     _protocol.dispose();
     _webViewController.dispose();
   }

--- a/lib/src/editor/controller.dart
+++ b/lib/src/editor/controller.dart
@@ -23,6 +23,7 @@ class MonacoController {
   MonacoController._(this._protocol, this._webViewController) {
     _wireEvents();
     _wireRequests();
+    _wireReloadRecovery();
     _lspManager = MonacoLspManager(protocol: _protocol);
   }
 
@@ -31,6 +32,11 @@ class MonacoController {
   final Completer<void> _onReady = Completer<void>();
   late final MonacoLspManager _lspManager;
   bool _disposed = false;
+
+  /// The exact `page.boot` payload of the first boot, replayed verbatim
+  /// when the page document reloads (see [onPageReloaded]). Null until
+  /// [_startBoot] runs.
+  Map<String, Object?>? _bootPayload;
 
   /// The EFFECTIVE interaction state ([_baseInteractionEnabled] with no
   /// active [runWithInteractionDisabled] scopes).
@@ -53,6 +59,10 @@ class MonacoController {
   final _events = StreamController<MonacoEvent>.broadcast();
   StreamSubscription<ProtocolEvent>? _eventSubscription;
 
+  // Page-reload recovery (see onPageReloaded).
+  final _pageReloaded = StreamController<void>.broadcast();
+  StreamSubscription<MonacoPageReload>? _reloadSubscription;
+
   late final MonacoFocusCoordinator _focus = MonacoFocusCoordinator(
     webView: _webViewController,
     ensureReady: _ensureReady,
@@ -64,8 +74,14 @@ class MonacoController {
   /// model is currently attached to the editor. See [MonacoDocument].
   late final MonacoDocument document = MonacoDocument.internal(_invoke, null);
 
-  final Map<String, CompletionProvider> _completionSources = {};
-  final Map<String, Future<void> Function()> _customActions = {};
+  /// Live completion registrations, keyed by provider id. Each entry keeps
+  /// its `completions.register` params so recovery from a page reload can
+  /// re-register it on the fresh page.
+  final Map<String, _CompletionRegistrationState> _completionSources = {};
+
+  /// Live Dart-defined actions, keyed by action id. Each entry keeps its
+  /// `actions.register` descriptor for page-reload replay.
+  final Map<String, _ActionRegistrationState> _customActions = {};
   StreamSubscription<ProtocolRequest>? _requestSubscription;
   int _registrationSeq = 0;
   MonacoCapabilities? _capabilities;
@@ -137,6 +153,38 @@ class MonacoController {
   Stream<MonacoScrollHandoffDetails> get onScrollHandoff => events
       .where((e) => e is MonacoScrollHandoffEvent)
       .map((e) => (e as MonacoScrollHandoffEvent).details);
+
+  /// Fires after the controller recovered from a page reload.
+  ///
+  /// The page document can reload outside the app's control: the Flutter
+  /// web engine detaches and re-inserts the editor's iframe during
+  /// platform-view re-composition (tab and route churn) and re-inserting an
+  /// iframe reloads it, a native WebView process can recover from a crash,
+  /// or the page can be refreshed. The reloaded document is a bare shell -
+  /// everything page-side is discarded.
+  ///
+  /// The controller recovers on its own before this fires: it re-boots the
+  /// editor with the ORIGINAL boot payload (options, text, language, theme
+  /// as passed to [create]), waits for readiness, and re-registers every
+  /// live [registerCompletions] provider and [addAction] action, so their
+  /// registration handles stay valid. By the time an event arrives here the
+  /// editor accepts commands again.
+  ///
+  /// What the controller cannot restore is state it never owned - listen to
+  /// this stream to restore it:
+  ///
+  /// * Document content and models: text reverts to the boot text; models
+  ///   opened with [openDocument] are gone (their pinned handles now throw
+  ///   [MonacoJavaScriptError]) - re-open and re-activate them.
+  /// * Post-boot configuration: [updateOptions], [setTheme], [defineTheme],
+  ///   [setScrollHandoffSources], markers, decorations, and view states.
+  /// * LSP connections: they died with the page - disconnect and reconnect.
+  ///
+  /// Commands that were in flight when the page reloaded fail with
+  /// [MonacoPageReloadedError]; retry them from here. If the re-boot itself
+  /// fails, the failure is delivered as an error event on this stream and
+  /// the editor stays unusable.
+  Stream<void> get onPageReloaded => _pageReloaded.stream;
 
   /// Creates a new [MonacoController] and boots the editor.
   ///
@@ -238,13 +286,16 @@ class MonacoController {
 
           // Boot the editor with the merged initial state; the response
           // acknowledges acceptance, the ready lifecycle follows creation.
-          await _protocol.invoke('page.boot', {
+          // The payload is kept for page-reload recovery (onPageReloaded).
+          final bootPayload = <String, Object?>{
             'options': bootOptions.toMonacoOptions(),
             'text': initialText ?? '',
             'language': bootLanguage.id,
             'theme': bootTheme.id,
             'scrollHandoff': const {'wheel': false, 'touch': false},
-          }, timeout: null);
+          };
+          _bootPayload = bootPayload;
+          await _protocol.invoke('page.boot', bootPayload, timeout: null);
 
           await _protocol.editorReady;
         }().timeout(
@@ -278,11 +329,20 @@ class MonacoController {
   /// When [markReady] is true, synthetic `pageReady` and `ready` lifecycle
   /// envelopes are pushed through the real protocol decode path so the
   /// controller behaves exactly as it does against a live page.
+  ///
+  /// When [runBoot] is true, the REAL boot pipeline runs against the fake
+  /// WebView instead ([markReady] is ignored): `load()` is expected to emit
+  /// `pageReady`, `page.boot` carries [bootOptions] and [bootInitialText],
+  /// and readiness follows the fake's `ready` lifecycle. Use this to
+  /// exercise flows that depend on boot state, like page-reload recovery.
   @visibleForTesting
   static Future<MonacoController> createForTesting({
     required PlatformWebViewController webViewController,
     bool markReady = true,
     String channelName = 'flutterChannel',
+    bool runBoot = false,
+    EditorOptions? bootOptions,
+    String? bootInitialText,
   }) async {
     final protocol = MonacoProtocol(webView: webViewController);
 
@@ -294,7 +354,14 @@ class MonacoController {
     );
 
     final controller = MonacoController._(protocol, webViewController);
-    if (markReady) {
+    if (runBoot) {
+      controller._startBoot(
+        options: bootOptions,
+        initialText: bootInitialText,
+        page: const MonacoPageConfig(),
+        readyTimeout: const Duration(seconds: 20),
+      );
+    } else if (markReady) {
       controller.completeReadyForTesting();
     }
     return controller;
@@ -571,13 +638,17 @@ class MonacoController {
     }
 
     final providerId = id ?? 'flutter_${++_registrationSeq}';
-    _completionSources[providerId] = provider;
-    try {
-      await _invoke('completions.register', {
+    final registration = _CompletionRegistrationState(
+      provider: provider,
+      params: {
         'id': providerId,
         'languages': [for (final language in languages) language.id],
         'triggerCharacters': List<String>.from(triggerCharacters),
-      });
+      },
+    );
+    _completionSources[providerId] = registration;
+    try {
+      await _invoke('completions.register', registration.params);
     } catch (e) {
       _completionSources.remove(providerId);
       rethrow;
@@ -646,9 +717,13 @@ class MonacoController {
         'Action "$actionId" is already registered',
       );
     }
-    _customActions[actionId] = run;
+    final registration = _ActionRegistrationState(
+      run: run,
+      descriptor: descriptor.toJson(),
+    );
+    _customActions[actionId] = registration;
     try {
-      await _invoke('actions.register', descriptor.toJson());
+      await _invoke('actions.register', registration.descriptor);
     } catch (e) {
       _customActions.remove(actionId);
       rethrow;
@@ -773,6 +848,65 @@ class MonacoController {
     });
   }
 
+  /// Wire up page-reload recovery (see [onPageReloaded]).
+  void _wireReloadRecovery() {
+    _reloadSubscription = _protocol.pageReloads.listen((reload) {
+      unawaited(_recoverFromPageReload(reload));
+    });
+  }
+
+  /// Converges a freshly reloaded page back to a booted, usable editor.
+  ///
+  /// Replays the original boot payload, awaits the reloaded page's ready
+  /// lifecycle, re-registers Dart-side completion providers and custom
+  /// actions, then announces the recovery on [onPageReloaded]. A newer
+  /// reload arriving mid-recovery fails this attempt's commands with
+  /// [MonacoPageReloadedError] and runs its own recovery; a genuine boot
+  /// failure is surfaced as an error on [onPageReloaded].
+  Future<void> _recoverFromPageReload(MonacoPageReload reload) async {
+    if (_disposed) return;
+    final bootPayload = _bootPayload;
+    if (bootPayload == null) {
+      // Reload before the first boot dispatched anything: there is nothing
+      // to replay, and the original boot flow still owns readiness.
+      debugPrint(
+        '[MonacoController] Page reloaded before boot completed; '
+        'leaving recovery to the boot flow.',
+      );
+      return;
+    }
+    debugPrint('[MonacoController] Page reloaded; re-booting the editor.');
+    try {
+      _capabilities = MonacoCapabilities.fromHandshake(reload.handshake);
+      await _protocol.invoke('page.boot', bootPayload, timeout: null);
+      await reload.editorReady;
+      await _replayRegistrations();
+      if (_disposed) return;
+      _pageReloaded.add(null);
+    } on MonacoPageReloadedError {
+      // Superseded by an even newer reload; its recovery takes over.
+    } on MonacoDisposedError {
+      // Disposed mid-recovery; nothing to announce.
+    } catch (e, st) {
+      debugPrint('[MonacoController] Page reload recovery failed: $e');
+      if (!_disposed) _pageReloaded.addError(e, st);
+    }
+  }
+
+  /// Re-registers every live completion provider and custom action on the
+  /// reloaded page, keeping existing registration handles valid.
+  Future<void> _replayRegistrations() async {
+    for (final entry in List.of(_completionSources.entries)) {
+      // Skip registrations disposed while recovery was in flight.
+      if (!identical(_completionSources[entry.key], entry.value)) continue;
+      await _protocol.invoke('completions.register', entry.value.params);
+    }
+    for (final entry in List.of(_customActions.entries)) {
+      if (!identical(_customActions[entry.key], entry.value)) continue;
+      await _protocol.invoke('actions.register', entry.value.descriptor);
+    }
+  }
+
   Future<void> _handleRequest(ProtocolRequest request) async {
     try {
       switch (request.name) {
@@ -807,7 +941,7 @@ class MonacoController {
       return;
     }
 
-    final provider = _completionSources[completionRequest.providerId];
+    final provider = _completionSources[completionRequest.providerId]?.provider;
     if (provider == null) {
       await _protocol.respond(request.id, value: emptySuggestions);
       return;
@@ -825,7 +959,7 @@ class MonacoController {
 
   Future<void> _handleActionRequest(ProtocolRequest request) async {
     final actionId = request.data['actionId'];
-    final run = actionId is String ? _customActions[actionId] : null;
+    final run = actionId is String ? _customActions[actionId]?.run : null;
     if (run == null) {
       await _protocol.respond(request.id, error: 'Unknown action: $actionId');
       return;
@@ -1244,11 +1378,32 @@ class MonacoController {
     _lspManager.dispose();
     _eventSubscription?.cancel();
     _requestSubscription?.cancel();
+    _reloadSubscription?.cancel();
     _completionSources.clear();
     _customActions.clear();
     _events.close();
+    _pageReloaded.close();
     _liveStats.dispose();
     _protocol.dispose();
     _webViewController.dispose();
   }
+}
+
+/// Replay state for one live completion registration: the Dart [provider]
+/// answering requests, and the `completions.register` [params] re-sent when
+/// a page reload discards the page-side registration.
+class _CompletionRegistrationState {
+  _CompletionRegistrationState({required this.provider, required this.params});
+
+  final CompletionProvider provider;
+  final Map<String, Object?> params;
+}
+
+/// Replay state for one live Dart-defined action: the [run] callback, and
+/// the `actions.register` [descriptor] re-sent after a page reload.
+class _ActionRegistrationState {
+  _ActionRegistrationState({required this.run, required this.descriptor});
+
+  final Future<void> Function() run;
+  final Map<String, Object?> descriptor;
 }

--- a/lib/src/platform/webview_web.dart
+++ b/lib/src/platform/webview_web.dart
@@ -65,8 +65,15 @@ String _monacoBridgeAssetUrl() {
 /// ### HTML Loading
 ///
 /// Monaco HTML is generated as a blob URL to avoid CORS issues with
-/// `file://` or asset paths. The blob URL is revoked after Monaco
-/// reports ready to free memory.
+/// `file://` or asset paths. The blob URL stays alive for as long as the
+/// iframe exists (released on [dispose] or when a retry replaces it): the
+/// Flutter web engine can detach and re-insert the iframe's DOM node at any
+/// time after creation (platform-view re-composition around tab and route
+/// churn), and re-inserting an iframe reloads its `src` from scratch. A
+/// revoked blob would make that reload render Chromium's ERR_FILE_NOT_FOUND
+/// page inside the editor. The reload itself is recovered by
+/// `MonacoController` re-booting the fresh page shell (see
+/// `MonacoProtocol.pageReloads`).
 ///
 /// ### Focus Handling
 ///
@@ -107,6 +114,25 @@ class WebViewController implements PlatformWebViewController {
   JSFunction? _messageHandler;
   String? _viewId;
   late final String _messageToken;
+
+  /// The blob URL currently assigned to the iframe's `src`.
+  ///
+  /// Held (not revoked at ready) because the engine may re-insert the
+  /// iframe later and the browser then re-fetches this URL; see the class
+  /// docs. Released only through [_replaceActiveBlobUrl].
+  String? _activeBlobUrl;
+
+  /// Revokes the previous blob URL (if any) and records [next] as current.
+  ///
+  /// The single revoke site in this controller: a retry replaces the failed
+  /// attempt's URL, and [dispose] passes `null` after the iframe is gone.
+  void _replaceActiveBlobUrl(String? next) {
+    final previous = _activeBlobUrl;
+    if (previous != null) {
+      web.URL.revokeObjectURL(previous);
+    }
+    _activeBlobUrl = next;
+  }
 
   final _widgetKey = GlobalKey();
   Widget? _cachedWidget;
@@ -459,15 +485,17 @@ class WebViewController implements PlatformWebViewController {
       final blobUrl = web.URL.createObjectURL(
         web.Blob([html.toJS].toJS, web.BlobPropertyBag(type: 'text/html')),
       );
+      _replaceActiveBlobUrl(blobUrl);
 
       try {
         _iframe!.src = blobUrl;
         await _ensureReady();
-        web.URL.revokeObjectURL(blobUrl);
+        // The blob URL intentionally stays alive (see _activeBlobUrl): an
+        // engine-driven iframe re-insertion reloads `src`, which must still
+        // resolve.
         return;
       } catch (e) {
         lastError = e;
-        web.URL.revokeObjectURL(blobUrl);
         if (attempt == maxLoadAttempts) {
           rethrow;
         }
@@ -511,6 +539,7 @@ class WebViewController implements PlatformWebViewController {
     _detachParentBindings();
     _iframe?.remove();
     _iframe = null;
+    _replaceActiveBlobUrl(null);
   }
 
   /// Removing the iframe element discards its browsing context WITHOUT

--- a/lib/src/protocol/protocol.dart
+++ b/lib/src/protocol/protocol.dart
@@ -39,6 +39,9 @@ class MonacoProtocol {
       StreamController<ProtocolEvent>.broadcast();
   final StreamController<ProtocolRequest> _requests =
       StreamController<ProtocolRequest>.broadcast();
+  final StreamController<MonacoPageReload> _pageReloads =
+      StreamController<MonacoPageReload>.broadcast();
+  Completer<void>? _reloadEditorReady;
   final Map<String, _PendingInvoke> _pending = {};
   int _invokeSeq = 0;
   int _lastEventSeq = 0;
@@ -66,6 +69,22 @@ class MonacoProtocol {
 
   /// JavaScript-initiated requests awaiting a Dart answer via [respond].
   Stream<ProtocolRequest> get requests => _requests.stream;
+
+  /// Fires when the page document loads AGAIN after the first successful
+  /// handshake.
+  ///
+  /// This happens outside the app's control: the Flutter web engine
+  /// re-inserted the editor's iframe during platform-view re-composition
+  /// (re-inserting an iframe reloads its `src`), a native WebView process
+  /// recovered from a crash, or the page was refreshed. The new document is
+  /// a bare shell - every model, registration, and listener of the old page
+  /// is gone, and commands that were in flight fail with
+  /// [MonacoPageReloadedError] the moment the reload is detected.
+  ///
+  /// A reload whose handshake shows a protocol version skew is NOT emitted
+  /// here (the page cannot be re-booted); it only fails the in-flight
+  /// commands.
+  Stream<MonacoPageReload> get pageReloads => _pageReloads.stream;
 
   /// Dispatches [method] with [params] and completes with the response
   /// value.
@@ -206,6 +225,15 @@ class MonacoProtocol {
     switch (name) {
       case 'pageReady':
         final handshake = MonacoHandshake.fromEnvelope(json);
+        final isReload = _pageReady.isCompleted;
+        if (isReload) {
+          // The document loaded again: the old page's state (models,
+          // registrations, response routing) is gone, so nothing still in
+          // flight can ever be answered. Event sequence numbering restarts
+          // with the new page.
+          _failPendingForReload();
+          _lastEventSeq = 0;
+        }
         if (handshake.protocolVersion != kMonacoProtocolVersion) {
           final error = MonacoProtocolError(
             operation: 'handshake',
@@ -217,12 +245,33 @@ class MonacoProtocol {
           );
           if (!_pageReady.isCompleted) _pageReady.completeError(error);
           if (!_editorReady.isCompleted) _editorReady.completeError(error);
+          if (isReload) {
+            // A skewed page cannot be re-booted; don't announce a
+            // recoverable reload.
+            debugPrint('[MonacoProtocol] Reloaded page has ${error.message}');
+          }
           return;
         }
-        if (!_pageReady.isCompleted) _pageReady.complete(handshake);
+        if (isReload) {
+          final editorReadyAgain = Completer<void>();
+          editorReadyAgain.future.ignore();
+          _reloadEditorReady = editorReadyAgain;
+          _pageReloads.add(
+            MonacoPageReload._(
+              handshake: handshake,
+              editorReady: editorReadyAgain.future,
+            ),
+          );
+          return;
+        }
+        _pageReady.complete(handshake);
       case 'ready':
         _editorReadyCompletedOk = true;
         if (!_editorReady.isCompleted) _editorReady.complete();
+        final reloadReady = _reloadEditorReady;
+        if (reloadReady != null && !reloadReady.isCompleted) {
+          reloadReady.complete();
+        }
       case 'fatal':
         final errorJson = json['error'];
         final error = MonacoJavaScriptError.fromJson(
@@ -233,9 +282,32 @@ class MonacoProtocol {
         );
         if (!_pageReady.isCompleted) _pageReady.completeError(error);
         if (!_editorReady.isCompleted) _editorReady.completeError(error);
+        final reloadReady = _reloadEditorReady;
+        if (reloadReady != null && !reloadReady.isCompleted) {
+          reloadReady.completeError(error);
+        }
       default:
         debugPrint('[MonacoProtocol] Unknown lifecycle stage: $name');
     }
+  }
+
+  /// Fails every in-flight invoke with [MonacoPageReloadedError]: their
+  /// responses died with the old page document.
+  void _failPendingForReload() {
+    for (final pending in List.of(_pending.values)) {
+      if (!pending.completer.isCompleted) {
+        pending.completer.completeError(
+          MonacoPageReloadedError(
+            message:
+                'The Monaco page reloaded while the command was in flight. '
+                'Retry after the editor recovers '
+                '(MonacoController.onPageReloaded).',
+            operation: pending.method,
+          ),
+        );
+      }
+    }
+    _pending.clear();
   }
 
   void _handleResponse(ResponseEnvelope envelope) {
@@ -306,8 +378,19 @@ class MonacoProtocol {
         ),
       );
     }
+    final reloadReady = _reloadEditorReady;
+    if (reloadReady != null && !reloadReady.isCompleted) {
+      reloadReady.completeError(
+        const MonacoDisposedError(
+          message:
+              'MonacoProtocol disposed while a page reload was '
+              'being recovered.',
+        ),
+      );
+    }
     _events.close();
     _requests.close();
+    _pageReloads.close();
   }
 
   /// JSON-encodes [value] for safe embedding inside a JavaScript source
@@ -328,4 +411,22 @@ class _PendingInvoke {
 
   final String method;
   final Completer<Object?> completer = Completer<Object?>();
+}
+
+/// One page-reload occurrence delivered on [MonacoProtocol.pageReloads].
+///
+/// Carries the fresh page's [handshake] and an [editorReady] future that
+/// tracks the RELOADED page's editor: after re-dispatching `page.boot`,
+/// await [editorReady] before issuing editor commands. It completes at the
+/// next `lifecycle: ready` and fails at the next `lifecycle: fatal` (or on
+/// dispose).
+final class MonacoPageReload {
+  MonacoPageReload._({required this.handshake, required this.editorReady});
+
+  /// The handshake the reloaded page shell reported.
+  final MonacoHandshake handshake;
+
+  /// Completes when the reloaded page's editor exists and every command is
+  /// registered.
+  final Future<void> editorReady;
 }

--- a/lib/src/widgets/monaco_editor_view.dart
+++ b/lib/src/widgets/monaco_editor_view.dart
@@ -672,8 +672,56 @@ class _MonacoEditorState extends State<MonacoEditor> {
     );
     _streamSubscriptions.add(scrollHandoffSub);
 
+    // The controller re-boots a reloaded page with its BOOT-time state; the
+    // widget then re-applies what it owns on top (current options, theme,
+    // background, scroll handoff). Recovery failures route to onError.
+    final reloadSub = _controller!.onPageReloaded.listen(
+      (_) => _reapplyAfterPageReload(),
+      onError: _reportAsyncError,
+    );
+    _streamSubscriptions.add(reloadSub);
+
     _statsListener = () => widget.onLiveStats?.call(_controller!.stats.value);
     _controller!.stats.addListener(_statsListener!);
+  }
+
+  /// Re-applies widget-owned configuration after the controller recovered
+  /// from a page reload (see `MonacoController.onPageReloaded`).
+  ///
+  /// The re-booted page carries the controller's boot-time options, so this
+  /// pushes the widget's CURRENT options, resolved theme, language,
+  /// background color, and scroll handoff sources - the same convergence
+  /// `_reconcileAfterBoot` performs after a slow first boot. Content is
+  /// deliberately not touched: it belongs to the application.
+  void _reapplyAfterPageReload() {
+    final controller = _controller;
+    if (controller == null || !mounted) return;
+    _ignoreAsync(() async {
+      await controller.updateOptions(widget.options);
+      final resolvedTheme = _resolveTheme();
+      _appliedResolvedTheme = resolvedTheme;
+      await controller.setTheme(resolvedTheme);
+      final language = widget.options.language;
+      if (language != null) {
+        await controller.document.setLanguage(language);
+      }
+      final backgroundColor = widget.backgroundColor;
+      if (backgroundColor != null) {
+        try {
+          await controller.setBackgroundColor(backgroundColor);
+          await controller.setHostPageBackgroundColor(backgroundColor);
+        } catch (e) {
+          debugPrint('[MonacoEditor] reload background re-apply failed: $e');
+        }
+      }
+      // The reloaded page booted with handoff sources disabled again (the
+      // replayed boot payload sends wheel/touch false); reset the synced
+      // snapshot to that state so the next sync pushes a real delta.
+      _syncedWheelSource = false;
+      _syncedTouchSource = false;
+      _syncedPolicy = MonacoScrollBoundaryPolicy.newGestureOnly;
+      _syncScrollHandoffSources();
+    }());
   }
 
   void _ignoreAsync(Future<void> future) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 3.3.0
+version: 3.4.0
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/core/monaco_controller_reload_test.dart
+++ b/test/core/monaco_controller_reload_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter_monaco/flutter_monaco.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../fakes/fake_platform_webview_controller.dart';
+
+/// A page reload (the Flutter web engine re-inserted the iframe, a WebView
+/// process recovered, or the page was refreshed) discards every page-side
+/// object. The controller must converge back to a booted editor on its own:
+/// re-dispatch `page.boot` with the original boot payload, re-register its
+/// Dart-side completion providers and custom actions, and only then announce
+/// the reload so applications can restore content they own.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> pumpMicrotasks([int rounds = 8]) async {
+    for (var i = 0; i < rounds; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  group('MonacoController page reload recovery', () {
+    late FakePlatformWebViewController webview;
+    late MonacoController controller;
+
+    setUp(() async {
+      webview = FakePlatformWebViewController();
+      controller = await MonacoController.createForTesting(
+        webViewController: webview,
+        markReady: false,
+        runBoot: true,
+        bootOptions: const EditorOptions(
+          language: MonacoLanguage.dart,
+          fontSize: 13,
+        ),
+        bootInitialText: 'original text',
+      );
+      await controller.whenReady;
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    test('boots through the real pipeline once before any reload', () {
+      expect(webview.executionCount('page.boot'), 1);
+      final boot = webview.dispatched.singleWhere(
+        (call) => call['method'] == 'page.boot',
+      );
+      final params = boot['params']! as Map<String, Object?>;
+      expect(params['text'], 'original text');
+      expect(params['language'], 'dart');
+    });
+
+    test('re-dispatches page.boot with the original boot payload', () async {
+      webview.emitReadyLifecycle();
+      await pumpMicrotasks();
+
+      expect(webview.executionCount('page.boot'), 2);
+      final reboot = webview.dispatched
+          .where((call) => call['method'] == 'page.boot')
+          .last;
+      final params = reboot['params']! as Map<String, Object?>;
+      expect(params['text'], 'original text');
+      expect(params['language'], 'dart');
+      expect(controller.isReady, isTrue);
+    });
+
+    test(
+      'onPageReloaded fires only after the editor is booted again',
+      () async {
+        var bootsAtEmit = -1;
+        controller.onPageReloaded.listen((_) {
+          bootsAtEmit = webview.executionCount('page.boot');
+        });
+
+        webview.emitReadyLifecycle();
+        await pumpMicrotasks();
+
+        expect(bootsAtEmit, 2);
+      },
+    );
+
+    test('re-registers completion providers and custom actions', () async {
+      var providerCalled = false;
+      await controller.registerCompletions(
+        id: 'my-completions',
+        languages: [MonacoLanguage.dart],
+        triggerCharacters: ['.'],
+        provider: (_) async {
+          providerCalled = true;
+          return const CompletionList(suggestions: []);
+        },
+      );
+      await controller.addAction(
+        const MonacoActionDescriptor(
+          id: MonacoAction('my.action'),
+          label: 'My Action',
+        ),
+        () async {},
+      );
+      expect(webview.executionCount('completions.register'), 1);
+      expect(webview.executionCount('actions.register'), 1);
+
+      webview.emitReadyLifecycle();
+      await pumpMicrotasks();
+
+      expect(webview.executionCount('completions.register'), 2);
+      expect(webview.executionCount('actions.register'), 2);
+
+      // The replayed registration still routes to the Dart provider.
+      webview.emitRequest('q1', 'completion', {
+        'requestId': 'q1',
+        'providerId': 'my-completions',
+        'language': 'dart',
+        'uri': null,
+        'position': {'lineNumber': 1, 'column': 1},
+        'defaultRange': {
+          'startLineNumber': 1,
+          'startColumn': 1,
+          'endLineNumber': 1,
+          'endColumn': 1,
+        },
+        'triggerKind': 0,
+      });
+      await pumpMicrotasks();
+      expect(providerCalled, isTrue);
+      expect(webview.responded, isNotEmpty);
+      expect(webview.responded.last['id'], 'q1');
+      expect(webview.responded.last['ok'], isTrue);
+    });
+
+    test(
+      'a disposed completion registration is not replayed after reload',
+      () async {
+        final registration = await controller.registerCompletions(
+          id: 'gone',
+          languages: [MonacoLanguage.dart],
+          provider: (_) async => const CompletionList(suggestions: []),
+        );
+        await registration.dispose();
+
+        webview.emitReadyLifecycle();
+        await pumpMicrotasks();
+
+        expect(webview.executionCount('completions.register'), 1);
+      },
+    );
+
+    test('a reload during recovery converges to the newest page', () async {
+      webview.emitReadyLifecycle();
+      webview.emitReadyLifecycle();
+      await pumpMicrotasks(16);
+
+      // Both reloads re-boot (the second may interrupt the first); the
+      // controller must end up ready with the last boot acknowledged.
+      expect(webview.executionCount('page.boot'), greaterThanOrEqualTo(2));
+      expect(controller.isReady, isTrue);
+    });
+  });
+
+  group('MonacoController reload without a boot payload', () {
+    test(
+      'a synthetic double-ready on a markReady controller is inert',
+      () async {
+        final webview = FakePlatformWebViewController();
+        final controller = await MonacoController.createForTesting(
+          webViewController: webview,
+        );
+        final reloads = <void>[];
+        controller.onPageReloaded.listen(reloads.add);
+
+        // A second ready pair arrives without _startBoot ever having run
+        // (nothing to replay): the controller must neither crash nor claim a
+        // recovery it cannot perform.
+        webview.emitReadyLifecycle();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(webview.executionCount('page.boot'), 0);
+        expect(reloads, isEmpty);
+        controller.dispose();
+      },
+    );
+  });
+}

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -177,4 +177,38 @@ void main() {
     );
     expect(tokenLine, contains(r'$_viewId'));
   });
+
+  test('the Monaco blob URL lives exactly as long as the iframe', () {
+    final source = webControllerSource();
+
+    // The Flutter web engine can detach and re-insert the iframe's DOM node
+    // at any time after creation (platform-view re-composition around tab
+    // and route churn). Re-inserting an iframe reloads its `src` from
+    // scratch, so the blob URL must stay resolvable for the controller's
+    // whole lifetime: a revoked blob reloads as Chromium's
+    // ERR_FILE_NOT_FOUND page ("It may have been moved, edited, or
+    // deleted.") inside the editor pane.
+    expect(source, contains('String? _activeBlobUrl'));
+    expect(source, contains('void _replaceActiveBlobUrl(String? next)'));
+
+    // Exactly one revoke site: replacement (which dispose() drives with
+    // null). Nothing may revoke at ready, on load success, or on a failed
+    // attempt while the iframe still points at the blob.
+    expect('web.URL.revokeObjectURL'.allMatches(source), hasLength(1));
+    expect(
+      source,
+      isNot(
+        matches(RegExp(r'await _ensureReady\(\);\s*web\.URL\.revokeObjectURL')),
+      ),
+    );
+
+    // dispose() releases the last blob URL through the same single site.
+    final disposeStart = source.indexOf('void dispose()');
+    expect(disposeStart, isNonNegative);
+    final disposeBlock = source.substring(
+      disposeStart,
+      source.indexOf('\n  }', disposeStart),
+    );
+    expect(disposeBlock, contains('_replaceActiveBlobUrl(null)'));
+  });
 }

--- a/test/protocol/protocol_test.dart
+++ b/test/protocol/protocol_test.dart
@@ -326,4 +326,135 @@ void main() {
       },
     );
   });
+
+  group('MonacoProtocol page reload', () {
+    late FakePlatformWebViewController webview;
+    late MonacoProtocol protocol;
+
+    String pageReadyEnvelope({int protocolVersion = kMonacoProtocolVersion}) {
+      return jsonEncode({
+        'v': kMonacoProtocolVersion,
+        'kind': 'lifecycle',
+        'name': 'pageReady',
+        'protocolVersion': protocolVersion,
+        'monacoVersion': 'test',
+        'capabilities': ['lsp', 'diff'],
+      });
+    }
+
+    String lifecycleEnvelope(String name, [Map<String, Object?>? extra]) {
+      return jsonEncode({
+        'v': kMonacoProtocolVersion,
+        'kind': 'lifecycle',
+        'name': name,
+        ...?extra,
+      });
+    }
+
+    setUp(() async {
+      webview = FakePlatformWebViewController()..autoRespond = false;
+      protocol = MonacoProtocol(webView: webview);
+      await webview.addJavaScriptChannel(
+        'flutterChannel',
+        protocol.handleChannelMessage,
+      );
+      // First boot: page shell reports in.
+      webview.emitToChannel('flutterChannel', pageReadyEnvelope());
+      await protocol.pageReady;
+    });
+
+    tearDown(() {
+      if (!protocol.isDisposed) protocol.dispose();
+    });
+
+    test('a second pageReady emits on pageReloads and fails in-flight invokes '
+        'with MonacoPageReloadedError', () async {
+      final reloads = <MonacoPageReload>[];
+      protocol.pageReloads.listen(reloads.add);
+
+      final inFlight = protocol.invoke('document.getText', {
+        'uri': null,
+      }, timeout: null);
+
+      webview.emitToChannel('flutterChannel', pageReadyEnvelope());
+
+      await expectLater(
+        inFlight,
+        throwsA(
+          isA<MonacoPageReloadedError>().having(
+            (e) => e.operation,
+            'operation',
+            'document.getText',
+          ),
+        ),
+      );
+      expect(reloads, hasLength(1));
+      expect(reloads.single.handshake.monacoVersion, 'test');
+    });
+
+    test(
+      'the reload editorReady completes at the next ready lifecycle',
+      () async {
+        final reloadFuture = protocol.pageReloads.first;
+        webview.emitToChannel('flutterChannel', pageReadyEnvelope());
+        final reload = await reloadFuture;
+
+        var ready = false;
+        unawaited(reload.editorReady.then((_) => ready = true));
+        await Future<void>.delayed(Duration.zero);
+        expect(ready, isFalse);
+
+        webview.emitToChannel('flutterChannel', lifecycleEnvelope('ready'));
+        await Future<void>.delayed(Duration.zero);
+        expect(ready, isTrue);
+      },
+    );
+
+    test('a fatal after reload fails the reload editorReady', () async {
+      final reloadFuture = protocol.pageReloads.first;
+      webview.emitToChannel('flutterChannel', pageReadyEnvelope());
+      final reload = await reloadFuture;
+
+      webview.emitToChannel(
+        'flutterChannel',
+        lifecycleEnvelope('fatal', {
+          'error': {'message': 'boot exploded'},
+        }),
+      );
+      await expectLater(
+        reload.editorReady,
+        throwsA(isA<MonacoJavaScriptError>()),
+      );
+    });
+
+    test('a version-skewed reload fails in-flight invokes but does not emit a '
+        'recoverable reload', () async {
+      final reloads = <MonacoPageReload>[];
+      protocol.pageReloads.listen(reloads.add);
+
+      final inFlight = protocol.invoke('document.getText', {
+        'uri': null,
+      }, timeout: null);
+
+      webview.emitToChannel(
+        'flutterChannel',
+        pageReadyEnvelope(protocolVersion: 999),
+      );
+
+      await expectLater(inFlight, throwsA(isA<MonacoPageReloadedError>()));
+      await Future<void>.delayed(Duration.zero);
+      expect(reloads, isEmpty);
+    });
+
+    test('invokes issued after the reload land on the new page', () async {
+      final reloadFuture = protocol.pageReloads.first;
+      webview.emitToChannel('flutterChannel', pageReadyEnvelope());
+      await reloadFuture;
+
+      webview.autoRespond = true;
+      webview.injectCommandSuccess('document.getText', value: 'post-reload');
+      final result = await protocol.invoke('document.getText', {'uri': null});
+      expect(result, 'post-reload');
+    });
+  });
 }


### PR DESCRIPTION
## Release 3.4.0

### Fixed
- Web: the editor pane could intermittently render Chromium's ERR_FILE_NOT_FOUND page ("It may have been moved, edited, or deleted."). The blob URL backing the iframe was revoked as soon as the page reported ready, but the Flutter web engine can detach and re-insert the iframe during platform-view re-composition, which reloads `src` from scratch. The blob URL now lives exactly as long as the iframe.

### Added
- Automatic page-reload recovery on all platforms: the protocol detects a reloaded page, fails in-flight commands fast with the new `MonacoPageReloadedError`, and both `MonacoController` and `MonacoDiffController` re-boot with the original payload and replay live completion providers and custom actions.
- `onPageReloaded` stream on both controllers so applications can restore documents/content they own.
- `MonacoEditor` re-applies widget-owned options, theme, background, and scroll handoff after recovery.

Note: `MonacoPageReloadedError` adds a member to the sealed `MonacoException` union; exhaustive switches over it need a new case (source-breaking for those switches, covered in the changelog).

### Verification
- `flutter analyze`: no issues
- `flutter test`: 617/617 (13 new reload-semantics tests, plus a source test locking the blob-lifetime invariant)
- `dart pub publish --dry-run`: clean
- pana: 160/160