### PR TITLE
Point the showcase social card at the new site URL

### DIFF
--- a/example/web/index.html
+++ b/example/web/index.html
@@ -13,14 +13,14 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="flutter_monaco - VS Code's editor, inside Flutter">
   <meta property="og:description" content="Embed Monaco - the editor that powers VS Code - in your Flutter app. 100+ languages, theming, IntelliSense, and a full Dart API.">
-  <meta property="og:url" content="https://omar-hanafy.github.io/flutter-monaco/">
-  <meta property="og:image" content="https://omar-hanafy.github.io/flutter-monaco/og.png">
+  <meta property="og:url" content="https://omar-hanafy.github.io/flutter_monaco/">
+  <meta property="og:image" content="https://omar-hanafy.github.io/flutter_monaco/og.png">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="flutter_monaco - VS Code's editor, inside Flutter">
   <meta name="twitter:description" content="Embed Monaco in your Flutter app. 100+ languages, theming, IntelliSense, and a full Dart API.">
-  <meta name="twitter:image" content="https://omar-hanafy.github.io/flutter-monaco/og.png">
+  <meta name="twitter:image" content="https://omar-hanafy.github.io/flutter_monaco/og.png">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Regression from the Pages migration.

`example/web/index.html` still carried `og:url`, `og:image` and `twitter:image` pointing at `https://omar-hanafy.github.io/flutter-monaco/`. That path is now a redirect stub containing only `index.html`, so `/flutter-monaco/og.png` returns **404** and shared links render without a preview image.

Verified: the asset is served at `https://omar-hanafy.github.io/flutter_monaco/og.png` (**200**).

Caught by sweeping the whole repo for the old URL rather than only `README.md` - the original migration PR only repointed the README.