### PR TITLE
Release 3.4.3: load the editor on Firefox

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "flutter-monaco",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "source": {
         "source": "local",
         "path": "./plugins/flutter-monaco"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "flutter-monaco",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "source": "./plugins/flutter-monaco",
       "description": "Package-specific skills and a read-only bridge reviewer for flutter_monaco."
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.4.3] - 2026-08-06
 
 ### Fixed
-- **Firefox can now load the editor on web.** Firefox does not treat the creating document's origin as CSP `'self'` inside `blob:` documents, so the blob-hosted Monaco page blocked its own loader, bridge scripts, stylesheet, and workers ("Failed to load Monaco loader.js"). The generated page no longer relies on `'self'` for anything it fetches: it names the origin of every resolved asset root, and each directive is built from one shared source list so a directive added later cannot omit them. Native platforms keep a byte-identical policy, and browsers where `'self'` already matches are unaffected.
-- **A CSP-blocked page load now says which directive refused which URL** instead of only "Failed to load Monaco loader.js", turning a cross-browser hunt into a single line in the reported error.
+- **Firefox can now load the editor on Web.** Firefox does not resolve CSP `'self'` to the creating document's origin inside `blob:` documents, so the blob-hosted editor page blocked its own loader, bridge scripts, stylesheet, and workers, failing with "Failed to load Monaco loader.js" while Chrome worked. The page no longer relies on `'self'` for anything it fetches: it names the origin of every resolved asset root explicitly. Native platforms keep a byte-identical policy, and browsers where `'self'` already matches are unaffected.
+- **A load blocked by the page's Content-Security-Policy now names the directive that refused it and the URL it refused**, instead of reporting only "Failed to load Monaco loader.js".
 
 ## [3.4.2] - 2026-07-19
 

--- a/doc/ai-assistant-support.md
+++ b/doc/ai-assistant-support.md
@@ -173,7 +173,7 @@ Claude eval pass until that command is available and actually runs.
 
 Authenticated behavior checks are opt-in and never run in CI. Claude requires a
 separate config directory containing a local marketplace installation of this plugin.
-The runner fails closed unless the plugin is enabled at version `3.4.2`, its cache is a
+The runner fails closed unless the plugin is enabled at version `3.4.3`, its cache is a
 byte-for-byte copy of this checkout, and its marketplace points to this checkout. It
 then loads only that isolated user configuration, the verified plugin, a fixed empty
 MCP set, nonpersistent sessions, disabled auto-memory, and disposable fixtures.
@@ -200,7 +200,7 @@ dart run tool/ai_extension_behavior_runner.dart \
 
 Codex requires a separate authenticated home so the runner cannot use or modify a
 maintainer's normal plugins. The runner fails closed unless the installed local
