### PR TITLE
Publish the showcase from this repo instead of omar-hanafy.github.io

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,130 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "lib/**"
+      - "assets/**"
+      - "example/**"
+      - "pubspec.yaml"
+      - ".github/workflows/pages.yml"
+  pull_request:
+    paths:
+      - "lib/**"
+      - "assets/**"
+      - "example/**"
+      - "pubspec.yaml"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # A project site is served from https://<user>.github.io/<repo>/, so the app
+  # must be built for that subpath. Leading and trailing slash are both
+  # required by `flutter build web --base-href`.
+  BASE_HREF: /flutter_monaco/
+  # example/lib holds several runnable entrypoints. main.dart is the minimal
+  # editor smoke test; the published demo is the showcase.
+  ENTRYPOINT: lib/showcase/main.dart
+
+jobs:
+  build:
+    name: Build showcase
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: read
+    concurrency:
+      # A new commit supersedes an older build of the same pull request. Main
+      # builds serialize so an older build cannot reach production after a
+      # newer one.
+      group: pages-build-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    defaults:
+      run:
+        working-directory: example
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build
+        run: |
+          flutter build web \
+            --release \
+            --wasm \
+            --base-href "$BASE_HREF" \
+            -t "$ENTRYPOINT"
+
+      - name: Verify the built base href
+        # A wrong base href is the failure mode for project sites: the page
+        # loads, then every asset 404s and the app never paints. Cheaper to
+        # fail here than to discover it as a white screen in production.
+        run: |
+          actual=$(grep -o '<base href="[^"]*">' build/web/index.html || true)
+          expected="<base href=\"$BASE_HREF\">"
+          if [ "$actual" != "$expected" ]; then
+            echo "Expected $expected but the build produced ${actual:-no base href tag}."
+            exit 1
+          fi
+          echo "$actual"
+
+      - name: Verify the showcase entrypoint was built
+        # Guards against -t being dropped or aimed at a valid-but-wrong file,
+        # which silently publishes example/lib/main.dart (a bare editor) in
+        # place of the showcase. This cannot be checked against index.html:
+        # example/web/index.html is shared by every entrypoint, so the target
+        # leaves no trace in it. Only the compiled output differs.
+        #
+        # MARKER is a user-visible string that exists solely in the showcase.
+        # If this step fails after a copy edit, update MARKER to match.
+        run: |
+          MARKER="Everything the editor can do"
+          if ! grep -qF "$MARKER" build/web/main.dart.js; then
+            echo "Built output does not contain the showcase marker: $MARKER"
+            echo "Either $ENTRYPOINT is no longer the showcase, or the copy changed."
+            exit 1
+          fi
+
+      - name: Configure Pages
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: example/build/web
+
+  deploy:
+    name: Deploy to GitHub Pages
+    # Pull requests and manual dispatches from non-main branches build and
+    # verify, but never publish.
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      # GitHub Pages has one production target. Serialize every deployment
+      # regardless of the triggering run or branch ref.
+      group: pages-production
+      cancel-in-progress: false
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
The flutter_monaco showcase is currently published by building it here, then
copying the output into the `omar-hanafy.github.io` repository by hand. The
history there reads `Rebuild flutter_monaco showcase (3.4.1)`, then
`(3.4.1, wasm parity)`, then `(3.4.1, correct showcase entrypoint)` - three
attempts to land one release's demo, in a second repository, after the fact.

This adds a `Pages` workflow so the release commit is the deploy. Nothing built
is committed anywhere.

## URL change

The demo moves from `/flutter-monaco/` to `/flutter_monaco/`, because a project
site is always served from the repository name. A permanent redirect stub stays
at the old path in the `omar-hanafy.github.io` repository, since READMEs of
already-published pub.dev versions point there and cannot be edited.

## Guards

Two failure modes already happened once, so the build asserts against both:

- **base href** - a project site lives under a subpath. Get it wrong and the
  page loads, every asset 404s, and the app never paints.
- **entrypoint** - `example/lib` holds several runnable entrypoints. This cannot
  be checked against `index.html`, because `example/web/index.html` is shared by
  every entrypoint and the `-t` target leaves no trace in it. The check greps the
  compiled output for a showcase-only string.

Pull requests build and verify but never deploy.