### PR TITLE
fix(web): name the asset origin in the page CSP so Firefox can load Monaco

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Firefox can now load the editor on web.** Firefox does not treat the creating document's origin as CSP `'self'` inside `blob:` documents, so the blob-hosted Monaco page blocked its own loader, bridge scripts, CSS, and fonts ("Failed to load Monaco loader.js"). The generated page CSP now names the resolved asset origin explicitly; native platforms and browsers where `'self'` already matches are unaffected.
+- **Firefox can now load the editor on web.** Firefox does not treat the creating document's origin as CSP `'self'` inside `blob:` documents, so the blob-hosted Monaco page blocked its own loader, bridge scripts, stylesheet, and workers ("Failed to load Monaco loader.js"). The generated page no longer relies on `'self'` for anything it fetches: it names the origin of every resolved asset root, and each directive is built from one shared source list so a directive added later cannot omit them. Native platforms keep a byte-identical policy, and browsers where `'self'` already matches are unaffected.
+- **A CSP-blocked page load now says which directive refused which URL** instead of only "Failed to load Monaco loader.js", turning a cross-browser hunt into a single line in the reported error.
 
 ## [3.4.2] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Firefox can now load the editor on web.** Firefox does not treat the creating document's origin as CSP `'self'` inside `blob:` documents, so the blob-hosted Monaco page blocked its own loader, bridge scripts, CSS, and fonts ("Failed to load Monaco loader.js"). The generated page CSP now names the resolved asset origin explicitly; native platforms and browsers where `'self'` already matches are unaffected.
+
 ## [3.4.2] - 2026-07-19
 
 ### Added

