### PR TITLE
Release 3.4.1: fail fast when the web platform view is never mounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.1] - 2026-07-11
+
+### Fixed
+- **Web: a boot whose platform view was never mounted now fails fast with an actionable error instead of a silent 40-second timeout.** On web the editor iframe only loads while `webViewWidget` is mounted and painted; when an app awaited `whenReady` without putting the widget in the tree (or hid it with `Offstage`/`Visibility(visible: false)`, or inserted it only after readiness), the load silently burned two 20-second attempts and surfaced a bare `TimeoutException`. A ready timeout with the iframe still detached now throws a `StateError` immediately that names the requirement: keep `webViewWidget` painted underneath your loading UI (an opaque `Stack` overlay, as the `MonacoEditor` widget does). `MonacoController.create` and `webViewWidget` document the constraint.
+
 ## [3.4.0] - 2026-07-11
 
 The editor now survives page reloads it never caused. On Flutter web the engine can detach and re-insert the editor's iframe during platform-view re-composition (closing/opening in-app tabs, route transitions), and re-inserting an iframe makes the browser reload it; native WebView processes can likewise recover from a crash. Both cases previously left a dead editor behind.

--- a/lib/src/editor/controller.dart
+++ b/lib/src/editor/controller.dart
@@ -210,6 +210,11 @@ class MonacoController {
   ///   [MonacoTimeoutError]. Defaults to [MonacoDefaults.readyTimeout]
   ///   (20s on native, 90s on web where the cold-cache first load must
   ///   download the editor bundle over the network).
+  ///
+  /// On web the boot can only complete while [webViewWidget] is mounted and
+  /// painted (the editor iframe loads only inside the document): keep the
+  /// widget in the tree underneath your loading UI rather than inserting it
+  /// once [whenReady] completes. See [webViewWidget].
   static Future<MonacoController> create({
     EditorOptions? options,
     String? initialText,
@@ -411,7 +416,16 @@ class MonacoController {
     }
   }
 
-  /// Get the platform-specific WebView widget
+  /// Get the platform-specific WebView widget.
+  ///
+  /// On web, the editor iframe only loads while this widget is mounted and
+  /// painted, so [whenReady] can only complete if the app keeps it in the
+  /// tree - painted underneath any loading chrome (an opaque Stack overlay,
+  /// as the `MonacoEditor` widget does) - from creation onward. Inserting
+  /// it only after readiness, or hiding it with `Offstage` /
+  /// `Visibility(visible: false)`, deadlocks the boot; the web load then
+  /// fails fast with a [StateError] naming this requirement. Native
+  /// WebViews load while detached, so this only constrains web.
   Widget get webViewWidget => _webViewController.widget;
 
   /// Ensure the editor is ready before executing commands.

--- a/lib/src/platform/webview_web.dart
+++ b/lib/src/platform/webview_web.dart
@@ -75,6 +75,16 @@ String _monacoBridgeAssetUrl() {
 /// `MonacoController` re-booting the fresh page shell (see
 /// `MonacoProtocol.pageReloads`).
 ///
+/// ### Widget Attachment
+///
+/// The iframe only loads while it is attached to the parent document, and
+/// it is only attached while [widget] is mounted and painted (that is when
+/// the engine composites the platform view slot). Boot therefore requires
+/// the app to keep the widget in the tree - painted underneath any loading
+/// chrome - from `load()` onward. A ready timeout with the iframe still
+/// detached fails fast with a [StateError] naming this requirement instead
+/// of retrying.
+///
 /// ### Focus Handling
 ///
 /// Web focus is tricky because the iframe is a separate browsing context.
@@ -495,6 +505,22 @@ class WebViewController implements PlatformWebViewController {
         // resolve.
         return;
       } catch (e) {
+        // A ready timeout while the iframe is outside the DOM is not a
+        // transient load failure: a detached iframe never loads its src at
+        // all, so retrying would only burn another silent 20s. This is a
+        // usage error - readiness is being awaited while nothing put the
+        // platform view on screen - and must surface as one.
+        if (e is TimeoutException && !(_iframe?.isConnected ?? false)) {
+          throw StateError(
+            'Monaco iframe is not attached to the DOM, so the editor page '
+            'can never load. On web, whenReady only completes while the '
+            "controller's webViewWidget is mounted and painted: keep the "
+            'widget in the tree underneath your loading UI (an opaque Stack '
+            'overlay, as the MonacoEditor widget does) instead of inserting '
+            'it after readiness, and do not hide it with Offstage or '
+            'Visibility(visible: false).',
+          );
+        }
         lastError = e;
         if (attempt == maxLoadAttempts) {
           rethrow;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 3.4.0
+version: 3.4.1
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/platform/web_view_controller_web_source_test.dart
+++ b/test/platform/web_view_controller_web_source_test.dart
@@ -178,6 +178,32 @@ void main() {
     expect(tokenLine, contains(r'$_viewId'));
   });
 
+  test('a ready timeout on a detached iframe fails fast with the mount '
+      'requirement instead of retrying', () {
+    final source = webControllerSource();
+
+    // A detached iframe never loads its src, so a ready timeout while the
+    // iframe is outside the DOM is not transient: retrying burns another
+    // silent 20s and the caller ends up with a bare TimeoutException and no
+    // idea the widget was simply never mounted (the deployed
+    // context_collector web regression). The load loop must recognize the
+    // detached case at timeout and throw the actionable usage error.
+    expect(source, contains('e is TimeoutException'));
+    expect(source, contains('_iframe?.isConnected ?? false'));
+    expect(source, contains('webViewWidget is mounted and painted'));
+
+    // The diagnosis must escape the retry loop (fail fast): it is thrown
+    // before the lastError/retry handling in the same catch block.
+    final loadStart = source.indexOf('Future<void> load(');
+    expect(loadStart, isNonNegative);
+    final catchStart = source.indexOf('} catch (e) {', loadStart);
+    expect(catchStart, isNonNegative);
+    final diagnosis = source.indexOf('not attached to the DOM', catchStart);
+    final retryPath = source.indexOf('lastError = e;', catchStart);
+    expect(diagnosis, isNonNegative);
+    expect(retryPath, greaterThan(diagnosis));
+  });
+
   test('the Monaco blob URL lives exactly as long as the iframe', () {
     final source = webControllerSource();
 


### PR DESCRIPTION
## What

Patch release. On web, a boot started while the controller's webViewWidget was never mounted (or hidden with Offstage / inserted only after readiness) silently burned two 20-second load attempts and surfaced a bare TimeoutException. The ready-timeout path now detects the detached iframe, skips the pointless retry, and throws an immediate StateError that names the web mount requirement (keep the widget painted underneath loading chrome, as MonacoEditor does).

## Why

Root-caused from the deployed context_collector web regression: its service gated the webview widget on readiness while awaiting whenReady, a deadlock that web physics (iframes only load in the DOM) turns into a silent timeout. The package cannot mount the app's widget, but it can make the failure instant and self-explaining.

## Changes
- webview_web.dart: detached-at-timeout diagnosis (fail fast, no retry), widget-attachment section in the class docs
- controller.dart: the constraint documented on create() and webViewWidget (doc-only)
- New source test locking the fail-fast shape; suite 618/618, analyzer clean, pana 160/160

🤖 Generated with [Claude Code](https://claude.com/claude-code)