-plugin is enabled, is version `3.4.2`, and is a byte-for-byte copy of this checkout:
+plugin is enabled, is version `3.4.3`, and is a byte-for-byte copy of this checkout:
 
 ```bash
 eval_codex_home="$(mktemp -d)"

--- a/macos/flutter_monaco.podspec
+++ b/macos/flutter_monaco.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_monaco'
-  s.version          = '3.4.2'
+  s.version          = '3.4.3'
   s.summary          = 'Native macOS focus integration for flutter_monaco.'
   s.description      = <<-DESC
 Performs the NSWindow first-responder handoff between the Flutter view and the

--- a/plugins/flutter-monaco/.claude-plugin/plugin.json
+++ b/plugins/flutter-monaco/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "flutter-monaco",
   "displayName": "Flutter Monaco",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Package-specific Claude Code skills and a read-only bridge reviewer for flutter_monaco.",
   "author": {
     "name": "Omar Hanafy",

--- a/plugins/flutter-monaco/.codex-plugin/plugin.json
+++ b/plugins/flutter-monaco/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-monaco",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Package-specific skills for integrating, diagnosing, migrating, and maintaining flutter_monaco.",
   "author": {
     "name": "Omar Hanafy",

--- a/plugins/flutter-monaco/README.md
+++ b/plugins/flutter-monaco/README.md
@@ -122,7 +122,7 @@ public-directory submission.
 
 - Consumer skills target `flutter_monaco` 3.x and inspect the resolved package APIs
   before proposing code. The migration skill covers 2.x to 3.x.
-- Both plugin manifests use version `3.4.2`, matching the package release that ships
+- Both plugin manifests use version `3.4.3`, matching the package release that ships
   this support. Both marketplace entries carry the same version.
 - The manifests and commands were validated with Claude Code 2.1.215 and Codex CLI
   0.144.6. The shared SKILL.md frontmatter deliberately uses the fields accepted by

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_monaco
 description: Integrate Monaco Editor (VS Code's editor) in Flutter apps. Features 100+ languages, syntax highlighting, themes, and full API.
-version: 3.4.2
+version: 3.4.3
 homepage: https://github.com/omar-hanafy/flutter_monaco
 repository: https://github.com/omar-hanafy/flutter_monaco
 issue_tracker: https://github.com/omar-hanafy/flutter_monaco/issues

--- a/test/ai_extensions/behavior_runner_test.dart
+++ b/test/ai_extensions/behavior_runner_test.dart
@@ -282,7 +282,7 @@ Future<void> main() async {
         'installed': <Object?>[
           <String, Object?>{
             'pluginId': 'flutter-monaco@flutter-monaco',
-            'version': '3.4.2',
+            'version': '3.4.3',
             'installed': true,
             'enabled': true,
           },
@@ -307,7 +307,7 @@ Future<void> main() async {
         <Object?>[
           <String, Object?>{
             'id': 'flutter-monaco@flutter-monaco-plugins',
-            'version': '3.4.2',
+            'version': '3.4.3',
             'enabled': true,
             'installPath': repositoryRoot.path,
           },
@@ -402,7 +402,7 @@ Future<void> main() async {
     final integrationPubspec = File.fromUri(
       integrationFixture.uri.resolve('pubspec.yaml'),
     ).readAsStringSync();
-    expect(integrationPubspec, contains('flutter_monaco: ^3.4.2'));
+    expect(integrationPubspec, contains('flutter_monaco: ^3.4.3'));
     expect(integrationPubspec, contains('path: vendor/flutter_monaco_current'));
     expect(integrationPubspec, isNot(contains('../')));
     expect(integrationPubspec, isNot(contains('path: /')));
@@ -411,7 +411,7 @@ Future<void> main() async {
         'vendor/flutter_monaco_current/pubspec.yaml',
       ),
     ).readAsStringSync();
-    expect(vendoredPubspec, contains('version: 3.4.2'));
+    expect(vendoredPubspec, contains('version: 3.4.3'));
     expect(
       File.fromUri(
         integrationFixture.uri.resolve(

--- a/tool/ai_extension_behavior_runner.dart
+++ b/tool/ai_extension_behavior_runner.dart
@@ -932,7 +932,7 @@ Future<void> prepareEvaluationFixture(
       ? '^3.4.1'
       : legacy
       ? '^2.3.0'
-      : '^3.4.2';
+      : '^3.4.3';
   _writeFixtureFile(
     fixture,
     'pubspec.yaml',
@@ -966,8 +966,8 @@ Future<void> prepareEvaluationFixture(
         '${kind != 'execution'
             ? ''
             : legacy
-            ? 'The dependency starts on the 2.3.0 API stub at vendor/flutter_monaco_legacy. After rewriting the app, change the dependency override to vendor/flutter_monaco_current for 3.4.2 validation. Do not edit either vendor tree.\n'
-            : 'The 3.4.2 package at vendor/flutter_monaco_current is a read-only fixture dependency. Do not edit it.\n'}',
+            ? 'The dependency starts on the 2.3.0 API stub at vendor/flutter_monaco_legacy. After rewriting the app, change the dependency override to vendor/flutter_monaco_current for 3.4.3 validation. Do not edit either vendor tree.\n'
+            : 'The 3.4.3 package at vendor/flutter_monaco_current is a read-only fixture dependency. Do not edit it.\n'}',
   );
   if (kind == 'execution') {
     _writeFixtureFile(fixture, 'analysis_options.yaml', '''analyzer:


### PR DESCRIPTION
## Summary
Patch release shipping the Firefox CSP fix merged in #41. No API changes.

- **Firefox can now load the editor on Web.** The blob-hosted page relied on CSP `'self'` to admit its own assets; Firefox does not resolve `'self'` to the creating document's origin inside a `blob:` document, so the loader, bridge scripts, stylesheet and workers were all blocked. The page now names the origin of every resolved asset root.
- **A CSP-blocked load now names the directive that refused it and the URL it refused.**

## Release classification
Public baseline is pub.dev **3.4.2** (published 2026-07-19), matching tag `flutter_monaco-v3.4.2`.

Net delta from that baseline is a backward-compatible bug fix plus its diagnostic. `lib/flutter_monaco.dart` is the only public entrypoint and does not export `html_builder.dart`, so the internal `sanitizeConnectSources` signature change is not part of the public API. **Patch: 3.4.3.**

Deliberately omitted from the changelog: the showcase URL update in `README.md` / `example/web/index.html` (the previously published URL still resolves 200, so nothing user-facing changed), the `web_asset_resolver.dart` doc comment, and test-only files.

## Version mirrors
`tool/validate_ai_extensions.dart` pins these to `pubspec.yaml`; all moved together:
`pubspec.yaml`, `macos/flutter_monaco.podspec`, both plugin manifests, both marketplace entries.

Also updated because they are coupled to the shipping version: the eval fixture constraint in `tool/ai_extension_behavior_runner.dart`, the fixture assertions in `test/ai_extensions/behavior_runner_test.dart`, and `doc/ai-assistant-support.md`. The migration skill's `targetVersion` fixtures are a separate concept and were left at 3.4.2.

## Verification
- [x] `flutter pub get`
- [x] `dart run tool/validate_ai_extensions.dart` - passed
- [x] `dart format --output=none --set-exit-if-changed .` - 0 changed
- [x] `flutter analyze` - no issues
- [x] `flutter test` - 645 passing, 1 skipped
- [x] `dart pub publish --dry-run` - **0 warnings**
- [x] `pana --exit-code-threshold 0 .` - **160/160**
- [x] Archive excludes the assistant plugin, `.claude-plugin`, `.agents`, `AGENTS.md`, `CLAUDE.md`, `doc/`

## Checklist
- [x] I updated docs or examples if needed.
- [x] I updated `CHANGELOG.md` if needed.
- [x] Release PR only: `pubspec.yaml` version updated.