--- a/lib/src/assets/html_builder.dart
+++ b/lib/src/assets/html_builder.dart
@@ -78,6 +78,20 @@ String buildMonacoIndexHtml({
 }) {
   final extraConnectSources = sanitizeConnectSources(allowedConnectSources);
 
+  // Firefox does not treat the creating document's origin as CSP 'self'
+  // inside blob: documents, so on web every asset load from the host origin
+  // (loader.js, the bridge scripts, editor CSS, fonts) is blocked there
+  // while Chrome allows it — the editor dies with "Failed to load Monaco
+  // loader.js". Naming the asset origin explicitly unblocks Firefox and is
+  // redundant-but-harmless in browsers where 'self' already matches. Only
+  // absolute http(s) asset URLs (the web case) produce an origin; native
+  // platforms keep the policy unchanged.
+  var assetOrigin = '';
+  final vsUri = Uri.tryParse(vsPath);
+  if (vsUri != null && (vsUri.scheme == 'http' || vsUri.scheme == 'https')) {
+    assetOrigin = ' ${vsUri.scheme}://${vsUri.authority}';
+  }
+
   final platform = isWeb
       ? 'web'
       : isWindows
@@ -230,7 +244,7 @@ String buildMonacoIndexHtml({
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' file: 'unsafe-inline' 'unsafe-eval'; script-src 'self' file: 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'${allowCdnFonts ? ' https:' : ''}; font-src 'self' file: data:${allowCdnFonts ? ' https:' : ''}; img-src 'self' data: blob: file:; worker-src 'self' blob:; connect-src 'self' blob:$extraConnectSources;"
+      content="default-src 'self'$assetOrigin file: 'unsafe-inline' 'unsafe-eval'; script-src 'self'$assetOrigin file: 'unsafe-inline' 'unsafe-eval'; style-src 'self'$assetOrigin 'unsafe-inline'${allowCdnFonts ? ' https:' : ''}; font-src 'self'$assetOrigin file: data:${allowCdnFonts ? ' https:' : ''}; img-src 'self'$assetOrigin data: blob: file:; worker-src 'self'$assetOrigin blob:; connect-src 'self'$assetOrigin blob:$extraConnectSources;"
     />
     <!-- NOTE: connect-src intentionally limits in-page requests to self/blob.
          Opt into remote endpoints (e.g. WebSocket language servers) via the

--- a/lib/src/assets/html_builder.dart
+++ b/lib/src/assets/html_builder.dart
@@ -1,19 +1,29 @@
 import 'dart:convert';
 
-/// Validates and joins extra CSP `connect-src` source expressions.
+/// Characters that would let a source expression escape the policy attribute
+/// or smuggle in an additional directive.
+final RegExp _unsafeCspSourceChars = RegExp(r'''[\s;'"<>]''');
+
+/// Whether [source] may be spliced into the page's CSP.
 ///
-/// Returns either an empty string or a leading-space-joined list ready to
-/// splice after `connect-src 'self' blob:`. Throws [ArgumentError] for
-/// entries that could break out of the policy attribute or smuggle in
-/// additional directives (whitespace, quotes, `;`, `<`, `>`).
-String sanitizeConnectSources(List<String> sources) {
-  if (sources.isEmpty) return '';
-  final forbidden = RegExp(r'''[\s;'"<>]''');
+/// The single definition of what is admissible, applied to every source
+/// expression that reaches the policy - both caller-supplied
+/// ([sanitizeConnectSources]) and derived from asset URLs ([_cspAssetOrigins]).
+bool _isSafeCspSource(String source) =>
+    source.isNotEmpty && !_unsafeCspSourceChars.hasMatch(source);
+
+/// Validates extra CSP `connect-src` source expressions.
+///
+/// Returns the non-empty entries, ready to append to the `connect-src`
+/// directive. Throws [ArgumentError] for entries that could break out of the
+/// policy attribute or smuggle in additional directives (whitespace, quotes,
+/// `;`, `<`, `>`).
+List<String> sanitizeConnectSources(List<String> sources) {
   final cleaned = <String>[];
   for (final raw in sources) {
     final source = raw.trim();
     if (source.isEmpty) continue;
-    if (forbidden.hasMatch(source)) {
+    if (!_isSafeCspSource(source)) {
       throw ArgumentError.value(
         raw,
         'allowedConnectSources',
@@ -23,7 +33,38 @@ String sanitizeConnectSources(List<String> sources) {
     }
     cleaned.add(source);
   }
-  return cleaned.isEmpty ? '' : ' ${cleaned.join(' ')}';
+  return cleaned;
+}
+
+/// CSP host-sources for every origin the generated page fetches from.
+///
+/// The policy must never depend on `'self'`. This document is always
+/// delivered over a local scheme - a `blob:` URL on web (see
+/// `webview_web.dart`) and a `file:` URL on native (see
+/// `webview_native.dart`) - and `'self'` is not dependable there: Firefox
+/// does not resolve it to the creating document's origin inside a `blob:`
+/// document, so every same-origin fetch the page makes (`loader.js`, the
+/// bridge scripts, `editor.main.css`, the workers) is blocked while Chrome
+/// allows it. Native has always handled this by naming `file:` in every
+/// directive; web names the origins it actually references.
+///
+/// Only absolute http(s) URLs carry an origin, so native's relative and
+/// `file:` asset paths contribute nothing and leave the policy unchanged.
+/// [Uri.origin] rather than `authority` is deliberate: it is
+/// `scheme://host[:port]` with no userinfo, which is the only form valid as a
+/// CSP host-source - `authority` would emit `https://user:pass@host`, an
+/// expression browsers discard, silently restoring the failure.
+List<String> _cspAssetOrigins(List<String> assetUrls) {
+  final origins = <String>{};
+  for (final url in assetUrls) {
+    final uri = Uri.tryParse(url);
+    if (uri == null) continue;
+    if (uri.scheme != 'http' && uri.scheme != 'https') continue;
+    if (uri.host.isEmpty) continue;
+    final origin = uri.origin;
+    if (_isSafeCspSource(origin)) origins.add(origin);
+  }
+  return origins.toList()..sort();
 }
 
 /// Neutralizes `</` sequences so injected CSS can never terminate its
@@ -78,19 +119,32 @@ String buildMonacoIndexHtml({
 }) {
   final extraConnectSources = sanitizeConnectSources(allowedConnectSources);
 
-  // Firefox does not treat the creating document's origin as CSP 'self'
-  // inside blob: documents, so on web every asset load from the host origin
-  // (loader.js, the bridge scripts, editor CSS, fonts) is blocked there
-  // while Chrome allows it — the editor dies with "Failed to load Monaco
-  // loader.js". Naming the asset origin explicitly unblocks Firefox and is
-  // redundant-but-harmless in browsers where 'self' already matches. Only
-  // absolute http(s) asset URLs (the web case) produce an origin; native
-  // platforms keep the policy unchanged.
-  var assetOrigin = '';
-  final vsUri = Uri.tryParse(vsPath);
-  if (vsUri != null && (vsUri.scheme == 'http' || vsUri.scheme == 'https')) {
-    assetOrigin = ' ${vsUri.scheme}://${vsUri.authority}';
-  }
+  // The page's whole fetch surface, named explicitly so nothing load-bearing
+  // depends on 'self' (see _cspAssetOrigins). Both asset roots contribute:
+  // the Monaco bundle and the bridge scripts are resolved by separate
+  // functions on web and are same-origin only by convention, so deriving the
+  // policy from one of them would leave the other unadmitted.
+  final selfSources = <String>[
+    "'self'",
+    ..._cspAssetOrigins([vsPath, bridgeBase]),
+  ];
+
+  // Every directive is emitted through here, so one added later cannot
+  // silently omit the asset origins. `default-src` is no safety net for
+  // that: it only backstops directives that are NOT declared.
+  String directive(String name, List<String> extra) =>
+      '$name ${[...selfSources, ...extra].join(' ')}';
+
+  final contentSecurityPolicy =
+      '${[
+        directive('default-src', ['file:', "'unsafe-inline'", "'unsafe-eval'"]),
+        directive('script-src', ['file:', "'unsafe-inline'", "'unsafe-eval'"]),
+        directive('style-src', ["'unsafe-inline'", if (allowCdnFonts) 'https:']),
+        directive('font-src', ['file:', 'data:', if (allowCdnFonts) 'https:']),
+        directive('img-src', ['data:', 'blob:', 'file:']),
+        directive('worker-src', ['blob:']),
+        directive('connect-src', ['blob:', ...extraConnectSources]),
+      ].join('; ')};';
 
   final platform = isWeb
       ? 'web'
@@ -244,11 +298,31 @@ String buildMonacoIndexHtml({
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'$assetOrigin file: 'unsafe-inline' 'unsafe-eval'; script-src 'self'$assetOrigin file: 'unsafe-inline' 'unsafe-eval'; style-src 'self'$assetOrigin 'unsafe-inline'${allowCdnFonts ? ' https:' : ''}; font-src 'self'$assetOrigin file: data:${allowCdnFonts ? ' https:' : ''}; img-src 'self'$assetOrigin data: blob: file:; worker-src 'self'$assetOrigin blob:; connect-src 'self'$assetOrigin blob:$extraConnectSources;"
+      content="$contentSecurityPolicy"
     />
-    <!-- NOTE: connect-src intentionally limits in-page requests to self/blob.
-         Opt into remote endpoints (e.g. WebSocket language servers) via the
-         allowedConnectSources parameter instead of editing this policy. -->
+    <!-- NOTE: connect-src intentionally limits in-page requests to this
+         page's own asset origins and blob:. Opt into remote endpoints (e.g.
+         WebSocket language servers) via the allowedConnectSources parameter
+         instead of editing this policy. -->
+    <script>
+      // A CSP block is this page's most likely load failure: it is served
+      // over a local scheme and fetches everything else from the app origin.
+      // Unrecorded, it surfaces only as "Failed to load Monaco loader.js",
+      // which names neither the directive that refused nor the URL it
+      // refused - the difference between a one-line report and a
+      // cross-browser hunt. Must precede every governed load.
+      window.__FM_CSP_VIOLATIONS = [];
+      document.addEventListener('securitypolicyviolation', function (e) {
+        if (window.__FM_CSP_VIOLATIONS.length >= 5) return;
+        window.__FM_CSP_VIOLATIONS.push(
+          (e.effectiveDirective || e.violatedDirective) + ' blocked ' + e.blockedURI
+        );
+      });
+      window.__fmCspDetail = function () {
+        var v = window.__FM_CSP_VIOLATIONS;
+        return v && v.length ? ' (CSP: ' + v.join('; ') + ')' : '';
+      };
+    </script>
     <style>
       html, body, #editor-container {
         width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden;
@@ -290,19 +364,27 @@ String buildMonacoIndexHtml({
         if (window._initMonacoWhenReady) window._initMonacoWhenReady();
       };
       loaderScript.onerror = function() {
-        console.error('[Monaco HTML] FATAL: loader.js FAILED TO LOAD.');
-        if (window.flutterMonacoPostMessage) {
-          window.flutterMonacoPostMessage({ event: 'error', message: 'Failed to load Monaco loader.js' });
-        } else if (window.flutterChannel) {
-          window.flutterChannel.postMessage(JSON.stringify({ event: 'error', message: 'Failed to load Monaco loader.js' }));
-        }
+        // This error event and securitypolicyviolation are dispatched
+        // independently, so yield once: a CSP block is then already recorded
+        // when the report is built. The host is waiting on a 20s readiness
+        // timeout, so one task is free.
+        setTimeout(function () {
+          var detail = window.__fmCspDetail ? window.__fmCspDetail() : '';
+          console.error('[Monaco HTML] FATAL: loader.js FAILED TO LOAD.' + detail);
+          var payload = { event: 'error', message: 'Failed to load Monaco loader.js' + detail };
+          if (window.flutterMonacoPostMessage) {
+            window.flutterMonacoPostMessage(payload);
+          } else if (window.flutterChannel) {
+            window.flutterChannel.postMessage(JSON.stringify(payload));
+          }
+        }, 0);
       };
       document.head.appendChild(loaderScript);
     </script>
     ''' : '''
     <script src="$vsPath/loader.js"
             onload="console.log('[Monaco HTML] loader.js successfully loaded.')"
-            onerror="console.error('[Monaco HTML] FATAL: loader.js FAILED TO LOAD.')"
+            onerror="console.error('[Monaco HTML] FATAL: loader.js FAILED TO LOAD.' + (window.__fmCspDetail ? window.__fmCspDetail() : ''))"
     ></script>
     '''}
 

--- a/lib/src/platform/web_asset_resolver.dart
+++ b/lib/src/platform/web_asset_resolver.dart
@@ -12,11 +12,13 @@
 /// reference, so an absolute [assetUrl] is returned unchanged and a relative
 /// one is anchored at the app root.
 ///
-/// **Cross-origin `assetBase` is not supported.** The generated editor page
-/// ships a CSP whose `script-src` allows only `'self'` (and `file:`), so a
-/// Monaco bundle resolved to a different origin is blocked by the page's own
-/// policy. Serve the Monaco assets from the app's origin; a CDN `assetBase`
-/// for the REST of the app is fine as long as the flutter_monaco assets stay
-/// same-origin.
+/// **Cross-origin `assetBase` is not supported.** The page's own CSP is no
+/// longer the obstacle - it names the origin of each resolved asset root
+/// explicitly (see `_cspAssetOrigins` in `html_builder.dart`) - but the asset
+/// host must then serve the Monaco bundle and bridge with CORS headers
+/// permitting the app's origin, including for the module workers, and that is
+/// not something this package can arrange. Serve the Monaco assets from the
+/// app's origin; a CDN `assetBase` for the REST of the app is fine as long as
+/// the flutter_monaco assets stay same-origin.
 String resolveWebAssetUrl(String documentBaseUri, String assetUrl) =>
     Uri.parse(documentBaseUri).resolve(assetUrl).toString();

--- a/test/assets/html_builder_test.dart
+++ b/test/assets/html_builder_test.dart
@@ -3,15 +3,18 @@ import 'dart:convert';
 import 'package:flutter_monaco/src/assets/html_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/csp.dart';
+
 String _build({
   String? customCss,
   String? messageToken,
   bool isWeb = false,
   String vsPath = 'monaco/min/vs',
+  String bridgeBase = 'bridge',
 }) {
   return buildMonacoIndexHtml(
     vsPath: vsPath,
-    bridgeBase: 'bridge',
+    bridgeBase: bridgeBase,
     monacoVersion: '0.55.1',
     isWeb: isWeb,
     messageToken: messageToken,
@@ -39,24 +42,108 @@ void main() {
       expect(html, contains('.margin { color: rgb(1, 2, 3); }'));
     });
 
-    test('absolute http(s) vsPath puts the asset origin into the CSP', () {
-      // Firefox does not resolve CSP 'self' to the creating origin inside
-      // blob: documents, so the origin must be named explicitly or every
-      // same-origin asset load (loader.js, bridge, CSS, fonts) is blocked.
-      final html = _build(
-        isWeb: true,
-        vsPath: 'http://localhost:9000/assets/monaco/min/vs',
-      );
-      expect(html, contains("script-src 'self' http://localhost:9000 "));
-      expect(html, contains("style-src 'self' http://localhost:9000 "));
-      expect(html, contains("font-src 'self' http://localhost:9000 "));
-      expect(html, contains("connect-src 'self' http://localhost:9000 "));
-    });
+    group('page CSP', () {
+      // The page is served from a blob: URL on web, and Firefox does not
+      // resolve 'self' to the creating document's origin there - every
+      // same-origin fetch (loader.js, the bridge, editor.main.css, the
+      // workers) is blocked while Chrome allows it. These tests hold the
+      // page to the invariant that removes the whole class: the policy must
+      // admit what the page fetches WITHOUT relying on 'self'.
+      const vsOrigin = 'https://app.example';
+      const bridgeOrigin = 'https://bridge.example';
 
-    test('relative vsPath leaves the CSP without an extra origin', () {
-      final html = _build(vsPath: 'monaco/min/vs');
-      expect(html, contains("script-src 'self' file: "));
-      expect(html, isNot(contains("'self' http")));
+      String buildWeb() => _build(
+        isWeb: true,
+        vsPath: '$vsOrigin/assets/monaco/min/vs',
+        bridgeBase: '$bridgeOrigin/assets/monaco/bridge',
+      );
+
+      test('every fetch directive admits the Monaco origin without self', () {
+        final csp = PageCsp.fromHtml(buildWeb());
+        // A representative subresource: the page hands Monaco a base path
+        // and the bundle fetches scripts, stylesheets and workers beneath
+        // it, so the whole origin has to be admitted everywhere.
+        const asset = '$vsOrigin/assets/monaco/min/vs/editor/editor.main.js';
+
+        expect(csp.fetchDirectives, isNotEmpty);
+        for (final directive in csp.fetchDirectives) {
+          expect(
+            csp.admitsWithoutSelf(directive, asset),
+            isTrue,
+            reason: '$directive does not admit $asset',
+          );
+        }
+      });
+
+      test('the bridge origin is admitted even when it differs from vs', () {
+        // vsPath and bridgeBase are resolved by separate functions on web
+        // (webview_web.dart) and agree only by convention. A policy derived
+        // from one of them silently leaves the other unadmitted.
+        final csp = PageCsp.fromHtml(buildWeb());
+        expect(
+          csp.admitsWithoutSelf(
+            'script-src',
+            '$bridgeOrigin/assets/monaco/bridge/boot.js',
+          ),
+          isTrue,
+        );
+      });
+
+      test('every script the page references is admitted without self', () {
+        final html = buildWeb();
+        final csp = PageCsp.fromHtml(html);
+        final urls = scriptUrlsIn(html);
+
+        expect(urls, contains('$vsOrigin/assets/monaco/min/vs/loader.js'));
+        for (final name in monacoBridgeScripts) {
+          expect(urls, contains('$bridgeOrigin/assets/monaco/bridge/$name'));
+        }
+        for (final url in urls) {
+          expect(
+            csp.admitsWithoutSelf('script-src', url),
+            isTrue,
+            reason: 'script-src does not admit $url',
+          );
+        }
+      });
+
+      test('credentials in an asset URL never reach the policy', () {
+        // Uri.authority would emit `https://user:pass@app.example`, which is
+        // not a valid CSP host-source: browsers discard the expression and
+        // the block returns with no signal.
+        final csp = PageCsp.fromHtml(
+          _build(
+            isWeb: true,
+            vsPath: 'https://user:pass@app.example/assets/monaco/min/vs',
+            bridgeBase: 'https://user:pass@app.example/assets/monaco/bridge',
+          ),
+        );
+
+        expect(csp.directives['script-src'], contains(vsOrigin));
+        for (final sources in csp.directives.values) {
+          expect(sources.join(' '), isNot(contains('@')));
+          expect(sources.join(' '), isNot(contains('pass')));
+        }
+      });
+
+      test('native asset paths leave the policy byte-identical', () {
+        // Native is served from file:// and its 'self'/file: behaviour comes
+        // from the host WebView, which this package does not control. Web
+        // work must not perturb it, so the generated policy is pinned.
+        const expected =
+            "default-src 'self' file: 'unsafe-inline' 'unsafe-eval'; "
+            "script-src 'self' file: 'unsafe-inline' 'unsafe-eval'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "font-src 'self' file: data:; "
+            "img-src 'self' data: blob: file:; "
+            "worker-src 'self' blob:; "
+            "connect-src 'self' blob:;";
+
+        for (final vsPath in ['monaco/min/vs', 'file:///C:/app/min/vs']) {
+          final html = _build(vsPath: vsPath, bridgeBase: 'bridge');
+          expect(html, contains('content="$expected"'), reason: vsPath);
+        }
+      });
     });
 
     test('the web message token is JSON-encoded in every interpolation', () {

--- a/test/assets/html_builder_test.dart
+++ b/test/assets/html_builder_test.dart
@@ -3,9 +3,14 @@ import 'dart:convert';
 import 'package:flutter_monaco/src/assets/html_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-String _build({String? customCss, String? messageToken, bool isWeb = false}) {
+String _build({
+  String? customCss,
+  String? messageToken,
+  bool isWeb = false,
+  String vsPath = 'monaco/min/vs',
+}) {
   return buildMonacoIndexHtml(
-    vsPath: 'monaco/min/vs',
+    vsPath: vsPath,
     bridgeBase: 'bridge',
     monacoVersion: '0.55.1',
     isWeb: isWeb,
@@ -32,6 +37,26 @@ void main() {
     test('ordinary customCss passes through', () {
       final html = _build(customCss: '.margin { color: rgb(1, 2, 3); }');
       expect(html, contains('.margin { color: rgb(1, 2, 3); }'));
+    });
+
+    test('absolute http(s) vsPath puts the asset origin into the CSP', () {
+      // Firefox does not resolve CSP 'self' to the creating origin inside
+      // blob: documents, so the origin must be named explicitly or every
+      // same-origin asset load (loader.js, bridge, CSS, fonts) is blocked.
+      final html = _build(
+        isWeb: true,
+        vsPath: 'http://localhost:9000/assets/monaco/min/vs',
+      );
+      expect(html, contains("script-src 'self' http://localhost:9000 "));
+      expect(html, contains("style-src 'self' http://localhost:9000 "));
+      expect(html, contains("font-src 'self' http://localhost:9000 "));
+      expect(html, contains("connect-src 'self' http://localhost:9000 "));
+    });
+
+    test('relative vsPath leaves the CSP without an extra origin', () {
+      final html = _build(vsPath: 'monaco/min/vs');
+      expect(html, contains("script-src 'self' file: "));
+      expect(html, isNot(contains("'self' http")));
     });
 
     test('the web message token is JSON-encoded in every interpolation', () {

--- a/test/helpers/csp.dart
+++ b/test/helpers/csp.dart
@@ -1,0 +1,90 @@
+/// A minimal Content-Security-Policy parser and matcher for the generated
+/// editor page.
+///
+/// Substring assertions on the policy test its formatting rather than its
+/// meaning: they break when sources are reordered, and they pass while a URL
+/// the page actually fetches goes unadmitted. This models what a browser
+/// does instead - with one deliberate deviation, see [admitsWithoutSelf].
+library;
+
+/// The policy carried by the page's `<meta http-equiv>` element.
+class PageCsp {
+  PageCsp._(this.directives);
+
+  /// Parses the CSP out of [html]. The policy can never contain a `"`
+  /// (source expressions are validated), so the attribute is delimited
+  /// unambiguously.
+  factory PageCsp.fromHtml(String html) {
+    final match = RegExp(
+      r'http-equiv="Content-Security-Policy"\s*content="([^"]*)"',
+      dotAll: true,
+    ).firstMatch(html);
+    if (match == null) {
+      throw StateError('No Content-Security-Policy meta element in the page');
+    }
+    final directives = <String, List<String>>{};
+    for (final part in match.group(1)!.split(';')) {
+      final tokens = part.trim().split(RegExp(r'\s+'));
+      if (tokens.isEmpty || tokens.first.isEmpty) continue;
+      directives[tokens.first] = tokens.skip(1).toList();
+    }
+    return PageCsp._(Map.unmodifiable(directives));
+  }
+
+  /// Directive name to its source expressions, in declared order.
+  final Map<String, List<String>> directives;
+
+  /// The declared fetch directives, excluding the `default-src` fallback.
+  Iterable<String> get fetchDirectives =>
+      directives.keys.where((name) => name != 'default-src');
+
+  /// Whether [directive] admits [url] **without** relying on `'self'`.
+  ///
+  /// `'self'` is treated as matching nothing. That is exactly Firefox's
+  /// behaviour inside the `blob:` document this page is served from, and
+  /// asserting against it is what proves the page does not depend on a
+  /// keyword whose meaning varies by browser and delivery scheme.
+  ///
+  /// Falls back to `default-src` when [directive] is not declared, as a
+  /// browser does for fetch directives.
+  bool admitsWithoutSelf(String directive, String url) {
+    final sources = directives[directive] ?? directives['default-src'] ?? [];
+    return sources.any((source) => _sourceMatches(source, url));
+  }
+
+  static bool _sourceMatches(String source, String url) {
+    // Keyword sources ('self', 'unsafe-inline', 'unsafe-eval') never admit a
+    // URL here: 'self' is inert by design, the others govern inline content.
+    if (source.startsWith("'")) return false;
+
+    final target = Uri.tryParse(url);
+    if (target == null) return false;
+
+    // Scheme-source, e.g. `file:`, `data:`, `blob:`, `https:`.
+    if (!source.contains('//')) {
+      return source.endsWith(':') &&
+          source.substring(0, source.length - 1) == target.scheme;
+    }
+
+    // Host-source, e.g. `https://app.example` or `ws://127.0.0.1:3000`.
+    final expected = Uri.tryParse(source);
+    if (expected == null) return false;
+    return expected.scheme == target.scheme &&
+        expected.host == target.host &&
+        expected.port == target.port;
+  }
+}
+
+/// Every script URL the generated page references literally: `<script src>`
+/// attributes plus the dynamically assigned `loaderScript.src` used on web.
+///
+/// Derived from the page rather than restated as literals, so a `<script>`
+/// added later pointing at a new asset root is covered automatically.
+List<String> scriptUrlsIn(String html) => [
+  ...RegExp(
+    r'<script[^>]*\ssrc="([^"]+)"',
+  ).allMatches(html).map((m) => m.group(1)!),
+  ...RegExp(
+    r"""\.src\s*=\s*'([^']+)'""",
+  ).allMatches(html).map((m) => m.group(1)!),
+];


### PR DESCRIPTION
## Summary
- Firefox does not treat the creating document's origin as CSP `'self'` inside `blob:` documents; Chrome does.
- The Monaco host page is a `blob:` iframe whose CSP only allows `'self'`, so on Firefox every same-origin asset load — `loader.js`, the bridge scripts, editor CSS, fonts — is blocked and the editor fails with "Failed to load Monaco loader.js", while Chrome works.
- Fix: derive the asset origin from the resolved `vsPath` and name it explicitly in each CSP directive that fetches from the host origin.
- Only absolute http(s) asset URLs (the web case) produce an origin; native platforms' CSP is unchanged, and browsers where `'self'` already matches are unaffected.
- Minimal repro: a `blob:` iframe with meta CSP `script-src 'self'` loading a same-origin script fires `onerror` in Firefox and `onload` in Chrome; with the origin named explicitly, Firefox fires `onload` too.
- Includes two regression tests in `test/assets/html_builder_test.dart` and a CHANGELOG entry.

## Changes
- `lib/src/assets/html_builder.dart`: derive the asset origin from the resolved `vsPath` (absolute http/https URLs only, i.e. the web case) and append it after `'self'` in every CSP directive of the generated Monaco host page (`default-src`, `script-src`, `style-src`, `font-src`, `img-src`, `worker-src`, `connect-src`). Relative asset paths (native platforms) leave the policy byte-for-byte unchanged.
- `test/assets/html_builder_test.dart`: two regression tests — an absolute `vsPath` puts the origin into the CSP directives; a relative `vsPath` produces no origin entry.
- `CHANGELOG.md`: added an Unreleased → Fixed entry.

## Testing
- [x] `flutter test` (642 passing, 1 skipped)
- [x] `flutter analyze` (no issues)
- [x] `dart format .` (no changes)
- [x] Other (describe): Manually verified the Firefox failure mode with a minimal repro — a `blob:` iframe carrying `<meta>` CSP `script-src 'self'` loading a same-origin `<script src>` fires `onerror` in Firefox and `onload` in Chrome; with the origin named explicitly in the policy, Firefox fires `onload` too. Also verified end-to-end in a real Flutter web app: unpatched, the editor fails on Firefox with "Failed to load Monaco loader.js"; patched, it boots.

## Checklist
- [x] I updated docs or examples if needed. (No doc/example changes needed — behavior-only fix.)
- [x] I updated `CHANGELOG.md` if needed.
- [ ] Release PR only: `pubspec.yaml` version updated. (Not a release PR.)